### PR TITLE
Bugikorjaus, tilausrivin varattu ja kpl ei saa olla samat

### DIFF
--- a/inc/verkkolasku-in-luo-keikkafile.inc
+++ b/inc/verkkolasku-in-luo-keikkafile.inc
@@ -651,7 +651,12 @@
 
 						switch ($fieldname) {
 							case 'varattu':
-								$values .= ", '{$kappaleerotus}'";
+								if ($tilausrivirow['kpl'] == 0) {
+									$values .= ", '{$kappaleerotus}'";
+								}
+								else {
+									$values .= ", '0'";
+								}
 								break;
 							case 'kpl':
 								if ($tilausrivirow['kpl'] == 0) {


### PR DESCRIPTION
Bugikorjaus!

Tsekki että ei mene vahingossa varattuun ja kappaleeseen samaa arvoa! Aikaisemmin saattoi insertöityä rivejä jossa varattu = 1 ja kpl = 1.
