### PR TITLE
FIX: Myyntitilauksen otsikko & täpät

### DIFF
--- a/tilauskasittely/luo_myyntitilausotsikko.inc
+++ b/tilauskasittely/luo_myyntitilausotsikko.inc
@@ -1,7 +1,7 @@
 <?php
 
 if (!function_exists("luo_myyntitilausotsikko")) {
-  function luo_myyntitilausotsikko($toim, $asiakasid, $tilausnumero = '', $myyjanro = '', $viesti = '', $kantaasiakastunnus = '', $ohjelmamoduli = '', $tilaustyyppi = '', $yhtiotoimipaikka = '', $ei_ketjutus = '') {
+  function luo_myyntitilausotsikko($toim, $asiakasid, $tilausnumero = '', $myyjanro = '', $viesti = '', $kantaasiakastunnus = '', $ohjelmamoduli = '', $tilaustyyppi = '', $yhtiotoimipaikka = '', $ei_ketjutus = '', $eilahe_osatoim = '') {
     global $kukarow, $yhtiorow, $session;
 
     $query  = "SELECT *

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -3117,7 +3117,7 @@ if (isset($jatka)) {
 
   list($varasto, $varastot) = palauta_varasto($args);
 
-  if ($toim == 'PIKATILAUS') {
+  if ($toim == 'PIKATILAUS' or ($toim == 'EXTRANET' and !empty($eilahe_osatoim))) {
 
     $_yhtiorow_talteen = $yhtiorow;
     $_yhtiotoimipaikka = hae_varaston_toimipaikka($varasto);


### PR DESCRIPTION
Lisätty uusi parametri "luo myyntitilausotsikko"-funktioon. Tämän parametrin ansiosta voidaan myös extranetin puolelta mennä tarkastelemaan tarvitaanko "suoraan laskutukseen"- ja "osatoimitus"-täppiä
