### PR TITLE
FIX: Ohita-keräys konseptin korjaus keräyksessä ja rivi lisäyksessä.

### DIFF
--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -1189,41 +1189,25 @@
 								$keraysera_update_res = pupe_query($query_upd);
 							}
 
-							// päivitetään tuoteperhen lapset kerätyiksi jos niillä on ohita_keräys täppä päällä
-							$query_chk = "	SELECT perheid, tuoteno, varattu, otunnus
-											FROM tilausrivi
-											WHERE yhtio = '{$kukarow['yhtio']}'
-											AND tunnus  = '{$apui}'
-											AND perheid = '{$apui}'";
-							$perheid_chk_res = pupe_query($query_chk);
-
-							if (mysql_num_rows($perheid_chk_res) > 0) {
-
-								$perheid_chk_row = mysql_fetch_assoc($perheid_chk_res);
-
-								// haetaan lapset, ei oteta isää huomioon
-								$query_lapset = "	SELECT tunnus, tuoteno, varattu
+							if (trim($maara[$apui]) != '') {
+								// haetaan lapset joilla on ohita_kerays täpätty ja tehdään poikkeama myös niille
+								$query_lapset = "	SELECT tilausrivi.tunnus, tilausrivi.varattu
 													FROM tilausrivi
-													WHERE yhtio = '{$kukarow['yhtio']}'
-													AND otunnus = '{$perheid_chk_row['otunnus']}'
-													AND perheid = '{$perheid_chk_row['perheid']}'
-													AND tunnus != '{$apui}'";
+													JOIN tilausrivin_lisatiedot ON (tilausrivin_lisatiedot.yhtio = tilausrivi.yhtio AND tilausrivin_lisatiedot.tilausrivitunnus = tilausrivi.tunnus and tilausrivin_lisatiedot.ohita_kerays != '')
+													WHERE tilausrivi.yhtio = '{$kukarow['yhtio']}'
+													AND tilausrivi.otunnus = '{$tilrivirow['otunnus']}'
+													AND tilausrivi.perheid = '{$tilrivirow['perheid']}'
+													AND tilausrivi.tunnus != '{$apui}'";
 								$lapset_chk_res = pupe_query($query_lapset);
 
 								while ($lapset_chk_row = mysql_fetch_assoc($lapset_chk_res)) {
 
-									$query_ohita = "	SELECT ohita_kerays, kerroin
-														FROM tuoteperhe
-														WHERE yhtio 	= '{$kukarow['yhtio']}'
-														AND tyyppi 		= 'P'
-														AND isatuoteno 	= '{$perheid_chk_row['tuoteno']}'
-														AND tuoteno 	= '{$lapset_chk_row['tuoteno']}'";
-									$ohita_chk_res = pupe_query($query_ohita);
-									$ohita_chk_row = mysql_fetch_assoc($ohita_chk_res);
-
-									// Pitääkö lapsen kerättymäärää muuttaa? (lapsi tulee myös $kerivi[] arrayssa, joten se merkataan joka tapauksessa kerätyksi, mutta muutetaan tässä määrä jos on tarvis)
-									if ($ohita_chk_row['ohita_kerays'] != '' and round($lapset_chk_row["varattu"], 2) != round($perheid_chk_row["varattu"] * $ohita_chk_row["kerroin"], 2)) {
-										$maara[$lapset_chk_row['tunnus']] = round($perheid_chk_row["varattu"] * $ohita_chk_row["kerroin"], 2);
+									if (round($lapset_chk_row["varattu"], 2) != round($maara[$apui] * ($lapset_chk_row["varattu"]/$tilrivirow["varattu"]), 2)) {
+										$query_upd = "	UPDATE tilausrivi
+														SET varattu = round({$maara[$apui]} * ({$lapset_chk_row["varattu"]}/{$tilrivirow["varattu"]}), 2)
+														WHERE yhtio = '{$kukarow['yhtio']}'
+														AND tunnus 	= '{$lapset_chk_row['tunnus']}'";
+										$keraysera_update_res = pupe_query($query_upd);
 									}
 								}
 							}
@@ -2534,8 +2518,10 @@
 						lasku.jtkielto,
 						$select_lisa
 						$sorttauskentta,
-						if (tuote.tuotetyyppi='K','2 Työt','1 Muut') tuotetyyppi
+						if (tuote.tuotetyyppi='K','2 Työt','1 Muut') tuotetyyppi,
+						tilausrivin_lisatiedot.ohita_kerays
 						FROM tilausrivi
+						LEFT JOIN tilausrivin_lisatiedot ON (tilausrivin_lisatiedot.yhtio = tilausrivi.yhtio AND tilausrivin_lisatiedot.tilausrivitunnus = tilausrivi.tunnus)
 						JOIN tuote ON tuote.yhtio = tilausrivi.yhtio and tuote.tuoteno = tilausrivi.tuoteno
 						JOIN lasku ON lasku.yhtio = tilausrivi.yhtio and lasku.tunnus = tilausrivi.otunnus
 						$asiakas_join_lisa
@@ -2801,14 +2787,20 @@
 							if ($yhtiorow['kerayserat'] == 'K' and $toim == "") {
 								echo "<span id='maaran_paivitys_{$row['tunnus']}'></span>";
 
-								$query = "	SELECT sum(kpl) kpl
-											FROM kerayserat
-											WHERE yhtio 	= '{$kukarow['yhtio']}'
-											AND nro 		= '$id'
-											AND tilausrivi 	= '{$row['tunnus']}'
-											ORDER BY pakkausnro ASC";
-								$keraysera_res = pupe_query($query);
-								$keraysera_row = mysql_fetch_assoc($keraysera_res);
+								if ($row['ohita_kerays'] != "") {
+									// ohita_kerays tuotteet ei mee keräyseriin
+									$keraysera_row['kpl'] = $row["varattu"];
+								}
+								else {
+									$query = "	SELECT sum(kpl) kpl
+												FROM kerayserat
+												WHERE yhtio 	= '{$kukarow['yhtio']}'
+												AND nro 		= '$id'
+												AND tilausrivi 	= '{$row['tunnus']}'
+												ORDER BY pakkausnro ASC";
+									$keraysera_res = pupe_query($query);
+									$keraysera_row = mysql_fetch_assoc($keraysera_res);
+								}
 
 								// Katotaan jo tässä vaiheessa onko erässä eri määrä kuin tilausrivillä.
 								// Määrä voi olla eri, koska keräyseriin menee vain kokonaislukuja ja tilausrivillä voi olla desimaalilukuja

--- a/tilauskasittely/korjaa_kerays.php
+++ b/tilauskasittely/korjaa_kerays.php
@@ -23,7 +23,6 @@
 		if (mysql_num_rows($tilre) > 0) {
 
 			$query = "	UPDATE tilausrivi
-						JOIN tilausrivin_lisatiedot ON (tilausrivin_lisatiedot.yhtio = tilausrivi.yhtio AND tilausrivin_lisatiedot.tilausrivitunnus = tilausrivi.tunnus AND tilausrivin_lisatiedot.ohita_kerays = '')
 						JOIN tuote ON (tilausrivi.yhtio = tuote.yhtio and tilausrivi.tuoteno = tuote.tuoteno and tuote.ei_saldoa = '')
 						SET tilausrivi.keratty = '',
 						tilausrivi.kerattyaika = ''

--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -100,10 +100,7 @@
 			$perhearray = array();
 			$tuoteno 	= strtoupper($tuoteno);
 
-			if (in_array($tuoteno, $isat_array)) {
-				//echo "FUULI! TEET IKUISEN LUUPIN!!!!!!!!<br>";
-			}
-			else {
+			if (!in_array($tuoteno, $isat_array)) {
 				$isat_array[] = $tuoteno;
 
 				// Haetaan tuoteperheen lapset ja lisätään ne $isa_array arrayseen
@@ -120,12 +117,12 @@
 				while ($perherow = mysql_fetch_assoc($perheresult)) {
 					$perherow["tuoteno"] = strtoupper($perherow["tuoteno"]);
 
-					$kaikki_array[]		= $perherow["tuoteno"]; // lisätään tuoteno arrayseen
-					$kerroin_array[]	= $tuoteno."#!¡!#".$perherow["kerroin"];
+					$kaikki_array[]		  = $perherow["tuoteno"]; // lisätään tuoteno arrayseen
+					$kerroin_array[]	  = $tuoteno."#!¡!#".$perherow["kerroin"];
 					$ohita_kerays_array[] = $perherow['ohita_kerays'];
 
 					$mikaisa = $perherow["tuoteno"];
-					$tmp_kaikki_array = $kaikki_array;
+					$tmp_kaikki_array  = $kaikki_array;
 					$tmp_kerroin_array = $kerroin_array;
 
 					krsort($tmp_kaikki_array);
@@ -1250,11 +1247,11 @@
 
 						if (count($tuoteperhe) > 0) {
 
-							$riikoko 		= 1;
-							$isat_array 	= array();
-							$kaikki_array 	= array($tuoteno);
-							$kerroin_array 	= array($tuoteno."#!¡!#1");
-							$perhearray 	= array();
+							$riikoko 			= 1;
+							$isat_array 		= array();
+							$kaikki_array 		= array($tuoteno);
+							$kerroin_array 		= array($tuoteno."#!¡!#1");
+							$perhearray 		= array();
 							$ohita_kerays_array = array();
 
 							for ($isa = 0; $isa < $riikoko; $isa++) {
@@ -1557,11 +1554,11 @@
 									$query = "	UPDATE tilausrivin_lisatiedot
 												SET
 												positio = if (positio = '', '$trivtyrow[selite]', positio),
-												toimittajan_tunnus	= '$toimittajan_tunnus',
-												muutospvm			= now(),
-												muuttaja			= '$kukarow[kuka]',
-												erikoistoimitus_myynti = '$myy_erikoistoimitus[$indeksi]',
-												ohita_kerays = '{$myy_ohita_kerays[$indeksi]}'
+												toimittajan_tunnus		= '$toimittajan_tunnus',
+												muutospvm				= now(),
+												muuttaja				= '$kukarow[kuka]',
+												erikoistoimitus_myynti	= '$myy_erikoistoimitus[$indeksi]',
+												ohita_kerays 			= '{$myy_ohita_kerays[$indeksi]}'
 												{$tlisatied_lisa}
 												{$tlisatied_lisa2}
 												WHERE yhtio			 = '$kukarow[yhtio]'
@@ -1774,6 +1771,7 @@
 		$puu_hintake	= array();
 		$puu_alekerr	= array();
 		$puu_ein 		= array();
+		$puu_ohiker		= array();
 		$puu_var		= array();
 
 		if ($rivityyppi == 'O' and $rivitunnus > 0 and isset($suoratoimitus_rivitun) and $suoratoimitus_rivitun > 0) {
@@ -1799,6 +1797,7 @@
 			$puu_hintake[]	= "X";
 			$puu_alekerr[]	= "X";
 			$puu_ein[]		= "";
+			$puu_ohiker[]	= "";
 			$puu_var[]		= $var;
 
 			if (substr($var,0,8) == "LOJ#!¡!#" and substr($var, 8) - $toimittamatta > 0) {
@@ -1807,6 +1806,7 @@
 				$puu_hintake[]	= "X";
 				$puu_alekerr[]	= "X";
 				$puu_ein[]		= "";
+				$puu_ohiker[]	= "";
 				$puu_var[]		= "";
 			}
 			elseif (substr($lop,0,8) == "LOP#!¡!#" and substr($lop, 8) - $toimittamatta > 0) {
@@ -1815,6 +1815,7 @@
 				$puu_hintake[]	= "X";
 				$puu_alekerr[]	= "X";
 				$puu_ein[]		= "";
+				$puu_ohiker[]	= "";
 				$puu_var[]		= "P";
 			}
 		}
@@ -1826,16 +1827,17 @@
 			$puu_hintake[]	= "X";
 			$puu_alekerr[]	= "X";
 			$puu_ein[]		= "";
+			$puu_ohiker[]	= "";
 			$puu_var[]		= $var;
 		}
 
 		if ($rivityyppi != 'O' and $perheid == 0 and $perhekielto == "") {
 
-			$riikoko 		= 1;
-			$isat_array 	= array();
-			$kaikki_array 	= (($yhtiorow['puute_jt_oletus'] == 'B' or $yhtiorow['puute_jt_oletus'] == 'A') and $uusin_korvaava_tuote != '') ? array($uusin_korvaava_tuote) : array($alkupera_trow["tuoteno"]);
-			$kerroin_array 	= (($yhtiorow['puute_jt_oletus'] == 'B' or $yhtiorow['puute_jt_oletus'] == 'A') and $uusin_korvaava_tuote != '') ? array($uusin_korvaava_tuote."#!¡!#1") : array($alkupera_trow["tuoteno"]."#!¡!#1");
-			$perhearray 	= array();
+			$riikoko 			= 1;
+			$isat_array 		= array();
+			$kaikki_array 		= (($yhtiorow['puute_jt_oletus'] == 'B' or $yhtiorow['puute_jt_oletus'] == 'A') and $uusin_korvaava_tuote != '') ? array($uusin_korvaava_tuote) : array($alkupera_trow["tuoteno"]);
+			$kerroin_array 		= (($yhtiorow['puute_jt_oletus'] == 'B' or $yhtiorow['puute_jt_oletus'] == 'A') and $uusin_korvaava_tuote != '') ? array($uusin_korvaava_tuote."#!¡!#1") : array($alkupera_trow["tuoteno"]."#!¡!#1");
+			$perhearray 		= array();
 			$ohita_kerays_array = array();
 
 			for ($isa=0; $isa < $riikoko; $isa++) {
@@ -1859,6 +1861,7 @@
 				$puu_hintake[]	= $perherow["hintakerroin"];
 				$puu_alekerr[]	= $perherow["alekerroin"];
 				$puu_ein[] 		= $perherow["ei_nayteta"];
+				$puu_ohiker[] 	= $perherow["ohita_kerays"];
 				$puu_var[]		= $var;
 			}
 		}
@@ -2425,7 +2428,9 @@
 							positio = if (positio = '', '$trivtyrow[selite]', positio),
 							toimittajan_tunnus	= '$toimittajan_tunnus',
 							muutospvm			= now(),
-							muuttaja			= '$kukarow[kuka]'
+							muuttaja			= '$kukarow[kuka]',
+							ei_nayteta			= '{$puu_ein[$i]}',
+							ohita_kerays 		= '{$puu_ohiker[$i]}'
 							{$tlisatied_lisa}
 							{$tlisatied_lisa2}
 							WHERE yhtio			 = '$kukarow[yhtio]'
@@ -2446,7 +2451,8 @@
 							tilausrivitunnus	= '$lisatty_tun',
 							jarjestys			= '$jarjestys',
 							vanha_otunnus		= '$kukarow[kesken]',
-							ei_nayteta			= '$puu_ein[$i]',
+							ei_nayteta			= '{$puu_ein[$i]}',
+							ohita_kerays 		= '{$puu_ohiker[$i]}',
 							luontiaika			= now(),
 							laatija 			= '$kukarow[kuka]'
 							{$tlisatied_lisa}


### PR DESCRIPTION
Ohita-keräys konseptin korjaus keräyksessä ja rivin lisäyksessä. Jatkossa ohita_kerays tieto löytyy aina luotettavasti tilausrivin lisätiedoista. Eli ohita_kerays tuotteet toimii sekä korvakeräyksessä että paperilla. Myös keräyspoikkeamat hanskataan nyt oikein.
