### PR TITLE
[fix] Suuntalavan tuloutus rivi kerrallaan

### DIFF
--- a/mobiili/suuntalavan_tuotteet.php
+++ b/mobiili/suuntalavan_tuotteet.php
@@ -28,10 +28,7 @@ if (isset($submit) and trim($submit) != '') {
 			exit;
 		}
 		elseif ($submit == 'submit') {
-			if ($ainokainen) {
-				echo "<META HTTP-EQUIV='Refresh'CONTENT='0;URL=vahvista_kerayspaikka.php?suuntalavan_tuotteet&{$url}&viimeinen'>";
-			}
-			else echo "<META HTTP-EQUIV='Refresh'CONTENT='0;URL=vahvista_kerayspaikka.php?suuntalavan_tuotteet&{$url}'>";
+			echo "<META HTTP-EQUIV='Refresh'CONTENT='0;URL=vahvista_kerayspaikka.php?suuntalavan_tuotteet&{$url}'>";
 			exit();
 		}
 	}
@@ -209,11 +206,7 @@ echo "</th>
 		}
 		echo "<td nowrap>{$tuote['osoite']}</td>";
 		echo "</tr>";
-// 					}
 	}
-if (mysql_num_rows($res) == 1) {
-	echo "<input type='hidden' name='ainokainen' value='true' />";
-}
 
 echo "
 	<input type='hidden' name='alusta_tunnus' value='{$alusta_tunnus}' />

--- a/mobiili/vahvista_kerayspaikka.php
+++ b/mobiili/vahvista_kerayspaikka.php
@@ -84,6 +84,15 @@ if (isset($submit) and trim($submit) != '') {
 			if (!is_numeric($koodi) or !tarkista_varaston_hyllypaikka($row['hyllyalue'], $row['hyllynro'], $row['hyllyvali'], $row['hyllytaso'], $koodi)) {
 				$errors[] = t("Virheellinen varmistuskoodi");
 			}
+
+			# Setataan viimeinen muuttuja jos lavalla vain yksi rivi jäjellä
+			if (!empty($alusta_tunnus)) {
+				$query = "SELECT * FROM tilausrivi WHERE suuntalava = '{$alusta_tunnus}' AND yhtio='{$kukarow['yhtio']}'";
+				$rivit_result = pupe_query($query);
+				$rivit = mysql_num_rows($rivit_result);
+			}
+			$viimeinen = (isset($rivit) and $rivit == 1) ? true : false;
+
 			# Jos ei virheitä
 			if(count($errors) == 0) {
 				$tilausrivit = array();
@@ -98,7 +107,7 @@ if (isset($submit) and trim($submit) != '') {
 					# Splitataan rivi
 					# Jos viimeinen rivi ja määrää pienennetty, pudotetaan toinen rivi pois lavalta.
 					# Koska viimeistä rivii viedessä viedään kaikkilavan rivit varastoon
-					if (isset($viimeinen)) {
+					if ($viimeinen) {
 						splittaa_tilausrivi($tilausrivi, ($row['varattu'] - $maara), false, true);
 					}
 					else {
@@ -190,7 +199,7 @@ if (isset($submit) and trim($submit) != '') {
 				$saapumiset = hae_saapumiset($alusta_tunnus);
 
 				# Viimeisellä rivillä viedään koko suuntalava, jolloin lava merkataan puretuksi
-				if(isset($viimeinen)) {
+				if($viimeinen) {
 					vie_varastoon($saapumiset[0], $alusta_tunnus, $hylly);
 				}
 				else {


### PR DESCRIPTION
Korjattu suuntalavan tuloutus kun rivi on haettu viivakoodilla. 
Oletti että haettu rivi on suuntalavan ainoa ja vei koko lavan varastoon.

Tarvitsee tietokantaan indeksin:
`create index suuntalava_index on tilausrivi (suuntalava)`
