### PR TITLE
Lisää rajauksia avoimet laskut -ohjelmaan

### DIFF
--- a/inc/avoimet.inc
+++ b/inc/avoimet.inc
@@ -119,7 +119,7 @@
 
 	echo "	<tr>
 			<th>".t("Mitkä laskut listataan:")."</th>
-			<td colspan = '3'><select name='laji'>
+			<td colspan = '3'><select name='laji' onchange='submit();'>
 			<option value='M'   $sel[M]>".t("myyntisaamiset")."</option>
 			<option value='MF'  $sel[MF]>".t("factoringmyyntisaamiset")."</option>
 			<option value='MK'  $sel[MK]>".t("konsernimyyntisaamiset")."</option>
@@ -136,27 +136,13 @@
 			<td colspan='3'><input type = 'text' name = 'ytunnus' value='".tarkistahetu($ytunnus)."'></td>
 			</tr>";
 
+	echo "<tr><th>".t("Rajauksia")."</th><td colspan='3'>";
 
-	$query = "	SELECT tunnus
-				FROM kustannuspaikka
-				WHERE yhtio = '$kukarow[yhtio]'
-				and tyyppi = 'K'
-				and kaytossa != 'E'
-				LIMIT 1";
-	$result = pupe_query($query);
-
-	if (mysql_num_rows($result) > 0) {
-
-		echo "<tr><th>".t("Kustannuspaikka")."</th><td colspan='3'>";
-
-		$monivalintalaatikot = array("KUSTP");
-		$noautosubmit = TRUE;
-		$piirra_otsikot = FALSE;
-
-		require ("tilauskasittely/monivalintalaatikot.inc");
-
-		echo "</td></tr>";
-	}
+	if (substr($laji,0,1) != 'O') $monivalintalaatikot = array("KUSTP", "ASIAKASOSASTO", "ASIAKASMYYJA");
+	else $monivalintalaatikot = array("KUSTP");
+	$noautosubmit = TRUE;
+	require ("tilauskasittely/monivalintalaatikot.inc");
+	echo "</td></tr>";
 
 	if ($naytetaankokommentit != "") $komsel = "CHECKED";
 	else $komsel = "";
@@ -277,13 +263,13 @@
 	echo "<tr><th>".t("Tee Excel")."</th><td colspan='3'><input type='checkbox' name='excel' value = 'YES' $exsel></td></tr>";
 
 	echo "</table><br>";
-	echo "<input type = 'submit' value = '".t("Aja raportti")."'>";
+	echo "<input type = 'submit' name = 'ajaraportti' value = '".t("Aja raportti")."'>";
 	echo "</form><br><br>";
 
 	$formi = 'valinta';
 	$kentta = 'pp';
 
-	if ($tee != '') {
+	if ($tee != '' AND isset($ajaraportti)) {
 
 		switch ($laji) {
 			case 'M' :
@@ -320,6 +306,17 @@
 			$valkoodi2 = " and suoritus.valkoodi = '$savalkoodi'";
 		}
 
+		$asiakasjoin = "";
+		if (isset($lisa) and strpos($lisa, "asiakas.") !== FALSE) {
+			$asiakasjoin = " JOIN asiakas ON (asiakas.yhtio = lasku.yhtio and asiakas.tunnus = lasku.liitostunnus)";
+		}
+		
+		$tiliointilisa = "";
+		if (isset($lisa) and strpos($lisa, "tiliointi.") !== FALSE) {
+			preg_match("/and tiliointi.kustp in \([',0-9]*?\)/", $lisa, $kustpeet);
+			$tiliointilisa = $kustpeet[0];
+		}
+
 		if (substr($laji,0,1) == 'O') {
 
 			$av_lisa = '';
@@ -330,13 +327,6 @@
 			}
 			else {
 				$indeksi = " use index (yhtio_tila_tapvm)";
-			}
-
-			if (isset($lisa) and strpos($lisa, "tiliointi.kustp") !== FALSE) {
-				$tiliointilisa = $lisa;
-			}
-			else {
-				$tiliointilisa = '';
 			}
 
 			if ($laji == 'OOK') 	$tili = "'".$yhtiorow['ostovelat']."','".$yhtiorow['konserniostovelat']."'";
@@ -618,13 +608,6 @@
 				$maalisa = " and lasku.maa = '$maa'";
 			}
 
-			if (isset($lisa) and strpos($lisa, "tiliointi.kustp") !== FALSE) {
-				$tiliointilisa = $lisa;
-			}
-			else {
-				$tiliointilisa = '';
-			}
-
 			$tili = 0;
 
 			if ($laji == 'MK') 		$tili = "'$yhtiorow[konsernimyyntisaamiset]'";
@@ -711,7 +694,8 @@
 						sum(if(tiliointi.tapvm = lasku.tapvm, tiliointi.summa, 0))-lasku.pyoristys tiliointisumma,
 						sum(if(tiliointi.tapvm = lasku.tapvm, tiliointi.summa_valuutassa, 0))-lasku.pyoristys_valuutassa tiliointisumma_valuutassa
 						FROM lasku $indeksi
-						JOIN tiliointi use index (tositerivit_index) ON (lasku.yhtio = tiliointi.yhtio and lasku.tunnus = tiliointi.ltunnus and tiliointi.tilino in ($tili) and tiliointi.korjattu = '' and tiliointi.tapvm <= '$pvm' {$tiliointilisa})
+						JOIN tiliointi use index (tositerivit_index) ON (lasku.yhtio = tiliointi.yhtio and lasku.tunnus = tiliointi.ltunnus and tiliointi.tilino in ($tili) and tiliointi.korjattu = '' and tiliointi.tapvm <= '$pvm')
+						$asiakasjoin
 						$luottovakuutuslisa
 						WHERE lasku.yhtio		= '$kukarow[yhtio]'
 						and (lasku.mapvm		> '$pvm' or lasku.mapvm = '0000-00-00')
@@ -720,6 +704,7 @@
 						and lasku.tapvm 		> '0000-00-00'
 						and lasku.tila			= 'U'
 						and lasku.alatila		= 'X'
+						$lisa
 						$av_lisa1
 						$valkoodi
 						$maalisa


### PR DESCRIPTION
Voidaan rajata Myyntireskontran Avoimet laskut -ohjelmassa kustannuspaikan lisäksi myyntilaskuja asiakasosastolla ja asiakasmyyjällä.
