### PR TITLE
Myyntitilien pdf tulostus eri taval

### DIFF
--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -767,7 +767,7 @@ if (!function_exists('rivi_kerayslista')) {
 				$varastopaikka = hyllyalue('', $row['hyllyalue'], 'riisuttu') . " " . $row["hyllynro"] . " " . $row["hyllyvali"] . " " . $row["hyllytaso"];
 
 				if (strpos($varastopaikka, "!!M") !== FALSE) {
-					$varastopaikka = "Myyntitili";
+					$varastopaikka = t("Myyntitili", $kieli);
 				}
 
 				$row["perhe_kommentti1"] = "";


### PR DESCRIPTION
Jos on varastopaikassa on !!M-osio eli se o myyntitili niin laitetaan tuotepaikan sijaan pdf:n teksti Myyntitili tuotepaikan kohalle. Myös lisätty kutistusfunktio, jos normi tuotepaikka oiskin liika pitkä.
