### PR TITLE
Virhelistan automaatikohdistus.

### DIFF
--- a/ostolasku_asn_tarkastelu.php
+++ b/ostolasku_asn_tarkastelu.php
@@ -217,7 +217,8 @@
 				if (mysql_num_rows($liitosotsikko_chk_res) > 0) {
 
 					$query = "	UPDATE asn_sanomat SET
-								status = 'X'
+								status = 'X',
+								tilausrivi = ''
 								WHERE yhtio = '{$kukarow['yhtio']}'
 								AND asn_numero = '{$lasku}'
 								AND status not in ('E', 'D')";


### PR DESCRIPTION
Jos virhelistalta painetaan "automaattikohdistukseen" ja lasku onkin jo saapumisella (liitetty käsin), nollataan myös sähköisen laskun tilausrivi-varaukset (niiltä osin jotka on ok) samalla kun sähköinen sanoma laitetaan "käytetyksi".
