### PR TITLE
* Tuotteiden parametrit Magentoon

### DIFF
--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -85,6 +85,7 @@ class MagentoClient {
    * Configurable-tuotteella k‰ytett‰v‰ nimityskentt‰, oletuksena nimitys
    */
   private $_configurable_tuote_nimityskentta = "nimitys";
+
   /**
    * T‰m‰n yhteyden aikana sattuneiden virheiden m‰‰r‰
    */

--- a/rajapinnat/tuote_export.php
+++ b/rajapinnat/tuote_export.php
@@ -733,8 +733,9 @@ if (isset($verkkokauppatyyppi) and $verkkokauppatyyppi == "magento") {
   if (isset($categoryaccesscontrol)) $magento_client->setCategoryaccesscontrol($categoryaccesscontrol);
 
   // Mitä tuotteen kenttää käytetään configurable-tuotteen nimityksenä
-  if (isset($magento_configurable_tuote_nimityskentta)
-      and !empty($magento_configurable_tuote_nimityskentta)) $magento_client->setConfigurableNimityskentta($magento_configurable_tuote_nimityskentta);
+  if (isset($magento_configurable_tuote_nimityskentta) and !empty($magento_configurable_tuote_nimityskentta)) {
+    $magento_client->setConfigurableNimityskentta($magento_configurable_tuote_nimityskentta);
+  }
 
   // lisaa_kategoriat
   if (count($dnstuoteryhma) > 0) {


### PR DESCRIPTION
- koskee sekä simple että configurable-tuotteita
- tuote_export.php nappaa muuttuneilta tuotteilta mukaan myös tuotteen_parametrit
- parametrin arvo (tuotteen_avainsana.selite) syötetään sen nimiselle (avainsana.selite) attribuutille Magentossa
- jos attribuutti on perustettu Magentoon ja sen tyyppi on 'dropdown', mutta arvoa ei ole ennestään olemassa, se luodaan
- jos nimellä ei löydy attribuuttia magentosta, ei sitä myöskään perusteta
