### PR TITLE
Näytetään saatavat-taulukossa "luottotilanne nyt"

### DIFF
--- a/raportit/saatanat.php
+++ b/raportit/saatanat.php
@@ -323,6 +323,7 @@
 		$ylivito					= 0;
 		$rivilask 					= 0;
 		$avoimettilaukset_yhteensa 	= 0;
+		$luottotilanne_nyt_yhteensa	= 0;
 
 		if (mysql_num_rows($result) > 0) {
 


### PR DESCRIPTION
Näytetään luottotilanne nyt suoraan saatavat-taulukossa. Aikaisemmin on nähnyt vain luottorajan ja avoimien myyntien määrän, ja tietääkseen luottotilanteen on pitänyt käyttää laskinta. Enää ei tarvitse laskinta.
