### PR TITLE
Ohituskaista, jotta saadaan tutkittua funktiolla myös normi tuotteita

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -22573,8 +22573,8 @@ if (!function_exists("lisaa_rivi")) {
 }
 
 if (!function_exists("saako_myyda_private_label")) {
-	function saako_myyda_private_label($asiakastunnus, $tuotenro, $alemaara = 1, $ohituskaista = 0) {
-		//$ohituskaista muuttujalla voidaan funktio pakottaa tutkimaan onko asiakashintoja/alennuksia olemassa, vaikka tuote olisikin normaali hinnasto-tuote
+	function saako_myyda_private_label($asiakastunnus, $tuotenro, $alemaara = 1, $tarkistakaikkituotteet = FALSE) {
+		//$tarkistakaikkituotteet muuttujalla voidaan funktio pakottaa tutkimaan onko asiakashintoja/alennuksia olemassa, vaikka tuote olisikin normaali hinnasto-tuote (eli tarkistetaan kaikki tuotteet)
 		global $kukarow, $yhtiorow;
 
 		//haetaan ensin tutkittavan tuotteen tiedot
@@ -22586,7 +22586,7 @@ if (!function_exists("saako_myyda_private_label")) {
 		$trow = mysql_fetch_assoc($tuotetempres);
 
 		//katotaan kannattako edes tutkia - jos tuote ei ole private label sitä saa myydä => ei kannata tutkia | eli tutkitaan jos on private label
-		if ($trow["hinnastoon"] == "V" OR $ohituskaista == 1) {
+		if ($trow["hinnastoon"] == "V" OR $tarkistakaikkituotteet) {
 
 			//haetaan asiakkaan tiedot
 			$query = "	SELECT tunnus liitostunnus, ytunnus, valkoodi, maa, ryhma, piiri

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -2895,8 +2895,7 @@
 
 					// hinnat p‰ivitet‰‰n vain jos asiakkaalla on asiakashinta tai asiakasalennus (saako_myyda_private_label palauttaa TRUE jos on asiakashinta tai alennus)
 					if ($yhtiorow["vaihda_asiakas_hintapaiv"] == "A") {
-						$ohituskaista = 1;
-						if (!saako_myyda_private_label($laskurow['liitostunnus'], $trow["tuoteno"], $row['tilkpl'], $ohituskaista)) {
+						if (!saako_myyda_private_label($laskurow['liitostunnus'], $trow["tuoteno"], $row['tilkpl'], TRUE)) {
 							$paivitetaanko = FALSE;
 						}
 					}


### PR DESCRIPTION
Eli nykyisellään saako_myydä_private_label tutkii, että onkos asiakashintoja vain jos tuote ei ole normi hinnasto tuote. Nyt kuitennii tätä tarvi käyttää normi hinnasto tuotteiden asiakas alennusten tutkimiseen -> ohituskaista, jolla voidaan pakottaa funktio tutkimaan, josko tuotteelta on olemassa asiakashitoja/alennuksia
