### PR TITLE
Optiscan pätkii: unifaun fetch fix

### DIFF
--- a/unifaun_fetch.php
+++ b/unifaun_fetch.php
@@ -149,7 +149,7 @@
 							if ($operaattori == 'unifaun_ps' and $unifaun_ps_host != "" and $unifaun_ps_user != "" and $unifaun_ps_pass != "" and $unifaun_ps_path != "") {
 								$unifaun = new Unifaun($unifaun_ps_host, $unifaun_ps_user, $unifaun_ps_pass, $unifaun_ps_path, $unifaun_ps_port, $unifaun_ps_fail, $unifaun_ps_succ);
 							}
-							elseif ($operaattori == 'unifaun_uo.inc' and $unifaun_uo_host != "" and $unifaun_uo_user != "" and $unifaun_uo_pass != "" and $unifaun_uo_path != "") {
+							elseif ($operaattori == 'unifaun_uo' and $unifaun_uo_host != "" and $unifaun_uo_user != "" and $unifaun_uo_pass != "" and $unifaun_uo_path != "") {
 								$unifaun = new Unifaun($unifaun_uo_host, $unifaun_uo_user, $unifaun_uo_pass, $unifaun_uo_path, $unifaun_uo_port, $unifaun_uo_fail, $unifaun_uo_succ);
 							}
 


### PR DESCRIPTION
Kun päivitetään Unifaunista saatu sscc ja jos paketilla on jo ulkoinen sscc, lähetetään discardParcel-sanoma jo olemassa olevasta ulkoisesta sscc:stä.
