### PR TITLE
* Tiliotteiden selvittelytiliöinnit omille tositteilleen

### DIFF
--- a/inc/teeselvittely.inc
+++ b/inc/teeselvittely.inc
@@ -21,6 +21,7 @@
 						luontiaika 	= now()";
 			$result = pupe_query($query);
 			$laskuid = mysql_insert_id ($link);
+
 			echo "<font class='message'>*** ".t("Tositteen otsikko luotu")." ***</font><br>\n";
 		}
 
@@ -153,12 +154,41 @@
 				$dummyresult = pupe_query($query);
 			}
 
-			// Merkataan käsitellyiksi & lisätään linkki
-			$vastavienti += $maara;
-			$vastavienti_valuutassa += $kohdm;
-
 			echo "<font class='message'>*** ".t("tiliöinti luotu")." ($tiliotesaantotilino) ***</font><br>\n";
+
+			if ($yhtiorow['tiliotteen_selvittelyt'] == "" and $tiliotedatarow['alku'] == $tiliotedatarow['loppu']) {
+				// Jos yhtiön parametri sallii ja käsittelyssä on yhden päivän tiliote niin voidaan tiliöidä kaikki selvittelyt samalle tositteelle.
+				$vastavienti += $maara;
+				$vastavienti_valuutassa += $kohdm;
+			}
+			else {
+				// Muuten tiliöidään kaikki selivttelyt omille tositteilleen ja tehdään vastavientiki per tosite, tietenki!
+				list($kustp_ins, $kohde_ins, $projekti_ins) = kustannuspaikka_kohde_projekti($yritirow["oletus_rahatili"]);
+
+				// Rahatili
+				$query = "	INSERT into tiliointi set
+			                yhtio 				= '$yritirow[yhtio]',
+			                ltunnus 			= '$laskuid',
+			                tilino 				= '$yritirow[oletus_rahatili]',
+			                kustp    			= '{$kustp_ins}',
+							kohde	 			= '{$kohde_ins}',
+							projekti 			= '{$projekti_ins}',
+			                tapvm 				= '$tpv-$tpk-$tpp',
+			                summa 				= '$maara',
+							summa_valuutassa	= '$kohdm',
+							valkoodi 			= '$tilinvaluutta',
+			                vero 				= 0,
+			                lukko 				= '',
+							selite 				= 'Vastavienti rahatilille',
+			                laatija 			= 'tiliote',
+			                laadittu 			= now()";
+				$result = pupe_query($query);
+
+				$vastavienti 			= 0;
+				$vastavienti_valuutassa = 0;
+				$laskuid 				= 0;
+
+				echo "<font class='message'>*** ".t("Vastavienti luotu")." ($yritirow[oletus_rahatili]) ***</font><br>\n";
+			}
 		}
 	}
-
-?>

--- a/inc/tiliote.inc
+++ b/inc/tiliote.inc
@@ -570,34 +570,23 @@
 			else {
 				$yritirow = mysql_fetch_assoc($result);
 
-				$query = "	SELECT *
-							FROM yhtio
-							WHERE yhtio = '$yritirow[yhtio]'";
-				$result = pupe_query($query);
+				$yhtiorow =	hae_yhtion_parametrit($yritirow["yhtio"]);
 
-				if (mysql_num_rows($result) != 1) {
-					echo "<font class='error'>".t("Yritystä")." '$yritirow[yhtio]' ".t("ei löytynyt")."!</font><br>\n";
-					$toim = 'E';
+				// Setataan kukarow-yhtiö
+				$kukarow["yhtio"] = $yritirow["yhtio"];
+
+				if ($silent == "") {
+					echo "<font class='message'>".t("Tiliote yritykselle")." $yhtiorow[nimi].<br>\n";
 				}
-				else {
-					$yhtiorow = mysql_fetch_assoc($result);
 
-					// Setataan kukarow-yhtiö
-					$kukarow["yhtio"] = $yritirow["yhtio"];
-
+				if ($yritirow["hyvak"] != "") {
 					if ($silent == "") {
-						echo "<font class='message'>".t("Tiliote yritykselle")." $yhtiorow[nimi].<br>\n";
+						echo t("Vastuussa")." '$yritirow[hyvak]'.<br>\n";
 					}
+				}
 
-					if ($yritirow["hyvak"] != "") {
-						if ($silent == "") {
-							echo t("Vastuussa")." '$yritirow[hyvak]'.<br>\n";
-						}
-					}
-
-					if ($silent == "") {
-						echo t("Ostovelat")." $yhtiorow[ostovelat], ".t("Konserniostovelat")." $yhtiorow[konserniostovelat], </font>";
-					}
+				if ($silent == "") {
+					echo t("Ostovelat")." $yhtiorow[ostovelat], ".t("Konserniostovelat")." $yhtiorow[konserniostovelat], </font>";
 				}
 
  				// Tarkistetaan tilit

--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -214,6 +214,27 @@
 		$jatko = 0;
 	}
 
+	if (mysql_field_name($result, $i) == "tiliotteen_selvittelyt") {
+
+		$ulos = "<td><select name='$nimi' ".js_alasvetoMaxWidth($nimi, 400).">";
+
+		$sel1 = "";
+		$sel2 = "";
+
+		if ($trow[$i] == '') {
+			$sel1 = "selected";
+		}
+		if ($trow[$i] == 'E') {
+			$sel2 = "selected";
+		}
+
+		$ulos .= "<option value = '' $sel1>".t("Tiliotteen kaikki selvittelytiliöinnit tehdään yhdelle tositteelle")."";
+		$ulos .= "<option value = 'E' $sel2>".t("Tiliotteen kaikki selvittelytiliöinnit tehdään omille tositteilleen")."";
+		$ulos .= "</select></td>";
+
+		$jatko = 0;
+	}
+
 	if (mysql_field_name($result, $i) == "laskutyyppi") {
 
 		$ulos = "<td><select name='$nimi' ".js_alasvetoMaxWidth($nimi, 400).">";

--- a/tiliote.php
+++ b/tiliote.php
@@ -487,8 +487,8 @@
 
 			if ($xtyyppi == 1) {
 				$tkesken = 0;
-				$maara = $vastavienti;
-				$kohdm = $vastavienti_valuutassa;
+				$maara   = $vastavienti;
+				$kohdm   = $vastavienti_valuutassa;
 
 				echo "<tr><td colspan = '6'>";
 				require("inc/teeselvittely.inc");
@@ -498,8 +498,8 @@
 
 			if ($xtyyppi == 2) {
 				$tkesken = 0;
-				$maara = $vastavienti;
-				$kohdm = $vastavienti_valuutassa;
+				$maara   = $vastavienti;
+				$kohdm   = $vastavienti_valuutassa;
 
 				require("inc/teeselvittely.inc");
 				echo "</table><br>\n<br>\n";


### PR DESCRIPTION
Uusi yhtiön parametri "tiliotteen_selvittelyt" jolla voidaan säätää homma niin, että tiliote tiliöi kaikki selvittelyt omille tositteilleen. Helpottaa kuulemma kirjnapitotyötä.

Jos luetaan sisään monipäiväisiä tiliotteita niin tiliöidään aina kaikki selvittelyt omille tositteilleen niin saadaan vastakirjauksetki aina oikealle päivälle. Ennen selvittelyt meni oikeille päiville mut sit koko vastakirjausklöntti meni vaan ekalle päivälle....

alter table yhtion_parametrit add column tiliotteen_selvittelyt char(1) not null after pankkitiedostot;
