### PR TITLE
***** Laskupohjat ilman rivihintoja *****

### DIFF
--- a/inc/asiakasrivi.inc
+++ b/inc/asiakasrivi.inc
@@ -943,6 +943,8 @@
 		$ulos .= "<option value = '1' $sel[1]>".t("Pelkistetty laskupohja 1");
 		$ulos .= "<option value = '3' $sel[3]>".t("Pelkistetty laskupohja 2 (Tuoteperheet yhdistetty)");
 		$ulos .= "<option value = '4' $sel[4]>".t("Pelkistetty laskupohja 3");
+		$ulos .= "<option value = '10' $sel[10]>".t("Normaali laskupohja ilman rivihintoja (ei laillinen Suomessa)");
+		$ulos .= "<option value = '12' $sel[12]>".t("Normaali laskupohja (Tuoteperheet yhdistetty) ilman rivihintoja (ei laillinen Suomessa)");
 
 		$ulos .= "</select></td>";
 

--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -196,15 +196,18 @@
 		$sel = array();
 		$sel[$apu] = "selected";
 
-		$ulos .= "<option value = '0' $sel[0]>".t("Normaali laskupohja");
-		$ulos .= "<option value = '2' $sel[2]>".t("Normaali laskupohja (Tuoteperheet yhdistetty)");
-		$ulos .= "<option value = '5' $sel[5]>".t("Normaali laskupohja (Ei n‰ytet‰ verollista rivihintaa)")."</option>";
-		$ulos .= "<option value = '6' $sel[6]>".t("Normaali laskupohja (Ei n‰ytet‰ tilausnumeroa/toimitusaikaa)")."</option>";
-		$ulos .= "<option value = '7' $sel[7]>".t("Normaali laskupohja (N‰ytet‰‰n tuotteen EAN koodi)")."</option>";
-		$ulos .= "<option value = '1' $sel[1]>".t("Pelkistetty laskupohja 1");
+		$ulos .= "<option value = '0'  $sel[0]>".t("Normaali laskupohja");
+		$ulos .= "<option value = '2'  $sel[2]>".t("Normaali laskupohja (Tuoteperheet yhdistetty)");
+		$ulos .= "<option value = '5'  $sel[5]>".t("Normaali laskupohja (Ei n‰ytet‰ verollista rivihintaa)")."</option>";
+		$ulos .= "<option value = '6'  $sel[6]>".t("Normaali laskupohja (Ei n‰ytet‰ tilausnumeroa/toimitusaikaa)")."</option>";
+		$ulos .= "<option value = '7'  $sel[7]>".t("Normaali laskupohja (N‰ytet‰‰n tuotteen EAN koodi)")."</option>";
+		$ulos .= "<option value = '1'  $sel[1]>".t("Pelkistetty laskupohja 1");
 		#$ulos .= "<option value = '3' $sel[3]>".t("Pelkistetty laskupohja 2 (Tuoteperheet yhdistetty)");
-		$ulos .= "<option value = '4' $sel[4]>".t("Pelkistetty laskupohja 3");
-		$ulos .= "<option value = '8' $sel[8]>".t("Ruotsin laskupohja")."</option>";
+		$ulos .= "<option value = '4'  $sel[4]>".t("Pelkistetty laskupohja 3");
+		$ulos .= "<option value = '8'  $sel[8]>".t("Ruotsin laskupohja")."</option>";
+		$ulos .= "<option value = '10' $sel[10]>".t("Normaali laskupohja ilman rivihintoja (ei laillinen Suomessa)");
+		$ulos .= "<option value = '12' $sel[12]>".t("Normaali laskupohja (Tuoteperheet yhdistetty) ilman rivihintoja (ei laillinen Suomessa)");
+				
 		$ulos .= "</select></td>";
 
 		$jatko = 0;

