### PR TITLE
Ei tulosteta tuotenumeroa kahteen kertaan ja ei päällekkäin

### DIFF
--- a/tilauskasittely/tulosta_ostotilaus.inc
+++ b/tilauskasittely/tulosta_ostotilaus.inc
@@ -428,7 +428,7 @@
 					}
 
 					if (strtoupper($row["toim_tuoteno"]) != strtoupper($row["tuoteno"]) AND strtoupper($row["toim_tuoteno"] != "")) {
-						list($ff_string, $ff_font) = pdf_fontfit("(".$row["tuoteno"].")", 110, $pdf, $pieni); 
+						list($ff_string, $ff_font) = pdf_fontfit("(".$row["tuoteno"].")", 110, $pdf, $pieni);
 						$oikpos = $pdf->strlen($ff_string, $ff_font);
 						$pdf->draw_text(290-$oikpos, $kala, $ff_string, $thispage, $ff_font);
 					}


### PR DESCRIPTION
Ei tulosteta tuotenumeroa ostotilauksen tulosteelle kahteen kertaan jos toimittajan tuotenumero on tyhjä - eikä myöskään tulosteta toimittajan tuotenumeroa tuotenumeron päälle.
