### PR TITLE
Uusin osasuorituksen tapvm laskun maksupvmksi

### DIFF
--- a/myyntires/manuaalinen_suoritusten_kohdistus.php
+++ b/myyntires/manuaalinen_suoritusten_kohdistus.php
@@ -1243,18 +1243,17 @@ if ($tila == 'tee_kohdistus') {
           //sitten katsotaan milloin nämä osasuoritukset on tehty
           $query = "SELECT tapvm
                     FROM tiliointi
-                     WHERE yhtio = '{$kukarow["yhtio"]}'
+                    WHERE yhtio = '{$kukarow["yhtio"]}'
                     AND tilino   = '{$suoritus["myyntisaamiset_tilino"]}'
                     AND ltunnus  = {$lasku["tunnus"]}
                     AND korjattu = ''
                     $wherelisa
                     ORDER BY tapvm DESC
                     LIMIT 1";
-
           $uusinresult = pupe_query($query);
           $uusin = mysql_fetch_assoc($uusinresult);
 
-          if ($uusin["tapvm"] > $laskun_maksupvm) {
+          if ((int) str_replace("-", "", $uusin["tapvm"]) > (int) str_replace("-", "", $laskun_maksupvm)) {
             $laskun_maksupvm_laskulle = $uusin["tapvm"];
           }
           else {
@@ -1266,7 +1265,7 @@ if ($tila == 'tee_kohdistus') {
         }
 
         $query = "UPDATE lasku
-                  SET mapvm     = '$laskun_maksupvm_laskulle',
+                  SET mapvm                 = '$laskun_maksupvm_laskulle',
                   viikorkoeur               = '$korkosumma',
                   saldo_maksettu            = 0,
                   saldo_maksettu_valuutassa = 0


### PR DESCRIPTION
Jos on kysessä osasuoritetun laskun viimeinen kohdistus JA tämä aiempi osasuoritus oli tehty myöhemmin kuin tämä nyt kohdistettava osasuoritus niin aiemmin tämän nyt kohdistettavan osasuorituksen päivämäärästä tuli laskun maksupäivämäärä. Nyt katsotaan että laitetaan viimeisimmän osasuorituksen tapahtumapäivämäärä laskun maksupäivämääräksi.

Eg:
laskun päivämäärä 1.4
suoritus yksi 3.4
suoritus kaksi 2.5

Jos suoritus kaksi kohdistettiin ennen suoritus yhtä, niin laskun maksupäivämääräksi meni 3.4. Nyt laskun maksupäivämääräksi menee aina uusimman suorituksen tapvm olipa suorituksen kohdistettu missä järjestyksessä tahansa.
