### PR TITLE
Lähetysmaa ja Alkuperämaa sarakkeet kuntoon

### DIFF
--- a/inc/intrastat_tarkistukset.inc
+++ b/inc/intrastat_tarkistukset.inc
@@ -55,7 +55,7 @@
 			$virhetxt .= t("Alkuperämaa puuttuu tuotteelta")." <a href='yllapito.php?toim=tuote&tunnus=$intrtuorow[tunnus]&lopetus=$lopetus_intra1$lopetus_intra2'>$intrtuorow[tuoteno]</a>!<br>";
 			$virhe++;
 		}
-		elseif ($intrtuorow["alkuperamaa"] == $yhtiorow["maa"] and $intrtuorow["lahetysmaa"] == $yhtiorow["maa"] and $tapa != "vienti") {
+		elseif ($intrtuorow["alkuperamaa"] == $yhtiorow["maa"] and $tapa != "vienti") {
 			$virhetxt .= t("Tuote").": <a href='yllapito.php?toim=tuote&tunnus=$intrtuorow[tunnus]&lopetus=$lopetus_intra1$lopetus_intra2'>$intrtuorow[tuoteno]</a>. ".t("Alkuperämaa ei voi olla sama kuin yhtiön kotimaa")."!<br>";
 			$virhe++;
 		}


### PR DESCRIPTION
Lähetysmaa ja Alkuperämaa sarakkeet kuntoon.

Saapumisissa lähetysmaa ja alkuperämaa sarakkeet selectöidään nyt paremmalla algoritmillä.

Lähetysmaa:
if (lasku.maa_lahetys='', ifnull(varastopaikat.maa, lasku.yhtio_maa), lasku.maa_lahetys)

Alkuperämaa:
(SELECT alkuperamaa FROM tuotteen_toimittajat WHERE tuotteen_toimittajat.yhtio=tilausrivi.yhtio and tuotteen_toimittajat.tuoteno=tilausrivi.tuoteno and tuotteen_toimittajat.alkuperamaa!='' ORDER BY if (alkuperamaa='$yhtiorow[maa]','2','1') LIMIT 1)
