### PR TITLE
Sailytetään rivitunnus jos vaihdetaan vastaava 

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -3841,7 +3841,6 @@ if ($tee == '') {
 				$var				= '';
 				$hinta				= '';
 				$netto				= '';
-				$rivitunnus			= 0;
 				$paikka				= '';
 				$alv				= '';
 				$perheid			= 0;


### PR DESCRIPTION
Rivi ei pompi ensimmäiseksi jos tunnus säilytetään, on mukavampi käyttöliittymä kun rivi on alkuperäisellä paikallaan kokoajan, vaikka rivin tuote vaihtuisikin vastaavat-taulukosta.
