### PR TITLE
Korjattu bugi datediff erotuksessa.

### DIFF
--- a/sopimusmuistutus.php
+++ b/sopimusmuistutus.php
@@ -33,11 +33,12 @@
 	// tilausrivi.toimaika => poikkeava loppup‰iv‰
 
 	// Haetaan kaikki 30 p‰iv‰n p‰‰st‰ vanhenevat sopimukset/sopimusrivit
+	// Datediff -30 tarkoittaa ett‰ 30 pv kuluttua sopimus menee umpeen ja 30 tarkoittaa ett‰ meni 30 pv sitten umpeen.
 	$query = "	(SELECT distinct lasku.tunnus, lasku.ytunnus, lasku.nimi, lasku.asiakkaan_tilausnumero, lasku.valkoodi
 				FROM lasku
 				JOIN laskun_lisatiedot ON (laskun_lisatiedot.yhtio = lasku.yhtio
 					AND laskun_lisatiedot.otunnus = lasku.tunnus
-					AND datediff(now(), laskun_lisatiedot.sopimus_loppupvm) = 30)
+					AND datediff(now(), laskun_lisatiedot.sopimus_loppupvm) = -30)
 				WHERE lasku.yhtio = '$yhtio'
 				AND lasku.tila = '0'
 				AND lasku.alatila != 'D')
@@ -50,7 +51,7 @@
 					AND tilausrivi.otunnus = lasku.tunnus
 					AND tilausrivi.tyyppi = 'L'
 					AND tilausrivi.toimaika != '0000-00-00'
-					AND datediff(now(), tilausrivi.toimaika) = 30)
+					AND datediff(now(), tilausrivi.toimaika) = -30)
 				WHERE lasku.yhtio = '$yhtio'
 				AND lasku.tila = '0'
 				AND lasku.alatila != 'D')


### PR DESCRIPTION
Datediff -30, on se että 30 pv:n päästä tulevaisuudessa sopimus menee umpeen ja pitää muistuttaa sähköpostiin.
