### PR TITLE
JT-tilaukset näkyvät myös Avoimet Tilaukset -listassa

### DIFF
--- a/muokkaatilaus.php
+++ b/muokkaatilaus.php
@@ -1286,7 +1286,7 @@
 						$kohdelisa
 						WHERE lasku.yhtio = '$kukarow[yhtio]'
 						and lasku.tila in ('L','N')
-						and lasku.alatila in ('A','')
+						and lasku.alatila in ('A','', 'J', 'T', 'U')
 						$haku
 						HAVING extra = '' or extra is null
 						order by lasku.luontiaika desc


### PR DESCRIPTION
Korjattu siten, että JT-tilaukset ( alatila J, T ja U ) näkyvät myös Avoimet Tilaukset -listassa
