### PR TITLE
Kirjoittimen mediatyyppi vaikuttaa HRX-tulostukseen

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -13924,6 +13924,13 @@ if (!function_exists('tulosta_hrx')) {
 		$ot_yhteyshenkilo = t("Yhteyshenkilö", $yhtiorow['kieli']);
 		$ot_puhelin = t("Puhelin", $yhtiorow['kieli']);
 
+		if (!empty($mediatyyppi) and in_array($mediatyyppi, array('LSN149X104','LSN59X40'))) {
+			$nauha = "2";
+		}
+		else {
+			$nauha = "0";
+		}
+
 		/*
 			Yhteyshenkilö ja puhelinnumero toimitusosoite-kohdassa tulee jostakin
 		*/
@@ -13999,7 +14006,7 @@ if (!function_exists('tulosta_hrx')) {
 					{RC016;{$monesko_laatikko} / {$montako_laatikkoa_yht} {$pakkauskoodi}|}
 
 					*** TULOSTUS  ***
-					{XS;I,0001,0002C3210|}
+					{XS;I,0001,0002C3{$nauha}10|}
 					".chr(12);
 
 		if (trim($reittietikettitulostin) != '' and $reittietikettitulostin != 'email') {

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -141,6 +141,8 @@
 			$kirjoitin_tunnus = $print["printteri6"]; // Rahtikirja A4
 		}
 
+		$mediatyyppi = "";
+
 		if ($komento != "PDF_RUUDULLE") {
 			// haetaan printterille tulostuskomento
 			$query = "	SELECT *
@@ -151,6 +153,7 @@
 
 			$kirjoitin = $print['komento'];
 			$merkisto  = $print['merkisto'];
+			$mediatyyppi = $print['mediatyyppi'];
 		}
 
 		$pvm = date("j.n.Y");

--- a/tilauskasittely/rahtikirja_hrx_siirto.inc
+++ b/tilauskasittely/rahtikirja_hrx_siirto.inc
@@ -171,6 +171,8 @@ if ($kollityht > 0) {
 
 		$lahettaja_maa_nimi = maa($lahettaja_maa, $kukarow['kieli']);
 
+		$mediatyyppi = !empty($mediatyyppi) ? $mediatyyppi : "";
+
 		for ($i = 1; $i <= $kollityht; $i++) {
 			// Tulostetaan Pupen oma kollitarra
 			$params = array(
@@ -189,6 +191,7 @@ if ($kollityht > 0) {
 	 			'lahettaja_maa' => $lahettaja_maa,
 	 			'lahettaja_maa_nimi' => $lahettaja_maa_nimi,
 	 			'reittietikettitulostin' => $kirjoitin,
+	 			'mediatyyppi' => $mediatyyppi,
 	 			'monesko_laatikko' => $i,
 	 			'montako_laatikkoa_yht' => $kollityht,
 	 			'pakkauskoodi' => $pakkaus[0],


### PR DESCRIPTION
Tarran tulostuskomennossa on ohjauskoodi jolla kerrotaan printterille että sen tulostusmode on "lämpösiirto/nauha". 
