### PR TITLE
Mahdollisuus lähettää keräysvahvistus vaihtoehtoiseen sähköpostiosoitteeseen

### DIFF
--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -1452,7 +1452,7 @@
 				if ($toim != 'VASTAANOTA_REKLAMAATIO') {
 					// Tulostetaan uusi lähete jos käyttäjä valitsi drop-downista printterin
 					// Paitsi jos tilauksen tila päivitettiin sellaiseksi, että lähetettä ei kuulu tulostaa
-					$query = "	SELECT lasku.*, asiakas.email, asiakas.lahete_email
+					$query = "	SELECT lasku.*, if(asiakas.keraysvahvistus_email != '', asiakas.keraysvahvistus_email, asiakas.email) email
 								FROM lasku
 								LEFT JOIN asiakas on lasku.yhtio = asiakas.yhtio and lasku.liitostunnus = asiakas.tunnus
 								WHERE lasku.tunnus in ($tilausnumeroita)


### PR DESCRIPTION
Mikäli asiakkaan tiedoissa on määritelty keraysvahvistus_email, lähetetään keräysvahvistus tänne oletussähköpostin sijasta.

ALTER TABLE `asiakas` ADD COLUMN `keraysvahvistus_email` varchar(255) NOT NULL DEFAULT '' AFTER `keraysvahvistus_lahetys`;
