### PR TITLE
* Uusi laskupohja ja lähetemuutoksia.

### DIFF
--- a/inc/asiakasrivi.inc
+++ b/inc/asiakasrivi.inc
@@ -937,20 +937,21 @@
 		$sel[$apu] = "selected";
 
 		$ulos .= "<option value = '-9'>".t("Oletus")."</option>";
-		$ulos .= "<option value = '0' $sel[0]>".t("Normaali laskupohja");
-		$ulos .= "<option value = '2' $sel[2]>".t("Normaali laskupohja (Tuoteperheet yhdistetty)");
+		$ulos .= "<option value = '0' $sel[0]>".t("Normaali laskupohja")."</option>";
+		$ulos .= "<option value = '2' $sel[2]>".t("Normaali laskupohja (Tuoteperheet yhdistetty)")."</option>";
 		$ulos .= "<option value = '5' $sel[5]>".t("Normaali laskupohja (Ei n‰ytet‰ verollista rivihintaa)")."</option>";
 		$ulos .= "<option value = '6' $sel[6]>".t("Normaali laskupohja (Ei n‰ytet‰ tilausnumeroa/toimitusaikaa)")."</option>";
 		$ulos .= "<option value = '7' $sel[7]>".t("Normaali laskupohja (N‰ytet‰‰n tuotteen EAN koodi ja asiakaskommentti)")."</option>";
-		$ulos .= "<option value = '1' $sel[1]>".t("Pelkistetty laskupohja 1");
-		#$ulos .= "<option value = '3' $sel[3]>".t("Pelkistetty laskupohja 2 (Tuoteperheet yhdistetty)");
-		$ulos .= "<option value = '4' $sel[4]>".t("Pelkistetty laskupohja 3");
-		$ulos .= "<option value = '10' $sel[10]>".t("Normaali laskupohja ilman rivihintoja (ei laillinen Suomessa)");
-		$ulos .= "<option value = '12' $sel[12]>".t("Normaali laskupohja (Tuoteperheet yhdistetty) ilman rivihintoja (ei laillinen Suomessa)");
-		$ulos .= "<option value = '13' $sel[13]>".t("Nettohinnat, ei alennuksia, ei verollisia hintoja");
-		$ulos .= "<option value = '14' $sel[14]>".t("Nettohinnat, ei alennuksia, ei verollisia hintoja (Tuoteperheet yhdistetty)");
-		$ulos .= "<option value = '15' $sel[15]>".t("SVH, Nettohinnat, ei alennuksia, ei verollisia hintoja");
-		$ulos .= "<option value = '16' $sel[16]>".t("SVH, Nettohinnat, ei alennuksia, ei verollisia hintoja (Tuoteperheet yhdistetty)");
+		$ulos .= "<option value = '1' $sel[1]>".t("Pelkistetty laskupohja 1")."</option>";
+		#$ulos .= "<option value = '3' $sel[3]>".t("Pelkistetty laskupohja 2 (Tuoteperheet yhdistetty)")."</option>";
+		$ulos .= "<option value = '4' $sel[4]>".t("Pelkistetty laskupohja 3")."</option>";
+		$ulos .= "<option value = '10' $sel[10]>".t("Normaali laskupohja ilman rivihintoja (ei laillinen Suomessa)")."</option>";
+		$ulos .= "<option value = '12' $sel[12]>".t("Normaali laskupohja (Tuoteperheet yhdistetty) ilman rivihintoja (ei laillinen Suomessa)")."</option>";
+		$ulos .= "<option value = '13' $sel[13]>".t("Nettohinnat, ei alennuksia, ei verollisia hintoja")."</option>";
+		$ulos .= "<option value = '14' $sel[14]>".t("Nettohinnat, ei alennuksia, ei verollisia hintoja (Tuoteperheet yhdistetty)")."</option>";
+		$ulos .= "<option value = '15' $sel[15]>".t("SVH, Nettohinnat, ei alennuksia, ei verollisia hintoja")."</option>";
+		$ulos .= "<option value = '16' $sel[16]>".t("SVH, Nettohinnat, ei alennuksia, ei verollisia hintoja (Tuoteperheet yhdistetty)")."</option>";
+		$ulos .= "<option value = '17' {$sel[17]}>".t("Normaali laskupohja (lihavoidut ja kursivoidut tekstit)")."</option>";
 
 		$ulos .= "</select></td>";
 

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -20374,6 +20374,28 @@ if(!function_exists('_two_dimensional_array_sort_by_key')) {
 	}
 }
 
