### PR TITLE
Näytetään vain oikeasti virheelliset asn:t

### DIFF
--- a/ostolasku_asn_tarkastelu.php
+++ b/ostolasku_asn_tarkastelu.php
@@ -2114,11 +2114,6 @@
 			while ($row = mysql_fetch_assoc($result)) {
 				$naytetaanko_toimittajabutton = true;
 
-				// n‰ytet‰‰n vain vialliset rivit
-				if ($row["rivit"] == $row["ok"] and $row["status"] == "X") {
-					continue;
-				}
-
 				$asn_numerot[$row['asn_numero']] = $row['asn_numero'];
 
 				if ($ed_toimittaja != '' and $ed_toimittaja != $row['toimittajanumero']) {


### PR DESCRIPTION
Jossain vaiheessa asn-rivin status jäänyt tyhjäksi, vaikka rivi on korjattu ja tuloutettu. Nämä rivit tulivat satunnaisesti näkyviin virheellisiä asn:iä selattaessa
