### PR TITLE
Näytetään molemmat kielet

### DIFF
--- a/crm/viikkosuunnitelma.php
+++ b/crm/viikkosuunnitelma.php
@@ -129,6 +129,13 @@ if ($tee == '') {
 	}
 	$konsernit = " and kalenteri.yhtio in (".substr($konsernit, 0, -1).") ";
 
+	$tapahaku = '';
+	if ($vstk == 'Asiakaskäynti') {
+		$tapahaku = "'Asiakaskäynti', 'Kliendikülastus'";
+	}
+	elseif ($vstk == 'Viikkosuunnitelma') {
+		$tapahaku = "'Viikkosuunnitelma', 'Nädalaplaan'";
+	}
 
 	$query = "	SELECT asiakas.postitp, asiakas.postino, asiakas.ytunnus, asiakas.asiakasnro, kalenteri.yhtio, asiakas.nimi,
 				asiakas.myyjanro, asiakas.email, asiakas.puhelin,
@@ -141,8 +148,8 @@ if ($tee == '') {
 				and kalenteri.kuka     = '$kukarow[kuka]'
 				and kalenteri.pvmalku >= '$viikkoalku 00:00:00'
 				and kalenteri.pvmalku <= '$viikkoloppu 23:59:59'
-				and kalenteri.tapa     = '$vstk'
-				and kalenteri.tyyppi in ('kalenteri','memo')
+				and kalenteri.tapa   IN ($tapahaku)
+				and kalenteri.tyyppi IN ('kalenteri','memo')
 				order by kalenteri.tunnus";
 	$result = pupe_query($query);
 

--- a/crm/viikkosuunnitelma_raportti.php
+++ b/crm/viikkosuunnitelma_raportti.php
@@ -229,8 +229,11 @@ if ($tee == '') {
 	$nayta_sarake = ($vstk == 'Asiakaskäynti' and $piilota_matkasarakkeet != "") ? FALSE : TRUE;
 
 	$tapahaku = '';
-	if ($vstk = 'Asiakaskäynti') {
+	if ($vstk == 'Asiakaskäynti') {
 		$tapahaku = "'Asiakaskäynti', 'Kliendikülastus'";
+	}
+	elseif ($vstk == 'Viikkosuunnitelma') {
+		$tapahaku = "'Viikkosuunnitelma', 'Nädalaplaan'";
 	}
 
 	foreach($yhtiot as $yhtio) {


### PR DESCRIPTION
Kun katotaan asiakaskäyntejä niin haetaan kans Kliendikülastus (= asiakaskäynti), kun ne on noilla nimillä kannassa, koska muuten ne ei löydy. Tämä sama juttu oli myös kalenterimerkinnän viikkosuunnitelma kanssa (Viikkosuunnitelma = Nädalaplaan). Tämä ongelma oli siis edustajaraportissa ja viikkosuunnitelmassa.
