### PR TITLE
* Palauta automaattisesti myyntitilaukselle lisätyt JT-rivit alkuperäiselle tilaukselle jos myyntitilaus mitätöidään

### DIFF
--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -836,6 +836,19 @@
 		$jatko = 0;
 	}
 
+	if (mysql_field_name($result, $i) == "jt_automatiikka_mitatoi_tilaus") {
+
+		$ulos = "<td><select name='{$nimi}' ".js_alasvetoMaxWidth($nimi, 400).">";
+
+		$sel = $trow[$i] == 'E' ? "selected" : "";
+
+		$ulos .= "<option value = ''>".t("Jos myyntitilaus mitätöidään, poistetaan tilauksella olevat JT-rivit (ei koske extranet:ia)")."</option>";
+		$ulos .= "<option value = 'E' {$sel}>".t("Ei mitätöidä JT-rivejä myyntitilauksen mukana, vaan palautetaan ne alkuperäiselle tilaukselle")."</option>";
+		$ulos .= "</select></td>";
+
+		$jatko = 0;
+	}
+
 	if (mysql_field_name($result, $i) == "saapumisen_jt_kasittely") {
 
 		$ulos = "<td><select name='$nimi' ".js_alasvetoMaxWidth($nimi, 400).">";
@@ -2101,19 +2114,6 @@
 
 		$ulos .= "<option value = ''>".t("Salli kaikki toiminnot")."</option>";
 		$ulos .= "<option value = 'E' $sel[E]>".t("Estä jt-rivien mitätöiminen extranetissä")."</option>";
-		$ulos .= "</select></td>";
-
-		$jatko = 0;
-	}
-
-	if (mysql_field_name($result, $i) == "jt_muiden_mukana") {
-
-		$ulos = "<td><select name='{$nimi}' ".js_alasvetoMaxWidth($nimi, 400).">";
-
-		$sel = $trow[$i] == 'E' ? "selected" : "";
-
-		$ulos .= "<option value = ''>".t("Jos myyntitilaus mitätöidään, poistetaan tilauksella olevat JT-rivit (ei koske extranet:ia)")."</option>";
-		$ulos .= "<option value = 'E' {$sel}>".t("Ei mitätöidä JT-rivejä myyntitilauksen mukana, vaan palautetaan ne alkuperäiselle tilaukselle")."</option>";
 		$ulos .= "</select></td>";
 
 		$jatko = 0;

--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -891,7 +891,7 @@
 													$values .= "";
 													break;
 												case 'positio':
-													if (($kukarow['extranet'] != '' or $yhtiorow['jt_muiden_mukana'] == 'E') and $tilaus_on_jo == "KYLLA") {
+													if (($kukarow['extranet'] != '' or $yhtiorow['jt_automatiikka_mitatoi_tilaus'] == 'E') and $tilaus_on_jo == "KYLLA") {
 														$kysely .= "positio='JT',";
 													}
 													else {


### PR DESCRIPTION
Lisätään toimitettavat JT rivit automaattisesti tilaukselle, mutta jos tilauksen mitätöi, ei mitätöidä JT rivejä vaan palautetaan ne takaisin alk.per. tilaukselle JT:seen odottamaan seuraavaa tilausta. 

Toisin sanoen vaikka toimitettavat JT rivit lisätään tilaukselle automaattisesti, ei ne katoa vaikka tilauksen mitätöisikin, vaan ne jää odottamaan seuraavaa tilausta.

``` SQL
ALTER TABLE yhtion_parametrit ADD COLUMN jt_automatiikka_mitatoi_tilaus CHAR(1) NOT NULL DEFAULT '' AFTER jt_automatiikka;
```
