### PR TITLE
Ei vaadita EUR EUR kurssia

### DIFF
--- a/ulask.php
+++ b/ulask.php
@@ -1816,7 +1816,7 @@ if ($tee == 'P' or $tee == 'E') {
 if ($tee == 'I') {
 
 	// Kurssiksi halutaan tämän päivän kurssi
-	if ($yhtiorow["ostolaskujen_kurssipaiva"] == 0 or $yhtiorow["valkoodi"] == $valkoodi) {
+	if ($yhtiorow["ostolaskujen_kurssipaiva"] == 0 or strtoupper($yhtiorow["valkoodi"]) == strtoupper($valkoodi)) {
 		$query = "SELECT kurssi FROM valuu WHERE nimi = '$valkoodi' AND yhtio = '$kukarow[yhtio]'";
 	}
 	else {


### PR DESCRIPTION
Ei tarvita valuu_historiaan EUR EUR dummykurssia käytettäessä ostolaskujen kurssipäivänä laskun päiväystä.
