### PR TITLE
BUGFIX: Rekisterinumeroiden haku tilausvahvistukseen

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -24816,16 +24816,17 @@ if (!function_exists('hae_tilauksen_rekisterinumerot')) {
       return array();
     }
 
-    $joinlisa = $tyhjat_rekkarit_pois ? "AND tilausrivin_lisatiedot.rekisterinumero != ''" : "";
+    $joinlisa = $tyhjat_rekkarit_pois ? "AND tl.rekisterinumero != ''" : "";
 
-    //Tilausrivi pit‰‰ joinaa, jottei tule poistettuja rekisterinumeroita
-    $query = "SELECT tilausrivin_lisatiedot.rekisterinumero
-              FROM tilausrivin_lisatiedot
-              JOIN tilausrivi
-              ON ( tilausrivi.yhtio = tilausrivin_lisatiedot.yhtio
-                AND tilausrivi.tunnus                  = tilausrivin_lisatiedot.tilausrivitunnus {$joinlisa})
-              WHERE tilausrivin_lisatiedot.yhtio       = '{$kukarow['yhtio']}'
-              AND tilausrivin_lisatiedot.vanha_otunnus = '{$tilausnumero}'
+    $query = "SELECT tl.rekisterinumero
+              FROM tilausrivi
+              JOIN tilausrivin_lisatiedot AS tl ON (
+                tl.yhtio = tilausrivi.yhtio AND
+                tl.tilausrivitunnus = tilausrivi.tunnus
+                {$joinlisa}
+              )
+              WHERE tilausrivi.yhtio = '{$kukarow['yhtio']}'
+              AND tilausrivi.otunnus = '{$tilausnumero}'
               ORDER BY tilausrivi.tunnus DESC";
     $result = pupe_query($query);
 


### PR DESCRIPTION
Käännetty querysta taulut päittäin. Haetaankin tiedot tilausrivi edellä. Korjattu myös että etsitään otunnusta, eikä vanhaa otunnusta.
