### PR TITLE
Hinnoittelupoikkeamat-raporttiin lisätty uusi kenttä

### DIFF
--- a/raportit/hinnoittelupoikkeamat.php
+++ b/raportit/hinnoittelupoikkeamat.php
@@ -30,7 +30,7 @@
 
 		if (!isset($myyja)) $myyja = 0;
 		if (!isset($tee)) $tee = '';
-		if (!isset($eropros_vahintaan)) $eropros_vahintaan = 0;
+		if (!isset($eropros_vahintaan)) $eropros_vahintaan = 3;
 
 		// Tarkistetaan viel‰ p‰iv‰m‰‰r‰t
 		if (!checkdate($akk, $app, $avv)) {


### PR DESCRIPTION
"Hinnoittelupoikkeamat" -raporttiin uusi kenttä, jossa voidaan antaa rajaukseksi ero-prosentti. Jos tähän syötetään luku, näytetään vain rivit joiden ero-prosentti on suurempi kuin syötetty luku.
