### PR TITLE
Avoimen laskun voi muuttaa käteiseksi

### DIFF
--- a/myyntires/eikateinen.php
+++ b/myyntires/eikateinen.php
@@ -39,7 +39,7 @@ if ((int) $maksuehto != 0 and (int) $tunnus != 0) {
 	$tilikausi = tarkista_saako_laskua_muuttaa($tapahtumapaiva);
 	$tilikausi_lasku = tarkista_saako_laskua_muuttaa($laskurow['tapvm']);
 
-	if (!$laskupvmerror and (empty($tilikausi) and (empty($tilikausi_lasku)) or ($toim == 'KATEINEN' and !$laskumaksettuerror))) {
+	if (empty($tilikausi) and (empty($tilikausi_lasku) or $toim == 'KATEINEN') and !$laskupvmerror and !$laskumaksettuerror) {
 		$mehtorow 		= hae_maksuehto($maksuehto);
 		$konsrow  		= hae_asiakas($laskurow);
 		$kassalipasrow 	= hae_kassalipas($kassalipas);


### PR DESCRIPTION
Avoimen laskun voi muuttaa käteiseksi, vaikka se olisi syntynyt sujletulla kaudella
