### PR TITLE
Ei rahtikirja_tyhja toimitustapoja

### DIFF
--- a/rahtikirja_custom.php
+++ b/rahtikirja_custom.php
@@ -803,7 +803,7 @@ function pupe_toimitustapa_fetch_all() {
 	$query  = "	SELECT *
 				FROM toimitustapa
 				WHERE yhtio = '{$GLOBALS['kukarow']['yhtio']}'
-				and rahtikirja not in ('rahtikirja_ups_siirto.inc','rahtikirja_dpd_siirto.inc','rahtikirja_unifaun_ps_siirto.inc','rahtikirja_unifaun_uo_siirto.inc','rahtikirja_hrx_siirto.inc')
+				and rahtikirja not in ('rahtikirja_ups_siirto.inc','rahtikirja_dpd_siirto.inc','rahtikirja_unifaun_ps_siirto.inc','rahtikirja_unifaun_uo_siirto.inc','rahtikirja_hrx_siirto.inc', 'rahtikirja_tyhja.inc')
 				order by jarjestys,selite";
 	$result = pupe_query($query);
 


### PR DESCRIPTION
Tyhän (custom) rahtikirjan tulostuksessa ei edes tarjota niitä toimitustapoja, joilla on rahtikijratyyppinä rahtikiraj tyhjä (aka rahtikirja_tyhja.inc), joka tarkoittaa sitä että rahtikirjaa ei toimitustavalla tulosteta. Koska rahtikirjaa ei ole tarkoitus tulostaa niin tyhjä rahtikirja ohjelma ei sitä edes luo.
