### PR TITLE
Debug modessa strict sql_mode

### DIFF
--- a/inc/connect.inc
+++ b/inc/connect.inc
@@ -58,4 +58,9 @@ mysql_select_db($dbkanta, $link) or die ("Tietokantaa $dbkanta ei löydy palvelim
 mysql_set_charset("latin1", $link);
 mysql_query("set group_concat_max_len=1000000", $link);
 
+// jos debugataan pienillä arvoilla, ni pakotetaan myös queryt kuntoon!
+if (isset($GLOBALS["pupe_query_debug"]) and $GLOBALS["pupe_query_debug"] > 0 and $GLOBALS["pupe_query_debug"] < 1) {
+	mysql_query("set session sql_mode = 'STRICT_ALL_TABLES,ONLY_FULL_GROUP_BY,NO_ZERO_IN_DATE'", $link); // NO_ZERO_DATE ois myös kova!
+}
+
 if (!isset($temporarylink)) $temporarylink = $masterlink;


### PR DESCRIPTION
Jos `$pupe_query_debug` on setattu `salasanat.php`:ssä ja se on `0..1` , niin pakotetaan sessiokohtainen `sql_mode` strictiksi.
