### PR TITLE
Mobiilituloutuksen saappari bugfix

### DIFF
--- a/mobiili/tuotteella_useita_tilauksia.php
+++ b/mobiili/tuotteella_useita_tilauksia.php
@@ -285,6 +285,9 @@ echo $sort_by_direction_hylly == 'asc' ? "<img src='{$palvelin2}pics/lullacons/a
 echo "</th>";
 echo "</tr>";
 
+// otetaan saapuminen rivilooppia varten talteen
+$_saapuminen = $saapuminen;
+
 # Loopataan ostotilaukset
 while($row = mysql_fetch_assoc($result)) {
 
@@ -295,6 +298,7 @@ while($row = mysql_fetch_assoc($result)) {
 
 	# Jos rivi on jo kohdistettu eri saapumiselle
 	if ($row['uusiotunnus'] != 0) $saapuminen = $row['uusiotunnus'];
+	else $saapuminen = $_saapuminen;
 
 	if ($orig_tilausten_lukumaara != $tilausten_lukumaara) $tilausten_lukumaara = $orig_tilausten_lukumaara;
 


### PR DESCRIPTION
Muistetaan esivalittu saapuminen riviloopissa, ja käytetään toista saapumista vain tarvittaessa.

Nyt saattoi käydä niin, että joku riveistä oli jo saapumisella, jolloin seuraavien rivien kohdalla käytettiin samaa saapumisnumeroa, vaikka olisi pitänyt käyttää jotain ihan muuta. 
