### PR TITLE
* "Matkallaolevat laskuittain"-rappariin uusia sarakkeita

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -645,9 +645,17 @@ if (!function_exists("tv2dateconv")) {
 }
 
 if (!function_exists("tv3dateconv")) {
-	function tv3dateconv($date) {
+	function tv3dateconv($date, $lyhyt = FALSE) {
 		//k‰‰nt‰‰ vvvvkkpp muodon muotoon vvvv-kk-pp
-		return substr($date,0,4)."-".substr($date,4,2)."-".substr($date,6,2)." 00:00:00";
+
+		if ($date == "00000000" or $date == "") {
+			return "";
+		}
+
+		$loppu = "";
+		if (!$lyhyt) $loppu = " 00:00:00";
+
+		return substr($date,0,4)."-".substr($date,4,2)."-".substr($date,6,2).$loppu;
 	}
 }
 


### PR DESCRIPTION
Matkalla olevien summa pitää täsmätä kirjanpidon matkalla 
olevat vaihto-om. tasetilin kanssa, koska on ko.tilin tase-erittely (mitä 
laskuja+muistioita tietyllä päivämäärällä otettu tilanne sisältää)

Avaava-tase -tositteen matkalla olevia ei mukaan raporttiin

Kirjanpidon ja tilinpäätöksen kannalta erittelyssä voisi näkyä vielä omilla 
sarakkeilla (tilintarkastajat haluavat listan): 
-loppukalkyyli pvm, eli milloin poistunut kirjanpidossa matkalla olevista 
-saapumisnro 
-logistiikan varastoonvienti pvm 
-mahdollisesti toimittajan takana oleva toimitusehto (jos tallennettu esim. 
DDU)
