### PR TITLE
PUMA: asiakkaan avainsanat

### DIFF
--- a/inc/asiakkaan_avainsanatrivi.inc
+++ b/inc/asiakkaan_avainsanatrivi.inc
@@ -58,10 +58,9 @@
 						ORDER BY 1";
 			$toimitustapares = pupe_query($query);
 
-			$ulos .= "<option value='x'>".t("Oletus")."</option>";
+			$ulos .= "<option value='OLETUS'>".t("Oletus")."</option>";
 
 			while ($toimitustaparow = mysql_fetch_assoc($toimitustapares)) {
-
 				$sel = $trow[$i] == $toimitustaparow['selite'] ? " selected" : "";
 
 				$ulos .= "<option value='{$toimitustaparow['selite']}'{$sel}>{$toimitustaparow['selite']}</option>";
@@ -136,7 +135,7 @@
 
 				$ulos .= "<option value='{$paikallisrow['tunnus']}'{$sel}>{$paikallisrow['selitetark']}</option>";
 			}
-			
+
 			$ulos .= "</select></td>";
 			$jatko = 0;
 		}

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -24188,10 +24188,11 @@ if (!function_exists('paivita_ohjausmerkki')) {
 						WHERE yhtio 	 = '{$kukarow['yhtio']}'
 						AND laji 		 = 'OHJAUSMERKKI'
 						AND liitostunnus = '{$laskurow['liitostunnus']}'
-						AND avainsana = 'x'
+						AND avainsana 	 = 'OLETUS'
 						LIMIT 1";
 			$ohjausmerkki_check_res = pupe_query($query);
 		}
+		
 		$ohjausmerkki_check_row = mysql_fetch_assoc($ohjausmerkki_check_res);
 
 		if ($ohjausmerkki_check_row['tarkenne'] != "") {


### PR DESCRIPTION
- uusi optio oletus (x) ohjausmerkki lajiseen avainsanaan
- jos paivita_ohjausmerkki funkkari ei löydä tarkennetta valitulla toimitustavalla, koitetaan etsia oletustarkenne 'x'-avainsanalla
