### PR TITLE
Siirtolistoilla setataan siirtorivitunnus

### DIFF
--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -1805,7 +1805,6 @@ if ($rivityyppi != 'O' and trim($var) == "" and $trow["tuoteno"] != "") {
                 $sres = pupe_query($query);
 
                 while ($srow = mysql_fetch_assoc($sres)) {
-
                   $query = "UPDATE sarjanumeroseuranta
                             SET $tunken      = '$lisatty_tun'
                             WHERE yhtio = '$kukarow[yhtio]'


### PR DESCRIPTION
Varastonsiirron rivin muokkauksen yhteydessä setattiin myyntirivitunnus, mikä johti sarjanumeroiden kanssa sekaannuksiin ja jumeihin. Korjattu niin, että nyt setataan siirtorivitunnus myyntirivitunnuksen sijaan varastosiirtorivin muokkauksen yhteydessä.
