### PR TITLE
Tuotenumero pois paikan päältä

### DIFF
--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -668,7 +668,7 @@ if (!function_exists('rivi_otsikot_kerayslista')) {
 
 			$pdf->draw_text(25,  $kala+15, "#",									$thispage, $norm);
 			$pdf->draw_text(45,  $kala+15, t("Paikka", $kieli),					$thispage, $norm);
-			$pdf->draw_text(160, $kala+15, t("Tuotenumero/Tuotenimi", $kieli),	$thispage, $norm); //125
+			$pdf->draw_text(160, $kala+15, t("Tuotenumero/Tuotenimi", $kieli),	$thispage, $norm);
 			$pdf->draw_text(330, $kala+15, t("Toimittajan tuoteno", $kieli),	$thispage, $norm);
 			$pdf->draw_text(425, $kala+15, t("Hyllyssä", $kieli),				$thispage, $norm);
 			$pdf->draw_text(473, $kala+15, t("Tilattu", $kieli),				$thispage, $norm);


### PR DESCRIPTION
Kun tulostetaan myyntitilikopioita niin siirrettiin siitä pdf:stä sitä tuotenumeroa/nimitystä vähän oikealle päin, jotta ne ei olis pitkien paikkatietojen päällä..
