### PR TITLE
Avoimet laskut teksti vain tietyissä tapauksissa

### DIFF
--- a/myyntires/paperikarhu.php
+++ b/myyntires/paperikarhu.php
@@ -175,7 +175,9 @@
 			if ($sivu == 1) {
 
 				//otsikko
-				$pdf->draw_text(30, $kala+30, t("Avoimet laskut", $kieli), $firstpage, $bold);
+				if ($yhtiorow['maksukehotus_kentat'] == 'J' or $yhtiorow['maksukehotus_kentat'] == 'L') {
+					$pdf->draw_text(30, $kala+30, t("Avoimet laskut", $kieli), $firstpage, $bold);
+				}
 
 				// tehd‰‰n riveist‰ max 90 merkki‰
 				$viesti = wordwrap($viesti, 90, "\n");


### PR DESCRIPTION
Näytetään karhuilla "Avoimet laskut" teksti vain jos parametri "Maksukehotus_kentat" on asennossa: "Näytetään viimeisin muistutuspäivä ja perintäkerrat sekä korot ja lisätään ne maksukehotuksen summaan" (J) tai "Ei näytetä viimeisintä muistutuspäivää eikä perintäkertoja. Näytetään korot ja lisätään ne maksukehotuksen summaan" (L).
