### PR TITLE
Muotoillaan XML-tiedosto _oikein_

### DIFF
--- a/sepa.php
+++ b/sepa.php
@@ -688,8 +688,12 @@
 		// Lis‰t‰‰n viel‰ oikea tapahtumien m‰‰r‰ sanoman headeriin
 		$xml->{"pain.001.001.02"}->GrpHdr->NbOfTxs = $tapahtuma_maara;
 
-		// Kirjoitetaaan XML ja tehd‰‰n UTF8 encode
-		fwrite($toot, str_replace(chr(10),"",utf8_encode($xml->asXML())));
+		// Kirjoitetaaan XML, tehd‰‰n t‰st‰ j‰sennelty aineisto. T‰m‰ toimii paremmin mm OPn kanssa
+		$dom = new DOMDocument('1.0');
+		$dom->preserveWhiteSpace = true;
+		$dom->formatOutput = true;
+		$dom->loadXML(str_replace(array("\n", "\r"), "", utf8_encode($xml->asXML())));
+		fwrite($toot, ($dom->saveXML()));
 		fclose($toot);
 
 		// Tehd‰‰n viel‰ t‰ss‰ vaiheessa XML validointi, vaikka ainesto onkin jo tehty. :(


### PR DESCRIPTION
Muotoillaan XML "oikein" esim OPn dokumentaatio sanoo, että aineiston tulisi olla rivitettyä. Näyttäisi toimivan tosin ilmankin.. Macister-ohjelma tuntui hylkivän aineistoa, jossa ei ole välejä.

Mikäli tämä on ok, voisi tuon schemaValidaten yhdistää XML-muotoiluun. Nythän DOM-elementti tehdään turhaan kaksi kertaa.

OP-POHJOLA-RYHMÄN C2B-PALVELUT 
C2B-aineistossa enkoodauksen on oltava UTF-8. Aineiston tulee olla rivitettyä ja se saa olla sisentämätöntä. Suurin yksittäinen OP-Pohjola-ryhmän vastaanottama aineisto on tällä hetkellä 100 megatavua. Yhdessä C2B- maksuaineistossa voi olla enintään 50 000 maksua, jonka jälkeen aineisto on pilkottava.
