### PR TITLE
POSTNORD: Keräyksen kuittauksen muutoksia

### DIFF
--- a/kerayksen_kuittaus_ulkoisesta_jarjestelmasta_cron.php
+++ b/kerayksen_kuittaus_ulkoisesta_jarjestelmasta_cron.php
@@ -71,6 +71,10 @@
 					if (isset($xml->MessageHeader) and isset($xml->MessageHeader->MessageType) and trim($xml->MessageHeader->MessageType) == 'OutboundDeliveryConfirmation') {
 
 						$otunnus = (int) $xml->CustPackingSlip->SalesId;
+
+						// Fallback to pickinglist id
+						if ($otunnus == 0) $otunnus = (int) $xml->CustPackingSlip->PickingListId;
+
 						list($pp, $kk, $vv) = explode("-", $xml->CustPackingSlip->DeliveryDate);
 						$toimaika = "{$vv}-{$kk}-{$pp}";
 						$toimitustavan_tunnus = (int) $xml->CustPackingSlip->TransportAccount;


### PR DESCRIPTION
Vain Magento-tilauksissa verrataan saldoja, lähetetään maili ja päivitetään tilauksella oleva määrä kerätyksi määräksi. Muissa tapauksissa päivitetään aineistossa tuleva määrä kerätyksi määräksi. Ei dellata enää filejä vaan siirretään done-kansioon.
