### PR TITLE
BUGFIX: Uuden tuotepaikan perustus 0-alueelle

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -20646,7 +20646,7 @@ if (!function_exists('lisaa_tuotepaikka')) {
     $hyllyvali   = strtoupper(trim($hyllyvali));
     $hyllytaso   = strtoupper(trim($hyllytaso));
 
-    if (empty($hyllyalue) and !empty($varasto)) {
+    if ($hyllyalue == '' and !empty($varasto)) {
       //Hyllyä ei ole annettu mutta varasto on. Luodaan annettuun varastoon tuotteelle default-tuotepaikka.
       $varasto = hae_varasto($varasto);
 
@@ -20655,7 +20655,7 @@ if (!function_exists('lisaa_tuotepaikka')) {
       $hyllyvali = 0;
       $hyllytaso = 0;
     }
-    elseif (empty($hyllyalue) and empty($varasto)) {
+    elseif ($hyllyalue == '' and empty($varasto)) {
       return false;
     }
 


### PR DESCRIPTION
Käytettiin liian rajua tarkistusta hyllyalueelle. Empty-funktiolle "0" ei ollut validi hyllyalue.
