### PR TITLE
Bruttokilot korjaus DGD lomake

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -14486,7 +14486,7 @@ if (!function_exists("palauta_vak_tiedot")) {
 						TRIM(TRAILING '.' FROM TRIM(TRAILING '0' FROM r1.kollit)) AS kollit,
 						round(r1.kilot,1) kilot
 						FROM rahtikirjat r1
-						WHERE r1.pakkaustieto_tunnukset = ''
+						WHERE (r1.pakkaustieto_tunnukset = '' OR r1.pakkaustieto_tunnukset IS NULL)
 						AND r1.otsikkonro in ({$otunnus})
 						AND r1.yhtio = '{$kukarow['yhtio']}'";
 			$riresult2 = pupe_query($query);


### PR DESCRIPTION
DGD lomakkeesta oli kadonnut bruttokilot, kun tyhjän sijasta oli mahdollsita, että rahtikirjat.pakkaustieto_tunnukset on myös NULL tyhjän lisäks. Katsotaan sitten että onko tyhjä tai onko NULL, jolloin tarvittavat tiedot löytyy oikeen ja saadan painot tulostettua DGD lomakkeelle!
