### PR TITLE
Tilausvahvistuksen kaunistus/selkeytys

### DIFF
--- a/tilauskasittely/tulosta_lahete.inc
+++ b/tilauskasittely/tulosta_lahete.inc
@@ -3744,6 +3744,7 @@ if (!function_exists('alvierittely_lahete')) {
 
 			$ei_otsikoita = "";
 			$sivu_vaihtui = TRUE;
+			$tots = 1;
 		}
 
 


### PR DESCRIPTION
Ei kadoteta valittua lähetetyyppiä kun tehdään uusi sivu + sivunumerot kuntoon (muistetaan sijottaa tots muuttujaan 1 uuden sivun luonnin jälkeen -> sivunumerot saadaan näkyviin ja vikalle sivulle ei tuu jatkuu tekstiä)
