### PR TITLE
FIX: Verollinen rivihinta kuntoon laskulla

### DIFF
--- a/myyntires/paperikarhu.php
+++ b/myyntires/paperikarhu.php
@@ -772,12 +772,12 @@
 			'tilauspaiva' => date("Y-m-d"),
 			'alv' => 0,
 			'rivihinta' => 0,
+			'rivihinta_verollinen' => 0,
 		);
 
 		$vatamount = 0;
-		$totalvat  = 0;
 
-		finvoice_rivi($tootfinvoice, $tilrow, $laskurow, $vatamount, $totalvat);
+		finvoice_rivi($tootfinvoice, $tilrow, $laskurow, $vatamount);
 
 		finvoice_lasku_loppu($tootfinvoice, $laskurow, $pankkitiedot, $masrow);
 

--- a/tilauskasittely/tulosta_lasku.inc
+++ b/tilauskasittely/tulosta_lasku.inc
@@ -592,7 +592,7 @@ if (!function_exists('rivi_lasku')) {
 				$row["ale{$alepostfix}"] = 0;
 			}
 		}
-		
+
 		$row['nimitys'] = t_tuotteen_avainsanat($row, 'nimitys', $kieli);
 
 		if ($row["vienti_kurssi"] > 0) {
@@ -888,7 +888,7 @@ if (!function_exists('rivi_original')) {
 				$verollrivi = $row["rivihinta_valuutassa"] * (1 + ($row["alv"] / 100));
 			}
 			else {
-				$verollrivi = $row["rivihinta"] * (1 + ($row["alv"] / 100));
+				$verollrivi = $row["rivihinta_verollinen"];
 			}
 
 			$oikpos = $pdf_lasku->strlen(hintapyoristys($verollrivi), $pieni);
@@ -1240,10 +1240,23 @@ if (!function_exists('rivi_perhe')) {
 		if ($row["perheid"] > 0) {
 			// kyseessä on isä
 			if ($row["perheid"] == $row["tunnus"]) {
+
+				$query_ale_lisa = generoi_alekentta('M');
+
+				if ($toim == 'PROFORMA') {
+					$lisa = " 	sum(tilausrivi.hinta / if ('$yhtiorow[alv_kasittely]' = '' and tilausrivi.alv<500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.kpl) * {$query_ale_lisa}) rivihinta,
+								round(sum(tilausrivi.hinta / if ('$yhtiorow[alv_kasittely]' = '' and tilausrivi.alv<500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.kpl) * {$query_ale_lisa}) / $row[kpl], '$yhtiorow[hintapyoristys]') hinta,";
+				}
+				else {
+					$lisa = "	sum(tilausrivi.rivihinta) rivihinta,
+								round(sum(tilausrivi.rivihinta) / $row[kpl], '$yhtiorow[hintapyoristys]') hinta,";
+				}
+
 				// lasketaan isätuotteen riville lapsien hinnat yhteen
 				$query = "	SELECT
-							sum(tilausrivi.rivihinta) rivihinta,
-							round(sum(tilausrivi.rivihinta) / $row[kpl], '$yhtiorow[hintapyoristys]') hinta
+							$lisa
+							sum(round(tilausrivi.hinta * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.kpl) * {$query_ale_lisa}, $yhtiorow[hintapyoristys])) rivihinta_verollinen,
+							sum((tilausrivi.hinta / {$laskurow["vienti_kurssi"]}) / if ('$yhtiorow[alv_kasittely]'  = '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.kpl) * {$query_ale_lisa}) rivihinta_valuutassa
 							FROM tilausrivi
 							WHERE tilausrivi.yhtio 		= '$kukarow[yhtio]'
 							and tilausrivi.uusiotunnus 	= '$row[uusiotunnus]'
@@ -1252,8 +1265,10 @@ if (!function_exists('rivi_perhe')) {
 				$riresult = pupe_query($query);
 				$perherow = mysql_fetch_assoc($riresult);
 
-				$row["hinta"] 		= $perherow["hinta"];
-				$row["rivihinta"] 	= $perherow["rivihinta"];
+				$row["hinta"] 					= $perherow["hinta"];
+				$row["rivihinta"] 				= $perherow["rivihinta"];
+				$row["rivihinta_verollinen"] 	= $perherow["rivihinta_verollinen"];
+				$row["rivihinta_valuutassa"] 	= $perherow["rivihinta_valuutassa"];
 
 				// Nollataan alet, koska hinta lasketaan rivihinnasta jossa alet on jo huomioitu
 				for ($alepostfix = 1; $alepostfix <= $yhtiorow['myynnin_alekentat']; $alepostfix++) {
@@ -2028,7 +2043,8 @@ if (!function_exists("tulosta_lasku")) {
 					min(tilausrivi.tilaajanrivinro) tilaajanrivinro,
 					min(tilausrivi.laadittu) laadittu,
 					sum(tilausrivi.tilkpl) tilkpl,
-					sum((tilausrivi.hinta / {$laskurow["vienti_kurssi"]}) / if ('$yhtiorow[alv_kasittely]' = '' and tilausrivi.alv<500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.kpl) * {$query_ale_lisa}) rivihinta_valuutassa,
+					sum(round(tilausrivi.hinta * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.kpl) * {$query_ale_lisa}, $yhtiorow[hintapyoristys])) rivihinta_verollinen,
+					sum((tilausrivi.hinta / {$laskurow["vienti_kurssi"]}) / if ('$yhtiorow[alv_kasittely]'  = '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.kpl) * {$query_ale_lisa}) rivihinta_valuutassa,
 					group_concat(tilausrivi.tunnus) rivitunnukset,
 					group_concat(distinct tilausrivi.perheid) perheideet,
 					count(*) rivigroup_maara,

--- a/tilauskasittely/uudelleenluo_laskuaineisto.php
+++ b/tilauskasittely/uudelleenluo_laskuaineisto.php
@@ -551,6 +551,7 @@
 							min(tilausrivi.tilaajanrivinro) tilaajanrivinro,
 							min(tilausrivi.laadittu) laadittu,
 							sum(tilausrivi.tilkpl) tilkpl,
+							sum(round(tilausrivi.hinta * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.kpl) * {$query_ale_lisa}, $yhtiorow[hintapyoristys])) rivihinta_verollinen,
 							sum((tilausrivi.hinta / {$lasrow["vienti_kurssi"]}) / if ('$yhtiorow[alv_kasittely]' = '' and tilausrivi.alv<500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.kpl) * {$query_ale_lisa}) rivihinta_valuutassa,
 							group_concat(tilausrivi.tunnus) rivitunnukset,
 							group_concat(distinct tilausrivi.perheid) perheideet,
@@ -585,7 +586,9 @@
 								// lasketaan isätuotteen riville lapsien hinnat yhteen
 								$query = "	SELECT
 											sum(tilausrivi.rivihinta) rivihinta,
-											round(sum(tilausrivi.rivihinta) / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta
+											round(sum(tilausrivi.rivihinta) / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta,
+											sum(round(tilausrivi.hinta * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}, $yhtiorow[hintapyoristys])) rivihinta_verollinen,
+											sum((tilausrivi.hinta / {$lasrow["vienti_kurssi"]}) / if ('$yhtiorow[alv_kasittely]'  = '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}) rivihinta_valuutassa
 											FROM tilausrivi
 											WHERE tilausrivi.yhtio 		= '$kukarow[yhtio]'
 											and tilausrivi.uusiotunnus 	= '$tilrow[uusiotunnus]'
@@ -594,8 +597,10 @@
 								$riresult = pupe_query($query);
 								$perherow = mysql_fetch_assoc($riresult);
 
-								$tilrow["hinta"] 		= $perherow["hinta"];
-								$tilrow["rivihinta"] 	= $perherow["rivihinta"];
+								$tilrow["hinta"] 				= $perherow["hinta"];
+								$tilrow["rivihinta"] 			= $perherow["rivihinta"];
+								$tilrow["rivihinta_verollinen"] = $perherow["rivihinta_verollinen"];
+								$tilrow["rivihinta_valuutassa"] = $perherow["rivihinta_valuutassa"];
 
 								// Nollataan alet, koska hinta lasketaan rivihinnasta jossa alet on jo huomioitu
 								for ($alepostfix = 1; $alepostfix <= $yhtiorow['myynnin_alekentat']; $alepostfix++) {
@@ -720,13 +725,6 @@
 						$tilrow["hinta"] = laskuval($tilrow["hinta"], $tilrow["vienti_kurssi"]);
 					}
 
-					// Verollinen Rivihinta. Lasketaan saman kaavan mukaan kuin laskutus.inc:ssä, eli pyöristetään kaikki kerralla lopuksi!
-					$totalvat = $tilrow["hinta"] * generoi_alekentta_php($tilrow, 'M', 'kerto') * $tilrow["kpl"];
-
-					if ($yhtiorow["alv_kasittely"] != '') {
-						$totalvat = $totalvat * (1 + ($tilrow["alv"] / 100));
-					}
-
 					// Yksikköhinta on laskulla aina veroton
 					if ($yhtiorow["alv_kasittely"] == '') {
 						$tilrow["hinta"] = $tilrow["hinta"] / (1 + $tilrow["alv"] / 100);
@@ -736,10 +734,10 @@
 					$vatamount = $tilrow['rivihinta'] * $tilrow['alv'] / 100;
 
 					// Pyöristetään ja formatoidaan lopuksi
-					$tilrow["hinta"] 	 = hintapyoristys($tilrow["hinta"]);
-					$tilrow["rivihinta"] = hintapyoristys($tilrow["rivihinta"]);
-					$totalvat			 = hintapyoristys($totalvat);
-					$vatamount 			 = hintapyoristys($vatamount);
+					$tilrow["hinta"] 	 			= hintapyoristys($tilrow["hinta"]);
+					$tilrow["rivihinta"] 			= hintapyoristys($tilrow["rivihinta"]);
+					$tilrow["rivihinta_verollinen"]	= hintapyoristys($tilrow["rivihinta_verollinen"]);
+					$vatamount 			 			= hintapyoristys($vatamount);
 
 					$tilrow['kommentti'] = preg_replace("/[^A-Za-z0-9ÖöÄäÅå ".preg_quote(".,-/!+()%#|:", "/")."]/", " ", $tilrow['kommentti']);
 					$tilrow['nimitys'] 	 = preg_replace("/[^A-Za-z0-9ÖöÄäÅå ".preg_quote(".,-/!+()%#|:", "/")."]/", " ", $tilrow['nimitys']);
@@ -772,13 +770,13 @@
 						elmaedi_rivi($tootedi, $tilrow, $rivinumero);
 					}
 					elseif ($lasrow["chn"] == "112") {
-						finvoice_rivi($tootsisainenfinvoice, $tilrow, $lasrow, $vatamount, $totalvat, $laskutyyppi);
+						finvoice_rivi($tootsisainenfinvoice, $tilrow, $lasrow, $vatamount, $laskutyyppi);
 					}
 					elseif ($yhtiorow["verkkolasku_lah"] == "iPost" or $yhtiorow["verkkolasku_lah"] == "finvoice" or $yhtiorow["verkkolasku_lah"] == "apix" or $yhtiorow["verkkolasku_lah"] == "maventa") {
-						finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $totalvat, $laskutyyppi);
+						finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $laskutyyppi);
 					}
 					else {
-						pupevoice_rivi($tootxml, $tilrow, $vatamount, $totalvat);
+						pupevoice_rivi($tootxml, $tilrow, $vatamount);
 					}
 
 					$rivilaskuri++;

--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -2173,6 +2173,7 @@
 										min(tilausrivi.tilaajanrivinro) tilaajanrivinro,
 										min(tilausrivi.laadittu) laadittu,
 										sum(tilausrivi.tilkpl) tilkpl,
+										sum(round(tilausrivi.hinta * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.kpl) * {$query_ale_lisa}, $yhtiorow[hintapyoristys])) rivihinta_verollinen,
 										sum((tilausrivi.hinta / {$lasrow["vienti_kurssi"]}) / if ('$yhtiorow[alv_kasittely]' = '' and tilausrivi.alv<500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.kpl) * {$query_ale_lisa}) rivihinta_valuutassa,
 										group_concat(tilausrivi.tunnus) rivitunnukset,
 										group_concat(distinct tilausrivi.perheid) perheideet,
@@ -2207,7 +2208,9 @@
 											// lasketaan isätuotteen riville lapsien hinnat yhteen
 											$query = "	SELECT
 														sum(tilausrivi.rivihinta) rivihinta,
-														round(sum(tilausrivi.rivihinta) / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta
+														round(sum(tilausrivi.rivihinta) / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta,
+														sum(round(tilausrivi.hinta * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}, $yhtiorow[hintapyoristys])) rivihinta_verollinen,
+														sum((tilausrivi.hinta / {$lasrow["vienti_kurssi"]}) / if ('$yhtiorow[alv_kasittely]'  = '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}) rivihinta_valuutassa
 														FROM tilausrivi
 														WHERE tilausrivi.yhtio 		= '$kukarow[yhtio]'
 														and tilausrivi.uusiotunnus 	= '$tilrow[uusiotunnus]'
@@ -2216,8 +2219,10 @@
 											$riresult = pupe_query($query);
 											$perherow = mysql_fetch_assoc($riresult);
 
-											$tilrow["hinta"] 		= $perherow["hinta"];
-											$tilrow["rivihinta"] 	= $perherow["rivihinta"];
+											$tilrow["hinta"] 				= $perherow["hinta"];
+											$tilrow["rivihinta"] 			= $perherow["rivihinta"];
+											$tilrow["rivihinta_verollinen"] = $perherow["rivihinta_verollinen"];
+											$tilrow["rivihinta_valuutassa"] = $perherow["rivihinta_valuutassa"];
 
 											// Nollataan alet, koska hinta lasketaan rivihinnasta jossa alet on jo huomioitu
 											for ($alepostfix = 1; $alepostfix <= $yhtiorow['myynnin_alekentat']; $alepostfix++) {
@@ -2341,13 +2346,6 @@
 									$tilrow["hinta"] = laskuval($tilrow["hinta"], $tilrow["vienti_kurssi"]);
 								}
 
-								// Verollinen Rivihinta. Lasketaan saman kaavan mukaan kuin laskutus.inc:ssä, eli pyöristetään kaikki kerralla lopuksi!
-								$totalvat = $tilrow["hinta"] * generoi_alekentta_php($tilrow, 'M', 'kerto') * $tilrow["kpl"];
-
-								if ($yhtiorow["alv_kasittely"] != '') {
-									$totalvat = $totalvat * (1 + ($tilrow["alv"] / 100));
-								}
-
 								// Yksikköhinta on laskulla aina veroton
 								if ($yhtiorow["alv_kasittely"] == '') {
 									$tilrow["hinta"] = $tilrow["hinta"] / (1 + $tilrow["alv"] / 100);
@@ -2357,10 +2355,10 @@
 								$vatamount = $tilrow['rivihinta'] * $tilrow['alv'] / 100;
 
 								// Pyöristetään ja formatoidaan lopuksi
-								$tilrow["hinta"]     = hintapyoristys($tilrow["hinta"]);
-								$tilrow["rivihinta"] = hintapyoristys($tilrow["rivihinta"]);
-								$totalvat            = hintapyoristys($totalvat);
-								$vatamount           = hintapyoristys($vatamount);
+								$tilrow["hinta"] 	 			= hintapyoristys($tilrow["hinta"]);
+								$tilrow["rivihinta"] 			= hintapyoristys($tilrow["rivihinta"]);
+								$tilrow["rivihinta_verollinen"]	= hintapyoristys($tilrow["rivihinta_verollinen"]);
+								$vatamount 			 			= hintapyoristys($vatamount);
 
 								$tilrow['kommentti'] = preg_replace("/[^A-Za-z0-9ÖöÄäÅå ".preg_quote(".,-/!+()%#|:", "/")."]/", " ", $tilrow['kommentti']);
 								$tilrow['nimitys']   = preg_replace("/[^A-Za-z0-9ÖöÄäÅå ".preg_quote(".,-/!+()%#|:", "/")."]/", " ", $tilrow['nimitys']);
@@ -2393,13 +2391,13 @@
 									elmaedi_rivi($tootedi, $tilrow, $rivinumero);
 								}
 								elseif ($lasrow["chn"] == "112") {
-									finvoice_rivi($tootsisainenfinvoice, $tilrow, $lasrow, $vatamount, $totalvat, $laskutyyppi);
+									finvoice_rivi($tootsisainenfinvoice, $tilrow, $lasrow, $vatamount, $laskutyyppi);
 								}
 								elseif ($yhtiorow["verkkolasku_lah"] == "iPost" or $yhtiorow["verkkolasku_lah"] == "finvoice" or $yhtiorow["verkkolasku_lah"] == "apix" or $yhtiorow["verkkolasku_lah"] == "maventa") {
-									finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $totalvat, $laskutyyppi);
+									finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $laskutyyppi);
 								}
 								else {
-									pupevoice_rivi($tootxml, $tilrow, $vatamount, $totalvat);
+									pupevoice_rivi($tootxml, $tilrow, $vatamount);
 								}
 
 								$rivilaskuri++;

--- a/tilauskasittely/verkkolasku_finvoice.inc
+++ b/tilauskasittely/verkkolasku_finvoice.inc
@@ -582,15 +582,16 @@ if (!function_exists('finvoice_otsikko_loput')) {
 }
 
 if (!function_exists('finvoice_rivi')) {
-	function finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $totalvat, $laskutyyppi = 0) {
+	function finvoice_rivi($tootfinvoice, $tilrow, $lasrow, $vatamount, $laskutyyppi = 0) {
 		global $err_finvoice, $yhtiorow, $kukarow;
 
 		if ($laskutyyppi == 10 or $laskutyyppi == 12) {
-			$tilrow['hinta'] = 0;
-			$tilrow['rivihinta'] = 0;
-			$totalvat = 0;
-			$vatamount = 0;
-			$alennukset_yhteensa = 0;
+			$tilrow['hinta'] 				= 0;
+			$tilrow['rivihinta'] 			= 0;
+			$tilrow["rivihinta_verollinen"] = 0;
+			$vatamount 						= 0;
+			$alennukset_yhteensa 			= 0;
+
 			for ($alepostfix = 1; $alepostfix <= $yhtiorow['myynnin_alekentat']; $alepostfix++) {
 				$tilrow["ale{$alepostfix}"] = 0;
 			}
@@ -735,11 +736,11 @@ if (!function_exists('finvoice_rivi')) {
 
 			$alennukset_yhteensa = generoi_alekentta_php($tilrow, 'M', 'plain');
 
-			xml_add("RowDiscountPercent",                                    					pp($alennukset_yhteensa, 2),										$tootfinvoice);
-			xml_add("RowVatRatePercent",                                    					pp($tilrow['alv'], 2, 5, 2),           								$tootfinvoice);
-			xml_add("RowVatAmount AmountCurrencyIdentifier=\"$lasrow[valkoodi]\"",          	pp($vatamount, $yhtiorow["hintapyoristys"], 5, 2),      			$tootfinvoice);	// veron määrä
-			xml_add("RowVatExcludedAmount AmountCurrencyIdentifier=\"$lasrow[valkoodi]\"",  	pp($tilrow['rivihinta'], $yhtiorow["hintapyoristys"], 5, 2),      	$tootfinvoice);	// veroton rivihinta
-			xml_add("RowAmount AmountCurrencyIdentifier=\"$lasrow[valkoodi]\"",             	pp($totalvat, $yhtiorow["hintapyoristys"], 5, 2),     				$tootfinvoice);	// verollinen rivihinta
+			xml_add("RowDiscountPercent",                                    					pp($alennukset_yhteensa, 2),											$tootfinvoice);
+			xml_add("RowVatRatePercent",                                    					pp($tilrow['alv'], 2, 5, 2),           									$tootfinvoice);
+			xml_add("RowVatAmount AmountCurrencyIdentifier=\"$lasrow[valkoodi]\"",          	pp($vatamount, $yhtiorow["hintapyoristys"], 5, 2),      				$tootfinvoice);	// veron määrä
+			xml_add("RowVatExcludedAmount AmountCurrencyIdentifier=\"$lasrow[valkoodi]\"",  	pp($tilrow['rivihinta'], $yhtiorow["hintapyoristys"], 5, 2),      		$tootfinvoice);	// veroton rivihinta
+			xml_add("RowAmount AmountCurrencyIdentifier=\"$lasrow[valkoodi]\"",             	pp($tilrow["rivihinta_verollinen"], $yhtiorow["hintapyoristys"], 5, 2), $tootfinvoice);	// verollinen rivihinta
 			fputs($tootfinvoice, "</InvoiceRow>\r\n");
 		}
 	}

--- a/tilauskasittely/verkkolasku_pupevoice.inc
+++ b/tilauskasittely/verkkolasku_pupevoice.inc
@@ -199,7 +199,7 @@ if (!function_exists('pupevoice_alvierittely')) {
 }
 
 if (!function_exists('pupevoice_rivi')) {
-	function pupevoice_rivi($tootxml, $tilrow, $vatamount, $totalvat) {
+	function pupevoice_rivi($tootxml, $tilrow, $vatamount) {
 		global $yhtiorow, $kukarow;
 
 		fputs($tootxml, "<Row>\n");
@@ -235,7 +235,7 @@ if (!function_exists('pupevoice_rivi')) {
 		xml_add("RowVatRatePercent",				$tilrow['alv'], 							$tootxml);
 		xml_add("RowVatAmount",						$vatamount, 								$tootxml); // veron m‰‰r‰
 		xml_add("RowTotalVatExcludedAmount",		$tilrow['rivihinta'],		 				$tootxml); // veroton rivihinta
-		xml_add("RowTotalVatIncludedAmount",		$totalvat, 									$tootxml); // verollinen rivihinta
+		xml_add("RowTotalVatIncludedAmount",		$tilrow["rivihinta_verollinen"], 			$tootxml); // verollinen rivihinta
 
 		// Jos t‰m‰ on t‰n tilauksen vika rivi
 		if ($tilrow['tuoteno'] != $yhtiorow["kuljetusvakuutus_tuotenumero"] and $tilrow['tuoteno'] != $yhtiorow["laskutuslisa_tuotenumero"] and $tilrow['seuraava_otunnus'] != $tilrow["otunnus"]) {


### PR DESCRIPTION
Verollinen rivihinta kuntoon laskulla. Jatkossa verollinen rivihinta lasketaan aina näin:

round(hinta \* if ('alv_kasittely' != '' and alv < 500, (1+alv/100), 1) \* kpl \* (1 - (ale/100)), 2);

Eli mennään saman kaavan mukaan kuin laskutus.inc:ssä

Ennen laskettiin näin: 

round(rivihinta \* if ('alv_kasittely' != '' and alv < 500, (1+alv/100), 1), 2);

Silloin mentiin metsään koska pyöristettiin 2 kertaa.
