### PR TITLE
DPD Delisprint path otetaan osittain rahtikirja-avainsanasta

### DIFF
--- a/tilauskasittely/rahtikirja_dpd_siirto.inc
+++ b/tilauskasittely/rahtikirja_dpd_siirto.inc
@@ -257,7 +257,7 @@ if ($kollityht > 0) {
 			$ftphost = $dpd_ds_host;
 			$ftpuser = $dpd_ds_user;
 			$ftppass = $dpd_ds_pass;
-			$ftppath = $dpd_ds_path . trim($avainrow['selitetark_3']) . "/";
+			$ftppath = (trim($avainrow['selitetark_3']) != '') ? $dpd_ds_path . trim($avainrow['selitetark_3']) . "/" : $dpd_ds_path;
 			$ftpfile = realpath($filenimi);
 
 			require ("inc/ftp-send.inc");


### PR DESCRIPTION
Voidaan tallentaa rahtikirja-avainsanaan rahtikirja_dpd_siirto.inc tapauksessa selitetark_3 kenttään ftp pathin loppu.
