### PR TITLE
* Sähköpostilaskun hiilikopio

### DIFF
--- a/tilauskasittely/tulosta_lasku.inc
+++ b/tilauskasittely/tulosta_lasku.inc
@@ -2654,8 +2654,13 @@ if (!function_exists("tulosta_lasku")) {
 				$kutsu = t("Lasku", $kieli)." ".$laskurow["laskunro"];
 				$liite = $pdf_laskufilenimi;
 
-				// l‰hetet‰‰n cc aina postittaja osoitteeseen
-				$sahkoposti_cc = $yhtiorow["postittaja_email"];
+				// l‰hetet‰‰n cc aina talhal/postittaja osoitteeseen
+				if ($yhtiorow["sahkopostilasku_cc_email"] != "") {
+					$sahkoposti_cc = $yhtiorow["sahkopostilasku_cc_email"];
+				}
+				else {
+					$sahkoposti_cc = "";
+				}
 
 				include("inc/sahkoposti.inc"); // sanotaan include eik‰ require niin ei kuolla
 			}


### PR DESCRIPTION
Voidaan valita mihin osoitteeseen sähköpostilaskun cc lähetetään. Jos kentän jättää tyhjäksi, niin cc:tä ei lähetetä.

alter table yhtion_parametrit add column sahkopostilasku_cc_email varchar(100) not null default '' after talhal_email;
