### PR TITLE
ASN-linkityksen korjaus

### DIFF
--- a/ostolasku_asn_tarkastelu.php
+++ b/ostolasku_asn_tarkastelu.php
@@ -1404,7 +1404,7 @@
 							JOIN toimi ON (toimi.yhtio = asn_sanomat.yhtio AND toimi.toimittajanro = asn_sanomat.toimittajanumero and toimi.tyyppi !='P')
 							WHERE asn_sanomat.yhtio = '{$kukarow['yhtio']}'
 							AND asn_sanomat.laji = 'asn'
-							GROUP BY asn_sanomat.paketinnumero, asn_sanomat.asn_numero, asn_sanomat.toimittajanumero, toimi.ytunnus, toimi.nimi, toimi.nimitark, toimi.osoite, toimi.osoitetark, toimi.postino, toimi.postitp, toimi.maa, toimi.swift
+							GROUP BY asn_sanomat.paketintunniste, asn_sanomat.asn_numero, asn_sanomat.toimittajanumero, toimi.ytunnus, toimi.nimi, toimi.nimitark, toimi.osoite, toimi.osoitetark, toimi.postino, toimi.postitp, toimi.maa, toimi.swift
 							ORDER BY asn_sanomat.asn_numero, asn_sanomat.paketintunniste";
 				$result = pupe_query($query);
 
@@ -1429,7 +1429,8 @@
 				$naytetaanko_toimittajabutton = true;
 
 				while ($row = mysql_fetch_assoc($result)) {
-
+					$naytetaanko_toimittajabutton = true;
+					
 					// n‰ytet‰‰n vain vialliset rivit
 					if ($row["rivit"] == $row["ok"] and $row["status"] == "X") {
 						continue;


### PR DESCRIPTION
Korjattu UI:sta virheellisesti ja väärään pakettiin linkkaaminen ostolaskujen tarkastelussa ASN-sanomien osalta. Aiheuttanut turhaa hämmennystä. Sekä poistettu kyselystä grouppauksesta paketinnumero, joka aiheutti kyseisen ongelman.
