### PR TITLE
Viedään lapsituotteet varastoon vain kerran

### DIFF
--- a/tilauskasittely/varastoon.inc
+++ b/tilauskasittely/varastoon.inc
@@ -272,8 +272,6 @@ elseif ($toiminto == "kalkyyli" and $tee == "varastoon") {
 	 						yhtio			= '{$kukarow['yhtio']}',
 				 			tuoteno     	= '{$chk_row['tuoteno']}',
 				 			oletus      	= '{$oletuspaikka_lapsi}',
-		   		 			saldo       	= '{$chk_row['varattu']}',
-		   		 			saldoaika   	= now(),
 							hyllyalue   	= '{$chk_row['hyllyalue']}',
 							hyllynro    	= '{$chk_row['hyllynro']}',
 							hyllytaso   	= '{$chk_row['hyllytaso']}',


### PR DESCRIPTION
Kun viedään tuoteperheitä varastoon ja perustetaan uusi paikka, niin ei viedä lapsituotteita varastoon myös tuotepaikan perustuksen yhteydessä. Tästä aiheutui se, että lopulta lapsituotteet vietiin varastoon kahdesti, kun perustettiin uusi paikka (jolloin näytti siltä kuin tuotetta olisi ollu saldoilla jo valmiiksi silloin kun tuoteperustettiin.
