### PR TITLE
Reklamaatiopurkulistan tulostuksen bugfix

### DIFF
--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -786,11 +786,36 @@ if (!function_exists('rivi_kerayslista')) {
 					$pdf->draw_text($plen+23, $kala, $ff_string, $thispage, $ff_font);
 					$kala -= $rivinkorkeus;
 
-					$plen = $pdf->strlen(t("Sis‰lt‰‰ tuotteet", $kieli).": ", $norm);
-					$pdf->draw_text(23, $kala, t("Sis‰lt‰‰ tuotteet", $kieli).": ", $thispage, $norm);
-					list($ff_string, $ff_font) = pdf_fontfit($row["perhe_kommentti2"], 500, $pdf, $norm);
-					$pdf->draw_text($plen+23, $kala, $ff_string, $thispage, $ff_font);
-					$kala -= $rivinkorkeus;
+					if (trim($row["perhe_kommentti2"]) != '') {
+						$plen = $pdf->strlen(t("Sis‰lt‰‰ tuotteet", $kieli).": ", $norm);
+						$pdf->draw_text(23, $kala, t("Sis‰lt‰‰ tuotteet", $kieli).": ", $thispage, $norm);
+						list($ff_string, $ff_font) = pdf_fontfit($row["perhe_kommentti2"], 500, $pdf, $norm);
+						$pdf->draw_text($plen+23, $kala, $ff_string, $thispage, $ff_font);
+						$kala -= $rivinkorkeus;
+					}
+
+					//jos ollaan liian pitk‰ll‰ tehd‰‰n uusi otsikko...
+					if ($kala < 95) {
+
+						$sivu++;
+
+						// Luodaan palautettavat
+						$return = array();
+
+						foreach ($params as $key => $null) {
+							$return[$key] = ${$key};
+						}
+
+						$params = loppu_kerayslista($return);
+						$params = uusi_sivu_kerayslista($params);
+
+						// Luodaan muuttujat
+						foreach ($params as $key => $val) {
+							${$key} = $val;
+						}
+
+						$page[$sivu] = $thispage;
+					}
 				}
 
 				if ($yhtiorow['kerayserat'] == 'K' and isset($kerayseran_numero) and $kerayseran_numero > 0) {
@@ -1301,5 +1326,3 @@ if (!function_exists('print_pdf_kerayslista')) {
 		}
 	}
 }
-
-?>


### PR DESCRIPTION
Tuoteperhe-casessa pdf:n generointi katkesi, jos lapsihaarassa laitettiin y-muuttujaa (lue: kala) liian alas ja uuden sivun checkiä ei tehty siinä kohdassa. Nyt uusi sivu luodaan jos tuoteperhe menee liian pitkäksi.
