### PR TITLE
Korjattu otsikon bugi

### DIFF
--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -513,12 +513,12 @@
 				}
 
 				if (trim($assrow["toim_nimi"]) == "") {
-					$assrow["toim_nimi"]	= $assrow["nimi"];
-					$assrow["toim_nimitark"]= $assrow["nimitark"];
-					$assrow["toim_osoite"]	= $assrow["osoite"];
-					$assrow["toim_postino"]	= $assrow["postino"];
-					$assrow["toim_postitp"]	= $assrow["postitp"];
-					$assrow["toim_maa"]		= $assrow["maa"];
+					$assrow["toim_nimi"]		= $assrow["nimi"];
+					$assrow["toim_nimitark"]	= $assrow["nimitark"];
+					$assrow["toim_osoite"]		= $assrow["osoite"];
+					$assrow["toim_postino"]		= $assrow["postino"];
+					$assrow["toim_postitp"]		= $assrow["postitp"];
+					$assrow["toim_maa"]			= $assrow["maa"];
 				}
 
 				if (trim($assrow["laskutus_nimi"]) == "") {


### PR DESCRIPTION
Korjattu havaittu erikoinen otsikon bugi. Mikäli otetaan myynnin-valikosta "Hae ja Selaa", valitaan tuotteet ja laitetaan avoimelle tilaukselle. Sen jälkeen mennään "avoimet tilaukset" ja valitaan se tilaus. Sitten valitaan "Liitä asiakas".
Laitettiin asiakkaan takaata oletukset
- toimitustapa
- maksuehto
- tilausvahvistus
- piiri 
- rahtivapaa
- toimitusehto

sekä : 
- toimaika
- kerayspvm
