### PR TITLE
Varastopaikan muutos: parametrikorjaus

### DIFF
--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -596,7 +596,7 @@
 				'mistarow' => $mistarow,
 				'minnerow' => $minnerow,
 				'sarjano_array' => !isset($sarjano_array) ? array() : $sarjano_array,
-				'selite' => $selite,
+				'selite' => !isset($selite) ? '' : $selite,
 			);
 
 			hyllysiirto($params);


### PR DESCRIPTION
Hyllysiirto-funktion sisällä tarkistettiin onko selite setattu. Jos $selite ei ole setattu ja arrayseen menee null, palauttaa funktio falsea.
