### PR TITLE
Näytetään virheet myös uudelleenluodessa verkkolaskuaineisto

### DIFF
--- a/tilauskasittely/uudelleenluo_laskuaineisto.php
+++ b/tilauskasittely/uudelleenluo_laskuaineisto.php
@@ -842,6 +842,9 @@
 		elmaedi_aineisto_loppu($tootedi, $timestamppi);
 		pupevoice_aineisto_loppu($tootxml);
 
+		//	Tulostetaan virheet jos niitä oli
+		echo $tulos_ulos;
+
 		// suljetaan faili
 		fclose($tootxml);
 		fclose($tootedi);

--- a/tilauskasittely/verkkolasku_finvoice.inc
+++ b/tilauskasittely/verkkolasku_finvoice.inc
@@ -496,7 +496,7 @@ if (!function_exists('finvoice_otsik')) {
 			#xml_add("AccountDimensionText",								"",										$tootfinvoice);
 			#xml_add("SellerAccountText",									"",										$tootfinvoice);
 		}
-		elseif ($silent == "" or strpos($_SERVER['SCRIPT_NAME'], "valitse_laskutettavat_tilaukset.php") !== FALSE) {
+		elseif ($silent == "" or strpos($_SERVER['SCRIPT_NAME'], "valitse_laskutettavat_tilaukset.php") !== FALSE  or strpos($_SERVER['SCRIPT_NAME'], "uudelleenluo_laskuaineisto.php") !== FALSE) {
 			if ($senderpartyid == "" or $senderintermediator == "") {
 				$tulos_ulos .= t("Finvoiceaineistoa ei voitu luoda. Yhtiolta puuttuu finvoice_senderpartyid tai finvoice_senderintermediator tunnus. Tulosta lasku manuaalisesti!")." ".$lasrow["laskunro"]."<br>\r\n<br>\r\n";
 			}


### PR DESCRIPTION
Huomasin, että näitä virheitä ei tulostettu jos uudelleenluotiin verkkolaskuaineistoa. Meni hetki, että tajusin, että vielä puuttui senderintermediaattoritietoja yhtion_parametreista.
