### PR TITLE
Haluttaessa näytetään vain tuotteet joilla on alennus 

### DIFF
--- a/tilauskasittely/tuote_selaus_haku.php
+++ b/tilauskasittely/tuote_selaus_haku.php
@@ -1387,8 +1387,15 @@
 					$hae_ja_selaa_asiakas = (int) $laskurow['liitostunnus'];
 				}
 
+				//jos ollaan verkkokaupassa ja n‰ytet‰‰n vain aletuotteet asetus on p‰‰ll‰ niin pakotetaan saako_myyda_private_label tarkistamaan alet kaikilta tuotteilta, jotta n‰ytet‰‰n vain aletuotteet
 				if ($hae_ja_selaa_asiakas != 0) {
-					if (!saako_myyda_private_label($hae_ja_selaa_asiakas, $row["tuoteno"])) {
+					$vainaletuotteet = FALSE;
+
+					if ($verkkokauppa != "" AND $kukarow["naytetaan_tuotteet"] == "A") {
+						$vainaletuotteet = TRUE;
+					}
+
+					if (!saako_myyda_private_label($hae_ja_selaa_asiakas, $row["tuoteno"], 1, $vainaletuotteet)) {
 						continue;
 					}
 				}


### PR DESCRIPTION
Jos extranetkäyttäjän takana on päällä asetus "näytetään verkkokaupassa vain tuotteet joilla on asiakashinta tai asiakasale" niin näytetään todella verkkokaupassa vain ne tuotteet joilla on asiakashinta tai asiakasale. Tämä tehtiin siis tuote_selaus_haku.php:seen, että käytetään tarkistukseen saako_myydä_private_label funktiota.
