### PR TITLE
* Hinnoittelupoikkeamat-raporttiin korjauksia

### DIFF
--- a/raportit/hinnoittelupoikkeamat.php
+++ b/raportit/hinnoittelupoikkeamat.php
@@ -294,7 +294,9 @@
 						$worksheet->write($excelrivi, $excelsarake, $v);
 						$excelsarake++;
 
-						echo "<td class='{$odd}'>{$v}</td>";
+						$stylelisa = $excelsarake > 7 ? " style='text-align: right;' " : "";
+
+						echo "<td class='{$odd}' {$stylelisa}>{$v}</td>";
 
 						if ($k == 'myyjä' and $v != '') $user = $v;
 						if ($k == 'ero' and $user != '') {


### PR DESCRIPTION
Raportin viimeinen sarake "Ero" on nyt rivin ero, ei kpl kohtainen ero. Eli kpl x ero = rivin ero.

Näytetään vain ne poikkeamat jossa hinta on ollut vähemmän kuin koneen hinta, ei jos myyty kalliimmalla.