--- a/tilauskasittely/tulosta_lasku.inc
+++ b/tilauskasittely/tulosta_lasku.inc
@@ -585,6 +585,14 @@ if (!function_exists('rivi_lasku')) {
 	function rivi_lasku ($laskurow, $asiakasrow, $row, $kieli, $pdf_lasku, $thispage, $kala, $laskutyyppi, $toim, $summa, $arvo) {
 		global $yhtiorow, $kukarow, $rectparam, $norm, $pieni, $boldi, $pieni_boldi, $iso;
 
+		if($laskutyyppi == 10 or $laskutyyppi == 12) {
+			$row["hinta"] = 0;
+			$row["rivihinta"] = 0;
+			for ($alepostfix = 1; $alepostfix <= $yhtiorow['myynnin_alekentat']; $alepostfix++) {
+				$row["ale{$alepostfix}"] = 0;
+			}
+		}
+		
 		$row['nimitys'] = t_tuotteen_avainsanat($row, 'nimitys', $kieli);
 
 		if ($row["vienti_kurssi"] > 0) {
@@ -709,7 +717,7 @@ if (!function_exists('rivi_lasku')) {
 		if ($laskutyyppi == 1) {
 			list($thispage, $kala, $summa, $arvo) = rivi_plain($laskurow, $asiakasrow, $row, $kieli, $pdf_lasku, $thispage, $kala, $laskutyyppi, $toim, $summa, $arvo, $kurssi);
 		}
-		elseif ($laskutyyppi == 2) {
+		elseif ($laskutyyppi == 2 or $laskutyyppi == 12) {
 			list($thispage, $kala, $summa, $arvo) = rivi_perhe($laskurow, $asiakasrow, $row, $kieli, $pdf_lasku, $thispage, $kala, $laskutyyppi, $toim, $summa, $arvo, $kurssi);
 		}
 		elseif ($laskutyyppi == 4 or $laskutyyppi == 8) {
@@ -2072,7 +2080,7 @@ if (!function_exists("tulosta_lasku")) {
 				$rivigrouppaus = TRUE;
 			}
 
-			if (($laskutyyppi != 2) or ($laskutyyppi == 2 and $row["perheid"] > 0 and $row["perheid"] == $row["tunnus"])) {
+			if (($laskutyyppi != 2 and $laskutyyppi != 12) or (($laskutyyppi == 2 or $laskutyyppi == 12) and $row["perheid"] > 0 and $row["perheid"] == $row["tunnus"])) {
 				$yhteensamaara += $row["kpl"];
 			}
 

--- a/tilauskasittely/uudelleenluo_laskuaineisto.php
+++ b/tilauskasittely/uudelleenluo_laskuaineisto.php
@@ -578,7 +578,7 @@
 				while ($tilrow = mysql_fetch_assoc($tilres)) {
 
 					// Näytetään vain perheen isä ja summataan lasten hinnat isäriville
-					if ($laskutyyppi == 2) {
+					if ($laskutyyppi == 2 or $laskutyyppi == 12) {
 						if ($tilrow["perheid"] > 0) {
 							// kyseessä on isä
 							if ($tilrow["perheid"] == $tilrow["tunnus"]) {
@@ -691,7 +691,7 @@
 						$tilrow["kommentti"] .= "S:nro: $sarjarow[sarjanumero] ";
 					}
 
-					if ($laskutyyppi == "7") {
+					if ($laskutyyppi == 7) {
 
 						if ($tilrow["eankoodi"] != "") {
 							$tilrow["kommentti"] = "EAN: $tilrow[eankoodi]|$tilrow[kommentti]";
@@ -772,10 +772,10 @@
 						elmaedi_rivi($tootedi, $tilrow, $rivinumero);
 					}
 					elseif ($lasrow["chn"] == "112") {
-						finvoice_rivi($tootsisainenfinvoice, $tilrow, $lasrow, $vatamount, $totalvat);
+						finvoice_rivi($tootsisainenfinvoice, $tilrow, $lasrow, $vatamount, $totalvat, $laskutyyppi);
 					}
 					elseif ($yhtiorow["verkkolasku_lah"] == "iPost" or $yhtiorow["verkkolasku_lah"] == "finvoice" or $yhtiorow["verkkolasku_lah"] == "apix" or $yhtiorow["verkkolasku_lah"] == "maventa") {
-						finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $totalvat);
+						finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $totalvat, $laskutyyppi);
 					}
 					else {
 						pupevoice_rivi($tootxml, $tilrow, $vatamount, $totalvat);

--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -2200,7 +2200,7 @@
 							while ($tilrow = mysql_fetch_assoc($tilres)) {
 
 								// Näytetään vain perheen isä ja summataan lasten hinnat isäriville
-								if ($laskutyyppi == 2) {
+								if ($laskutyyppi == 2 or $laskutyyppi == 12) {
 									if ($tilrow["perheid"] > 0) {
 										// kyseessä on isä
 										if ($tilrow["perheid"] == $tilrow["tunnus"]) {
@@ -2312,7 +2312,7 @@
 									$tilrow["kommentti"] .= "S:nro: $sarjarow[sarjanumero] ";
 								}
 
-								if ($laskutyyppi == "7") {
+								if ($laskutyyppi == 7) {
 
 									if ($tilrow["eankoodi"] != "") {
 										$tilrow["kommentti"] = "EAN: $tilrow[eankoodi]|$tilrow[kommentti]";
@@ -2393,10 +2393,10 @@
 									elmaedi_rivi($tootedi, $tilrow, $rivinumero);
 								}
 								elseif ($lasrow["chn"] == "112") {
-									finvoice_rivi($tootsisainenfinvoice, $tilrow, $lasrow, $vatamount, $totalvat);
+									finvoice_rivi($tootsisainenfinvoice, $tilrow, $lasrow, $vatamount, $totalvat, $laskutyyppi);
 								}
 								elseif ($yhtiorow["verkkolasku_lah"] == "iPost" or $yhtiorow["verkkolasku_lah"] == "finvoice" or $yhtiorow["verkkolasku_lah"] == "apix" or $yhtiorow["verkkolasku_lah"] == "maventa") {
-									finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $totalvat);
+									finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $totalvat, $laskutyyppi);
 								}
 								else {
 									pupevoice_rivi($tootxml, $tilrow, $vatamount, $totalvat);

--- a/tilauskasittely/verkkolasku_finvoice.inc
+++ b/tilauskasittely/verkkolasku_finvoice.inc
@@ -582,8 +582,19 @@ if (!function_exists('finvoice_otsikko_loput')) {
 }
 
 if (!function_exists('finvoice_rivi')) {
-	function finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $totalvat) {
+	function finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $totalvat, $laskutyyppi = 0) {
 		global $err_finvoice, $yhtiorow, $kukarow;
+
+		if ($laskutyyppi == 10 or $laskutyyppi == 12) {
+			$tilrow['hinta'] = 0;
+			$tilrow['rivihinta'] = 0;
+			$totalvat = 0;
+			$vatamount = 0;
+			$alennukset_yhteensa = 0;
+			for ($alepostfix = 1; $alepostfix <= $yhtiorow['myynnin_alekentat']; $alepostfix++) {
+				$tilrow["ale{$alepostfix}"] = 0;
+			}
+		}
 
 		if ($err_finvoice == 0) {
 			fputs($tootfinvoice, "<InvoiceRow>\r\n");


### PR DESCRIPTION
Lisätty laskupohjat 10 ja 12, jotka ovat muuten kuin 0 ja 2, mutta rivitason hintoja ei näytetä. Alv-lain mukaan riveillä on näytettävä yksikköhinta, joten tämä pohja ei ole Suomessa lain mukainen.

alter table yhtion_parametrit modify laskutyyppi int(2); 
alter table asiakas modify laskutyyppi int(2);
