### PR TITLE
Lasku kopio.

### DIFF
--- a/tilauskasittely/tulosta_lasku.inc
+++ b/tilauskasittely/tulosta_lasku.inc
@@ -2462,7 +2462,6 @@ if (!function_exists("tulosta_lasku")) {
 
 			if (($komento == "email" and $kukarow["eposti"] != '') or substr($komento,0,12) == 'asiakasemail') {
 				// l‰hetet‰‰n meili
-				$komento = "";
 
 				$kutsu = t("Lasku", $kieli)." ".$laskurow["laskunro"];
 


### PR DESCRIPTION
Tulosta toiminnon kautta lähettäminen asiakkaan emailiin bugfix.

Komento -muuttuja asetettiin tyhjäksi hieman ennen sähköposti.inc includea. Tästä syystä sahkoposti.inc:ssa käytettiin aina kukarow['eposti'] muuttujasta löytyvää epostia, eikä ikinä menty asiakasemail tarkistukseen.
