### PR TITLE
Verkkolaskun valuutan puuttuessa default valuutta -fix

### DIFF
--- a/inc/verkkolasku-in.inc
+++ b/inc/verkkolasku-in.inc
@@ -561,9 +561,11 @@
 				if ($laskuttajan_valkoodi != "") {
 					$valkoodi = $laskuttajan_valkoodi;
 				}
+				elseif ($trow['oletus_valkoodi'] != '') {
+					$valkoodi = $trow['oletus_valkoodi'];
+				}
 				else {
-					if ($trow['oletus_valkoodi'] != '') $valkoodi = $trow['oletus_valkoodi'];
-					else $valkoodi = 'EUR';
+					$valkoodi = 'EUR';
 				}
 
 				// Hyl‰t‰‰n viite jos se on nollaa


### PR DESCRIPTION
Siirretään valuuttachekkiä alemmas ja katotaan default toimittajalta, jos aineistossa sitä ei tule.

Samassa myös muita kenttiä alemmas, niitä ei tarvita kuin vasta myöhemmin.