+if (!function_exists('hae_maa')) {
+	function hae_maa($params) {
+
+		$maakoodi = !empty($params['maakoodi']) ? $params['maakoodi'] : '';
+
+		if ($maakoodi == '') return array();
+
+		$maan_tiedot = array();
+
+		$query = "	SELECT *
+					FROM maat
+					WHERE koodi = '{$maakoodi}'
+					LIMIT 1";
+		$maa_res = pupe_query($query);
+		$maa_row = mysql_fetch_assoc($maa_res);
+
+		$maan_tiedot['nimi'] = $maa_row['name'] != '' ? $maa_row['name'] : $maa_row['koodi'];
+
+		return $maan_tiedot;
+	}
+}
+
 //etsii halutun array keyn arraysta ja palauttaa kyseisen keyn parentit arrayssa jos key löytyy
 //esim voit etsiä funktiolla order ja funktio palauttaa kaikki ensimmäisen tason (tuoteno) arrayt jos order löytyy
 /**

--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -196,21 +196,22 @@
 		$sel = array();
 		$sel[$apu] = "selected";
 
-		$ulos .= "<option value = '0'  $sel[0]>".t("Normaali laskupohja");
-		$ulos .= "<option value = '2'  $sel[2]>".t("Normaali laskupohja (Tuoteperheet yhdistetty)");
+		$ulos .= "<option value = '0'  $sel[0]>".t("Normaali laskupohja")."</option>";
+		$ulos .= "<option value = '2'  $sel[2]>".t("Normaali laskupohja (Tuoteperheet yhdistetty)")."</option>";
 		$ulos .= "<option value = '5'  $sel[5]>".t("Normaali laskupohja (Ei n‰ytet‰ verollista rivihintaa)")."</option>";
 		$ulos .= "<option value = '6'  $sel[6]>".t("Normaali laskupohja (Ei n‰ytet‰ tilausnumeroa/toimitusaikaa)")."</option>";
 		$ulos .= "<option value = '7'  $sel[7]>".t("Normaali laskupohja (N‰ytet‰‰n tuotteen EAN koodi ja asiakaskommentti)")."</option>";
-		$ulos .= "<option value = '1'  $sel[1]>".t("Pelkistetty laskupohja 1");
-		#$ulos .= "<option value = '3' $sel[3]>".t("Pelkistetty laskupohja 2 (Tuoteperheet yhdistetty)");
-		$ulos .= "<option value = '4'  $sel[4]>".t("Pelkistetty laskupohja 3");
+		$ulos .= "<option value = '1'  $sel[1]>".t("Pelkistetty laskupohja 1")."</option>";
+		#$ulos .= "<option value = '3' $sel[3]>".t("Pelkistetty laskupohja 2 (Tuoteperheet yhdistetty)")."</option>";
+		$ulos .= "<option value = '4'  $sel[4]>".t("Pelkistetty laskupohja 3")."</option>";
 		$ulos .= "<option value = '8'  $sel[8]>".t("Ruotsin laskupohja")."</option>";
-		$ulos .= "<option value = '10' $sel[10]>".t("Normaali laskupohja ilman rivihintoja (ei laillinen Suomessa)");
-		$ulos .= "<option value = '12' $sel[12]>".t("Normaali laskupohja (Tuoteperheet yhdistetty) ilman rivihintoja (ei laillinen Suomessa)");
-		$ulos .= "<option value = '13' $sel[13]>".t("Nettohinnat, ei alennuksia, ei verollisia hintoja");
-		$ulos .= "<option value = '14' $sel[14]>".t("Nettohinnat, ei alennuksia, ei verollisia hintoja (Tuoteperheet yhdistetty)");
-		$ulos .= "<option value = '15' $sel[15]>".t("SVH, Nettohinnat, ei alennuksia, ei verollisia hintoja");
-		$ulos .= "<option value = '16' $sel[16]>".t("SVH, Nettohinnat, ei alennuksia, ei verollisia hintoja (Tuoteperheet yhdistetty)");
+		$ulos .= "<option value = '10' $sel[10]>".t("Normaali laskupohja ilman rivihintoja (ei laillinen Suomessa)")."</option>";
+		$ulos .= "<option value = '12' $sel[12]>".t("Normaali laskupohja (Tuoteperheet yhdistetty) ilman rivihintoja (ei laillinen Suomessa)")."</option>";
+		$ulos .= "<option value = '13' $sel[13]>".t("Nettohinnat, ei alennuksia, ei verollisia hintoja")."</option>";
+		$ulos .= "<option value = '14' $sel[14]>".t("Nettohinnat, ei alennuksia, ei verollisia hintoja (Tuoteperheet yhdistetty)")."</option>";
+		$ulos .= "<option value = '15' $sel[15]>".t("SVH, Nettohinnat, ei alennuksia, ei verollisia hintoja")."</option>";
+		$ulos .= "<option value = '16' $sel[16]>".t("SVH, Nettohinnat, ei alennuksia, ei verollisia hintoja (Tuoteperheet yhdistetty)")."</option>";
+		$ulos .= "<option value = '17' {$sel[17]}>".t("Normaali laskupohja (lihavoidut ja kursivoidut tekstit)")."</option>";
 		$ulos .= "</select></td>";
 
 		$jatko = 0;

--- a/tilauskasittely/tulosta_lahete.inc
+++ b/tilauskasittely/tulosta_lahete.inc
@@ -171,14 +171,22 @@ if (!function_exists('alku_lahete')) {
 				$pdf->draw_text(50, 707, $asiakas_tunnus_row["nimitark"],			$thispage, $norm);
 				$pdf->draw_text(50, 697, $asiakas_tunnus_row["osoite"], 			$thispage, $norm);
 				$pdf->draw_text(50, 687, $asiakas_tunnus_row["postino"]." ".$asiakas_tunnus_row["postitp"], $thispage, $norm);
-				$pdf->draw_text(50, 677, $asiakas_tunnus_row["maa"], 				$thispage, $norm);
+
+				if ($yhtiorow['maa'] != $asiakas_tunnus_row['maa']) {
+					$maan_tiedot = hae_maa(array('maakoodi' => $asiakas_tunnus_row['maa']));
+					$pdf->draw_text(50, 677, $maan_tiedot["nimi"], 				$thispage, $norm);
+				}
 			}
 			else {
 				$pdf->draw_text(50, 717, $laskurow["nimi"], 			$thispage, $norm);
 				$pdf->draw_text(50, 707, $laskurow["nimitark"],			$thispage, $norm);
 				$pdf->draw_text(50, 697, $laskurow["osoite"], 			$thispage, $norm);
 				$pdf->draw_text(50, 687, $laskurow["postino"]." ".$laskurow["postitp"], $thispage, $norm);
-				$pdf->draw_text(50, 677, $laskurow["maa"], 				$thispage, $norm);
+
+				if ($yhtiorow['maa'] != $laskurow['maa']) {
+					$maan_tiedot = hae_maa(array('maakoodi' => $laskurow['maa']));
+					$pdf->draw_text(50, 677, $maan_tiedot["nimi"], 				$thispage, $norm);
+				}
 			}
 
 			$pdf->draw_text(50, 656, t("Toimitusosoite", $kieli), 	$thispage, $pieni);
@@ -186,7 +194,11 @@ if (!function_exists('alku_lahete')) {
 			$pdf->draw_text(50, 634, $laskurow["toim_nimitark"], 	$thispage, $boldi);
 			$pdf->draw_text(50, 624, $laskurow["toim_osoite"],	 	$thispage, $boldi);
 			$pdf->draw_text(50, 614, $laskurow["toim_postino"]." ".$laskurow["toim_postitp"], $thispage, $boldi);
-			$pdf->draw_text(50, 604, $laskurow["toim_maa"], 		$thispage, $boldi);
+
+			if ($yhtiorow['maa'] != $laskurow['toim_maa']) {
+				$maan_tiedot = hae_maa(array('maakoodi' => $laskurow['toim_maa']));
+				$pdf->draw_text(50, 604, $maan_tiedot["nimi"], 		$thispage, $boldi);
+			}
 		}
 
 		if (str_replace("perhe_", "", $lahetetyyppi) == "tulosta_lahete_custom.inc") {
@@ -3366,12 +3378,14 @@ if (!function_exists('loppu_lahete')) {
 			$pdf->draw_text(40, 85, $allekirjoitus_row['asema'], $thispage, $norm);
 		}
 
-		if (str_replace("perhe_", "", $lahetetyyppi) == "tulosta_lahete_custom.inc") {
-			$yhteystiedot_len = $pdf->strlen("$y_nimi, $y_osoite, $y_postino $y_postitp, $y_maa", $pieni);
-			$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 55, "$y_nimi, $y_osoite, $y_postino $y_postitp, $y_maa", $thispage, $pieni);
+		$maan_tiedot = hae_maa(array('maakoodi' => $y_maa));
+		$yhteystiedot_teksti = "{$y_nimi}, {$y_osoite}, {$y_postino} {$y_postitp}, {$maan_tiedot['nimi']}";
+		$yhteystiedot_len = $pdf->strlen($yhteystiedot_teksti, $pieni);
+		$yhteystiedot_len_www = $pdf->strlen($y_www, $pieni);
 
-			$yhteystiedot_len = $pdf->strlen($y_www, $pieni);
-			$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 42, $y_www, $thispage, $pieni);
+		if (str_replace("perhe_", "", $lahetetyyppi) == "tulosta_lahete_custom.inc") {
+			$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 55, $yhteystiedot_teksti, $thispage, $pieni);
+			$pdf->draw_text((595 / 2) - ($yhteystiedot_len_www / 2), 42, $y_www, $thispage, $pieni);
 		}
 		else {
 			//Alimmat kolme laatikkoa, yhtiötietoja
@@ -3381,8 +3395,8 @@ if (!function_exists('loppu_lahete')) {
 
 			$pdf->draw_text(30, 55, $y_nimi,		$thispage, $pieni);
 			$pdf->draw_text(30, 45, $y_osoite,		$thispage, $pieni);
-			$pdf->draw_text(30, 35, $y_postino."  ".$y_postitp,	$thispage, $pieni);
-			$pdf->draw_text(30, 25, $y_maa,			$thispage, $pieni);
+			$pdf->draw_text(30, 35, "{$y_postino}  {$y_postitp}",	$thispage, $pieni);
+			$pdf->draw_text(30, 25, $maan_tiedot['nimi'],			$thispage, $pieni);
 
 			$pdf->draw_text(217, 55, t("Puhelin", $kieli).":",			$thispage, $pieni);
 			$pdf->draw_text(257, 55, $y_puhelin,						$thispage, $pieni);
@@ -3437,11 +3451,8 @@ if (!function_exists('loppu_lahete')) {
 				}
 
 				if ($sivu != $ed_sivu) {
-					$yhteystiedot_len = $pdf->strlen("$y_nimi, $y_osoite, $y_postino $y_postitp, $y_maa", $pieni);
-					$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 55, "$y_nimi, $y_osoite, $y_postino $y_postitp, $y_maa", $thispage, $pieni);
-
-					$yhteystiedot_len = $pdf->strlen($y_www, $pieni);
-					$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 42, $y_www, $thispage, $pieni);
+					$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 55, $yhteystiedot_teksti, $thispage, $pieni);
+					$pdf->draw_text((595 / 2) - ($yhteystiedot_len_www / 2), 42, $y_www, $thispage, $pieni);
 				}
 
 				if ($kala-90 <= 100) {
@@ -3465,11 +3476,8 @@ if (!function_exists('loppu_lahete')) {
 					$ei_otsikoita = "";
 					$tots = 1;
 
-					$yhteystiedot_len = $pdf->strlen("$y_nimi, $y_osoite, $y_postino $y_postitp, $y_maa", $pieni);
-					$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 55, "$y_nimi, $y_osoite, $y_postino $y_postitp, $y_maa", $thispage, $pieni);
-
-					$yhteystiedot_len = $pdf->strlen($y_www, $pieni);
-					$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 42, $y_www, $thispage, $pieni);
+					$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 55, $yhteystiedot_teksti, $thispage, $pieni);
+					$pdf->draw_text((595 / 2) - ($yhteystiedot_len_www / 2), 42, $y_www, $thispage, $pieni);
 
 					$kala += 36;
 				}
@@ -3518,11 +3526,8 @@ if (!function_exists('loppu_lahete')) {
 					$ei_otsikoita = "";
 					$tots = 1;
 
-					$yhteystiedot_len = $pdf->strlen("$y_nimi, $y_osoite, $y_postino $y_postitp, $y_maa", $pieni);
-					$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 55, "$y_nimi, $y_osoite, $y_postino $y_postitp, $y_maa", $thispage, $pieni);
-
-					$yhteystiedot_len = $pdf->strlen($y_www, $pieni);
-					$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 42, $y_www, $thispage, $pieni);
+					$pdf->draw_text((595 / 2) - ($yhteystiedot_len / 2), 55, $yhteystiedot_teksti, $thispage, $pieni);
+					$pdf->draw_text((595 / 2) - ($yhteystiedot_len_www / 2), 42, $y_www, $thispage, $pieni);
 
 					$kala += 110;
 				}

--- a/tilauskasittely/tulosta_lasku.inc
+++ b/tilauskasittely/tulosta_lasku.inc
@@ -12,6 +12,9 @@ $rectparam["width"] 	= 0.3;
 $norm["height"] 		= 10;
 $norm["font"] 			= "Times-Roman";
 
+$norm_italic["height"] 		= 10;
+$norm_italic["font"]		= "Times-Italic";
+
 $pieni["height"] 		= 8;
 $pieni["font"] 			= "Times-Roman";
 
@@ -26,7 +29,7 @@ $iso["font"] 			= "Helvetica-Bold";
 
 if (!function_exists('alku')) {
 	function alku ($laskurow, $asiakasrow, $kieli, $pdf_lasku, $toim, $laskutyyppi, $kaanteinen_verotus, $page_lasku, $sivu) {
-		global $yhtiorow, $kukarow, $rectparam, $norm, $pieni, $boldi, $pieni_boldi, $iso;
+		global $yhtiorow, $kukarow, $rectparam, $norm, $norm_italic, $pieni, $boldi, $pieni_boldi, $iso;
 
 		$page_lasku[$sivu] = $pdf_lasku->new_page("a4");
 
@@ -86,7 +89,11 @@ if (!function_exists('alku')) {
 			$pdf_lasku->draw_text(50, 707, $laskutusosoite_row["laskutus_nimitark"],	$page_lasku[$sivu], $norm);
 			$pdf_lasku->draw_text(50, 697, $laskutusosoite_row["laskutus_osoite"], 		$page_lasku[$sivu], $norm);
 			$pdf_lasku->draw_text(50, 687, $laskutusosoite_row["laskutus_postino"]." ".$laskutusosoite_row["laskutus_postitp"], $page_lasku[$sivu], $norm);
-			$pdf_lasku->draw_text(50, 677, $laskutusosoite_row["laskutus_maa"], 		$page_lasku[$sivu], $norm);
+
+			if ($yhtiorow['maa'] != $laskutusosoite_row['laskutus_maa']) {
+				$maan_tiedot = hae_maa(array('maakoodi' => $laskutusosoite_row['laskutus_maa']));
+				$pdf_lasku->draw_text(50, 677, $maan_tiedot['nimi'], 		$page_lasku[$sivu], $norm);
+			}
 
 			$ostaja_kala = 644;
 			$toim_kala = 583;
@@ -104,11 +111,15 @@ if (!function_exists('alku')) {
 			$pdf_lasku->draw_text(50, 729, t("Ostaja/Laskutusosoite", $kieli), 	$page_lasku[$sivu], $pieni);
 		}
 
-		$pdf_lasku->draw_text(50, $ostaja_kala, $laskurow["nimi"], 				$page_lasku[$sivu], $norm);
-		$pdf_lasku->draw_text(50, $ostaja_kala-10, $laskurow["nimitark"],		$page_lasku[$sivu], $norm);
+		$pdf_lasku->draw_text(50, $ostaja_kala, $laskurow["nimi"], 				$page_lasku[$sivu], ($laskutyyppi == 17 ? $boldi : $norm));
+		$pdf_lasku->draw_text(50, $ostaja_kala-10, $laskurow["nimitark"],		$page_lasku[$sivu], ($laskutyyppi == 17 ? $boldi : $norm));
 		$pdf_lasku->draw_text(50, $ostaja_kala-20, $laskurow["osoite"], 		$page_lasku[$sivu], $norm);
 		$pdf_lasku->draw_text(50, $ostaja_kala-30, $laskurow["postino"]." ".$laskurow["postitp"], $page_lasku[$sivu], $norm);
-		$pdf_lasku->draw_text(50, $ostaja_kala-40, $laskurow["maa"], 			$page_lasku[$sivu], $norm);
+
+		if ($yhtiorow['maa'] != $laskurow['maa']) {
+			$maan_tiedot = hae_maa(array('maakoodi' => $laskurow['maa']));
+			$pdf_lasku->draw_text(50, $ostaja_kala-40, $maan_tiedot["nimi"], 			$page_lasku[$sivu], $norm);
+		}
 
 		//$pdf_lasku->draw_rectangle(674, 20,  611, 300, $page_lasku[$sivu], $rectparam);
 		$pdf_lasku->draw_text(50, $toim_kala, t("Toimitusosoite", $kieli), 	$page_lasku[$sivu], $pieni);
@@ -116,7 +127,11 @@ if (!function_exists('alku')) {
 		$pdf_lasku->draw_text(50, $toim_kala-22, $laskurow["toim_nimitark"], 	$page_lasku[$sivu], $norm);
 		$pdf_lasku->draw_text(50, $toim_kala-32, $laskurow["toim_osoite"],	 	$page_lasku[$sivu], $norm);
 		$pdf_lasku->draw_text(50, $toim_kala-42, $laskurow["toim_postino"]." ".$laskurow["toim_postitp"], $page_lasku[$sivu], $norm);
-		$pdf_lasku->draw_text(50, $toim_kala-52, $laskurow["toim_maa"], 		$page_lasku[$sivu], $norm);
+
+		if ($yhtiorow['maa'] != $laskurow['toim_maa']) {
+			$maan_tiedot = hae_maa(array('maakoodi' => $laskurow['toim_maa']));
+			$pdf_lasku->draw_text(50, $toim_kala-52, $maan_tiedot["nimi"], 		$page_lasku[$sivu], $norm);
+		}
 
 		//Oikea sarake
 		$otsik[1] = 792;
@@ -178,7 +193,7 @@ if (!function_exists('alku')) {
 		$rivi_ind = 1;
 
 		$pdf_lasku->draw_text(310, $otsik[$rivi_ind], t("Laskun pvm", $kieli), 					$page_lasku[$sivu], $pieni);
-		$pdf_lasku->draw_text(310, $arvo[$rivi_ind], tv1dateconv($laskurow["tapvm"]),			$page_lasku[$sivu], $norm);
+		$pdf_lasku->draw_text(310, $arvo[$rivi_ind], tv1dateconv($laskurow["tapvm"]),			$page_lasku[$sivu], ($laskutyyppi == 17 ? $boldi : $norm));
 		$rivi_ind++;
 
 		if ($laskutyyppi != "8") {
@@ -218,17 +233,17 @@ if (!function_exists('alku')) {
 
 		// Oikean laidan ruudukko, oikea sarake
 		// Riviindeksi
-		$rivi_ind = 1;
+		$rivi_ind = $laskutyyppi == 17 ? 2 : 1;
 
 		$pdf_lasku->draw_text(430, $otsik[$rivi_ind], t("Eräpäivä", $kieli), 									$page_lasku[$sivu], $pieni);
 		if ($laskurow["kateistyyppi"] != '') $erapaiva = t('MAKSETTU', $kieli);
 		else $erapaiva = tv1dateconv($laskurow["erpcm"]);
 		$pdf_lasku->draw_text(430, $arvo[$rivi_ind], $erapaiva, 												$page_lasku[$sivu], $norm);
-		$rivi_ind++;
+		$laskutyyppi == 17 ? $rivi_ind-- : $rivi_ind++;
 
 		$pdf_lasku->draw_text(430, $otsik[$rivi_ind], t("Laskun numero", $kieli), 								$page_lasku[$sivu], $pieni);
 		if ($laskurow["laskunro"] != 0) $pdf_lasku->draw_text(430, $arvo[$rivi_ind], $laskurow["laskunro"], 	$page_lasku[$sivu], $boldi);
-		$rivi_ind++;
+		$rivi_ind = $laskutyyppi == 17 ? $rivi_ind + 2 : $rivi_ind + 1;
 
 		if ($laskutyyppi != "8") {
 			$pdf_lasku->draw_text(430, $otsik[$rivi_ind], t("Kassa-alennus", $kieli)." ".$laskurow["valkoodi"], 	$page_lasku[$sivu], $pieni);
@@ -480,10 +495,10 @@ if (!function_exists('alku')) {
 					list($o, $v) = explode("###", $kommentti);
 
 					$pdf_lasku->draw_text(35, $pohja, trim($o), $page_lasku[$sivu], $boldi);
-					$pdf_lasku->draw_text(35+$maxoik+5, $pohja, trim($v), $page_lasku[$sivu], $norm);
+					$pdf_lasku->draw_text(35+$maxoik+5, $pohja, trim($v), $page_lasku[$sivu], ($laskutyyppi == 17 ? $norm_italic : $norm));
 				}
 				else {
-					$pdf_lasku->draw_text(35, $pohja, trim($kommentti), $page_lasku[$sivu], $norm);
+					$pdf_lasku->draw_text(35, $pohja, trim($kommentti), $page_lasku[$sivu], ($laskutyyppi == 17 ? $norm_italic : $norm));
 				}
 
 				$pohja = $pohja - 10;
@@ -859,7 +874,7 @@ if (!function_exists('rivi_original')) {
 		global $yhtiorow, $kukarow, $rectparam, $norm, $pieni, $boldi, $pieni_boldi, $iso, $tullinimike_ja_alkuperamaa;
 
 		//Nimitys
-		list($ff_string, $ff_font) = pdf_fontfit($row["nimitys"], 150, $pdf_lasku, $norm);
+		list($ff_string, $ff_font) = pdf_fontfit($row["nimitys"], 150, $pdf_lasku, ($laskutyyppi == 17 ? $boldi : $norm));
 		$pdf_lasku->draw_text(35,  $kala, $ff_string, $thispage, $ff_font);
 
 		//Tuoteno
@@ -1587,7 +1602,7 @@ if (!function_exists('loppu')) {
 			$erapaiva = tv1dateconv($laskurow["erpcm"]);
 		}
 
-		$pdf_lasku->draw_text(30,  92+$vientikala+$barcode_korkeus,  $erapaiva,		$thispage, $norm);
+		$pdf_lasku->draw_text(30,  92+$vientikala+$barcode_korkeus,  $erapaiva,		$thispage, ($laskutyyppi == 17 ? $boldi : $norm));
 
 		if ($laskutyyppi != 8) {
 			$pdf_lasku->draw_text(217, 102+$vientikala+$barcode_korkeus, t("Viitenumero", $kieli),	$thispage, $pieni);
@@ -1805,7 +1820,9 @@ if (!function_exists('loppu')) {
 		$pdf_lasku->draw_text(30, 55 + $tileja + $barcode_korkeus, $y_nimi,									$thispage, $pieni);
 		$pdf_lasku->draw_text(30, 45 + $tileja + $barcode_korkeus, $y_osoite,								$thispage, $pieni);
 		$pdf_lasku->draw_text(30, 35 + $tileja + $barcode_korkeus, $y_postino."  ".$y_postitp,				$thispage, $pieni);
-		$pdf_lasku->draw_text(30, 25 + $tileja + $barcode_korkeus, $y_maa,									$thispage, $pieni);
+
+		$maan_tiedot = hae_maa(array('maakoodi' => $y_maa));
+		$pdf_lasku->draw_text(30, 25 + $tileja + $barcode_korkeus, $maan_tiedot['nimi'],					$thispage, $pieni);
 
 		$pdf_lasku->draw_text(217, 55 + $tileja + $barcode_korkeus, t("Puhelin", $kieli).": $y_puhelin",	$thispage, $pieni);
 		$pdf_lasku->draw_text(217, 45 + $tileja + $barcode_korkeus, t("Telefax", $kieli).": $y_fax",		$thispage, $pieni);

--- a/tilauskasittely/tulosta_ostotilaus.inc
+++ b/tilauskasittely/tulosta_ostotilaus.inc
@@ -101,8 +101,11 @@
 				$pdf->draw_text(50, 707, $laskurow["nimitark"],			$thispage, $norm);
 				$pdf->draw_text(50, 697, $laskurow["osoite"], 			$thispage, $norm);
 				$pdf->draw_text(50, 687, $laskurow["postino"]." ".$laskurow["postitp"], $thispage, $norm);
-				$pdf->draw_text(50, 677, $laskurow["maa"], 				$thispage, $norm);
 
+				if ($yhtiorow['maa'] != $laskurow['maa']) {
+					$maan_tiedot = hae_maa(array('maakoodi' => $laskurow['maa']));
+					$pdf->draw_text(50, 677, $maan_tiedot["nimi"], 				$thispage, $norm);
+				}
 
 				//$pdf->draw_rectangle(674, 20,  611, 300, $thispage, $rectparam);
 				$pdf->draw_text(50, 656, t("Vastaanottaja", $kieli), 	$thispage, $pieni);
@@ -110,7 +113,11 @@
 				$pdf->draw_text(50, 634, $laskurow["toim_nimitark"], 	$thispage, $norm);
 				$pdf->draw_text(50, 624, $laskurow["toim_osoite"],	 	$thispage, $norm);
 				$pdf->draw_text(50, 614, $laskurow["toim_postino"]." ".$laskurow["toim_postitp"], $thispage, $norm);
-				$pdf->draw_text(50, 604, $laskurow["toim_maa"], 		$thispage, $norm);
+
+				if ($yhtiorow['maa'] != $laskurow['toim_maa']) {
+					$maan_tiedot = hae_maa(array('maakoodi' => $laskurow['toim_maa']));
+					$pdf->draw_text(50, 604, $maan_tiedot["nimi"], 		$thispage, $norm);
+				}
 
 				$query = "	SELECT *
 							FROM toimi
@@ -502,7 +509,9 @@
 				$pdf->draw_text(30, 55, $yhtiorow["nimi"], $thispage, $pieni);
 				$pdf->draw_text(30, 45, $yhtiorow["osoite"], $thispage, $pieni);
 				$pdf->draw_text(30, 35, $yhtiorow["postino"]."  ".$yhtiorow["postitp"],	$thispage, $pieni);
-				$pdf->draw_text(30, 25, $yhtiorow["maa"], $thispage, $pieni);
+
+				$maan_tiedot = hae_maa(array('maakoodi' => $yhtiorow['maa']));
+				$pdf->draw_text(30, 25, $maan_tiedot["nimi"], $thispage, $pieni);
 
 				$pdf->draw_text(217, 55, t("Puhelin", $kieli).":", $thispage, $pieni);
 				$pdf->draw_text(257, 55, $yhtiorow["puhelin"],$thispage, $pieni);


### PR DESCRIPTION
Uusi laskupohja lisätty. Laskupohjassa laskunumeron ja eräpäivän paikkaa vaihdettu päittäin. Kommentit kursivoidaan ja lihavointeja lisätty laskupohjaan.

Tilausvahvistus-, lähete-, lasku- ja ostotilaus-PDF:t haetaan maat-taulusta maan koko nimi. Jos nimeä ei ole kannassa, laitetaan tuttu ja turvallinen maakoodi. Maakoodia, tahi nimeä, ei näytetä osoitetiedoissa, jos yhtiön ja osoitetiedon maat ovat samat. Poikkeuksena toki PDF:n alalaidassa olevat yhtiön osoitetiedot jossa aina näytetään maan nimi / koodi.
