### PR TITLE
Tee tiliotesääntö-bugfix

### DIFF
--- a/inc/tiliote.inc
+++ b/inc/tiliote.inc
@@ -410,6 +410,12 @@
 
 		if ($kuittikoodi == ' ') {
 			if ($eiselitetta == 1) $selite = '';
+
+			$selite = str_replace("\n", "", $selite);
+			$selite = urlencode($selite);
+			$koodiselite = urlencode($koodiselite);
+			$maksaa = urlencode($maksaa);
+
 			echo "<a href=\"javascript:lataaiframe('{$tiliotedatarow['tunnus']}', '{$palvelin2}tiliotesaannot.php?tee=U&pankkitili=$yritirow[tilino]&tiliote=Z&koodi=$koodi&koodiselite=$koodiselite&nimitieto=$maksaa&selite=$selite&pvm=$pvm&ohje=off');\">".t("Tee tiliotesääntö")."</a>";
 		}
 


### PR DESCRIPTION
- Javascript-ongelma FIREFOXISSA liittyen rivinvaihtoihin selite-kentässä, poistetaan rivinvaihdot ja encodaillaan urlia nyt miedosti
- Chromella ongelmaa ei ollut laisinkaan, ehkä tästä vois ottaa jotain opiksi
