### PR TITLE
* Hae ja selaa ohjelman perhe- ja saldorajaus

### DIFF
--- a/tilauskasittely/tuote_selaus_haku.php
+++ b/tilauskasittely/tuote_selaus_haku.php
@@ -1458,7 +1458,7 @@
 
 			$isan_kuva = '';
 
-			foreach ($rows as $row_key => &$row) {
+			foreach ($rows as $row_key => $row) {
 
 				if ($kukarow['extranet'] != '' or $verkkokauppa != "") {
 					$hae_ja_selaa_asiakas = (int) $kukarow['oletus_asiakas'];


### PR DESCRIPTION
Ominaisuus A)
- uusi täppä "piilota tuoteperherakenne"
- tällä valinnalla näytetään tuoteperheistä ainoastaan isätuotteet

Ominaisuus B)
- mahdollisuus rajata tuotehakua näyttämällä vain tuotteita jolla on saldoa
- saldottomat tuotteet jotka eivät ole isätuotteita tai eivät kuulu tuoteperheeseen poistetaan listauksesta
- koko tuoteperhe poistetaan listauksesta jos lapsissa oli saldottomia
