### PR TITLE
Jälkilaskenta skippaamaan konvertoituja tapahtumia

### DIFF
--- a/tilauskasittely/jalkilaskenta.inc
+++ b/tilauskasittely/jalkilaskenta.inc
@@ -478,11 +478,11 @@ if (!function_exists('korjaatapahtuma')) {
     // Tämä keissi on tärkeä, jos tilikauden alkua ollaan siirretty taaksepäin historiaan
     $query = "DELETE
               FROM tapahtuma
-              WHERE yhtio     = '{$kukarow['yhtio']}'
-              AND laji        = 'korjaus'
-              AND rivitunnus != 0
-              AND rivitunnus  = '{$tun_chk_row['rivitunnus']}'
-              AND laadittu    >= '{$yhtiorow['tilikausi_alku']} 00:00:00'";
+              WHERE yhtio    = '{$kukarow['yhtio']}'
+              AND laji       = 'korjaus'
+              AND rivitunnus > 0
+              AND rivitunnus = '{$tun_chk_row['rivitunnus']}'
+              AND laadittu   >= '{$yhtiorow['tilikausi_alku']} 00:00:00'";
     $del_res = pupe_query($query);
 
     if ($jalkilaskenta_debug > 1) $jalkilaskenta_debug_text .= "$query<br>";
@@ -500,10 +500,10 @@ if (!function_exists('korjaatapahtuma')) {
       // Hinta halutaan hakea kuitenkin 10.03.2013 korjauksilta
       $query = "SELECT kplhinta, hinta
                 FROM tapahtuma
-                WHERE yhtio     = '{$kukarow['yhtio']}'
-                AND laji        IN ('{$tun_chk_row['laji']}', 'korjaus')
-                AND rivitunnus != 0
-                AND rivitunnus  = '{$tun_chk_row['rivitunnus']}'
+                WHERE yhtio    = '{$kukarow['yhtio']}'
+                AND laji       IN ('{$tun_chk_row['laji']}', 'korjaus')
+                AND rivitunnus > 0
+                AND rivitunnus = '{$tun_chk_row['rivitunnus']}'
                 ORDER BY laadittu DESC, tunnus DESC
                 LIMIT 1";
       $hinta_chk_res = pupe_query($query);
@@ -685,11 +685,11 @@ if ($tuoteno != '') {
 
       $query = "SELECT *
                 FROM tapahtuma
-                WHERE yhtio = '$kukarow[yhtio]'
-                AND tuoteno = '$tuoteno'
-                AND rivitunnus >= 0
+                WHERE yhtio           = '$kukarow[yhtio]'
+                AND tuoteno           = '$tuoteno'
+                AND rivitunnus        > 0
                 AND left(laadittu,10) = '$pvm'
-                AND laji    in ('tulo','valmistus')
+                AND laji              in ('tulo','valmistus')
                 LIMIT 1";
       $result = pupe_query($query);
     }
@@ -728,11 +728,11 @@ if ($tuoteno != '') {
 
       $query = "SELECT sum(kpl) saldomuutos, sum(if(laji='Epäkurantti',1,0)) epaku
                 FROM tapahtuma
-                WHERE yhtio  = '$kukarow[yhtio]'
-                AND tuoteno  = '$tuoteno'
-                AND laadittu >= '$pvm'
+                WHERE yhtio     = '$kukarow[yhtio]'
+                AND tuoteno     = '$tuoteno'
+                AND laadittu   >= '$pvm'
                 AND rivitunnus >= 0
-                AND kpl      <> 0";
+                AND kpl        <> 0";
       $result = pupe_query($query);
 
       if ($jalkilaskenta_debug > 1) $jalkilaskenta_debug_text .= "$query<br>";
@@ -765,11 +765,11 @@ if ($tuoteno != '') {
         // skipataan myös siirto, vaikka siellä voikin olla hinta (siirron aikana hinta ei voi muuttua)
         $query = "SELECT hinta, tunnus, rivitunnus
                   FROM tapahtuma
-                  WHERE yhtio  = '$kukarow[yhtio]'
-                  and tuoteno  = '$tuoteno'
-                  and laadittu < '$pvm'
+                  WHERE yhtio     = '$kukarow[yhtio]'
+                  and tuoteno     = '$tuoteno'
+                  and laadittu    < '$pvm'
                   AND rivitunnus >= 0
-                  and laji     not in ('poistettupaikka', 'uusipaikka', 'siirto')
+                  and laji not in ('poistettupaikka', 'uusipaikka', 'siirto')
                   ORDER BY laadittu DESC, tunnus DESC
                   LIMIT 1";
         $result = pupe_query($query);
@@ -781,10 +781,10 @@ if ($tuoteno != '') {
           // Katsotaan löytyykö tälle tapahtumariville korjausrivi ja otetaan edellinen kehahin sieltä
           $query = "SELECT hinta
                     FROM tapahtuma
-                    WHERE yhtio     = '{$kukarow['yhtio']}'
-                    AND laji        = 'korjaus'
-                    AND rivitunnus != 0
-                    AND rivitunnus  = '{$trow['rivitunnus']}'
+                    WHERE yhtio    = '{$kukarow['yhtio']}'
+                    AND laji       = 'korjaus'
+                    AND rivitunnus > 0
+                    AND rivitunnus = '{$trow['rivitunnus']}'
                     ORDER BY laadittu DESC, tunnus DESC
                     LIMIT 1";
           $hinta_chk_res = pupe_query($query);
@@ -824,12 +824,12 @@ if ($tuoteno != '') {
           // Nyt lasketaan kaikki hankintahinnat uusiksi
           $query = "SELECT tuoteno, laadittu, laji, kpl, kplhinta, hinta, tunnus, rivitunnus
                     FROM tapahtuma
-                    WHERE yhtio   = '$kukarow[yhtio]'
-                    AND tuoteno   = '$tuoteno'
-                    AND laadittu  >= '$pvm'
+                    WHERE yhtio     = '$kukarow[yhtio]'
+                    AND tuoteno     = '$tuoteno'
+                    AND laadittu   >= '$pvm'
                     AND rivitunnus >= 0
-                    AND laji     != 'korjaus'
-                    AND kpl       <> 0
+                    AND laji       != 'korjaus'
+                    AND kpl        <> 0
                     ORDER BY laadittu, tunnus";
           $result = pupe_query($query);
 
@@ -860,10 +860,10 @@ if ($tuoteno != '') {
               // Katsotaan löytyykö tälle tapahtumariville korjausrivi ja otetaan edellinen kehahin sieltä
               $query = "SELECT kplhinta, hinta
                         FROM tapahtuma
-                        WHERE yhtio     = '{$kukarow['yhtio']}'
-                        AND laji        = 'korjaus'
-                        AND rivitunnus != 0
-                        AND rivitunnus  = '{$rivitunnuslisa}'
+                        WHERE yhtio    = '{$kukarow['yhtio']}'
+                        AND laji       = 'korjaus'
+                        AND rivitunnus > 0
+                        AND rivitunnus = '{$rivitunnuslisa}'
                         ORDER BY laadittu DESC, tunnus DESC
                         LIMIT 1";
               $hinta_chk_res = pupe_query($query);


### PR DESCRIPTION
Konvertoitu tapahtuma = tapahtuma.rivitunnus < 0 tai 0 (siirto ja uusipaikka).

Tämä bränchi korjaa tulevat jälkilaskennat tilanteessa, missä useamman yrityksen tapahtumia on konvertoitu yhdelle yritykselle, ja jälkilasketaan tapahtumaa, jonka jälkeen ja ennen, on konvertoituja tapahtumia.

Edellisen kehahinnan haussa hypätään siirtojen yli, jotta ei saada sieltä vahingossa konvertoitua hintaa. Siirron aikana kehahin ei ole voinut muuttua, joten sen yli voidaan hyppää (se ei myöskään voi olla ensimmäinen tapahtuma).

Saldomuutos-laskenta vaatii myös, että on tehty oikein konversiossa suoritettu konversion alkusaldotapahtuma (esim tuloutus). Jos alkusaldotapahtumalle on tehty vastakirjaus, niin sen kuuluu osua kategoriaan "konvertoitu tapahtuma", ja alkosaldotapahtuman kuuluu olla normaali tapahtuma.
