### PR TITLE
Hitaaseen queryyn use index lisä

### DIFF
--- a/inventointi_listat.php
+++ b/inventointi_listat.php
@@ -619,7 +619,7 @@
 
 				if ($from == '') {
 					$yhtiotaulu = "tuotepaikat";
-					$from 		= " FROM tuotepaikat";
+					$from 		= " FROM tuotepaikat ";
 					$join 		= " JOIN tuote use index (tuoteno_index) ON tuote.yhtio = tuotepaikat.yhtio and tuote.tuoteno = tuotepaikat.tuoteno and tuote.ei_saldoa = '' {$rajauslisatuote}";
 					$lefttoimi 	= " LEFT JOIN tuotteen_toimittajat ON tuotteen_toimittajat.yhtio = tuotepaikat.yhtio and tuotteen_toimittajat.tuoteno = tuotepaikat.tuoteno ";
 


### PR DESCRIPTION
Inventointilistat ohjemaan hitaaseen queryyn indexin käyttö mukaan (USE INDEX yhtio_inventointilista_aika)

Ja ei ajeta varaston_hyllypaikat queryä turhaan! Varaston_hyllypaikat kysely vain, jos keräyserät on mittoihin perustuvat (ennen jos keräyserät oli vaan käytössä niin ajettiin tämä query, mutta osassa tapauksista siis turhaan)
