### PR TITLE
Tilauksesta varastosiirto, rivit var H aina

### DIFF
--- a/tilauskasittely/tilauksesta_varastosiirto.inc
+++ b/tilauskasittely/tilauksesta_varastosiirto.inc
@@ -247,8 +247,7 @@ if (!function_exists('luo_varastosiirtorivi')) {
     $korvaavakielto   = 1;
     $perhekielto      = $lapsituotteet == "" ? 1 : 0;
     $orvoteikiinnosta = "EITOD";
-    $var              = '';
-    $varataan_saldoa  = 'EI';
+    $var              = 'H';
 
     //Laitetaan tuote oletusvaraston tuotepaikalle
     $tuotteen_oletuspaikka = hae_tuotteen_tuotepaikat($tilausrivi['tuoteno'], $tilausrivi['kohdevarasto_tunnus']);


### PR DESCRIPTION
Myyntitilauksen kautta luotu siirtolistarivi meni aikaisemmin var tyhjänä, mutta myyntitilauksella rivien lisäyksen yhteydessä on jo katsottu, että myytävissä määrä riittää. Jos kuitenkin ehti tulla varauksia (esim jälkitoimitusrivejä) ennen kuin tilaus laitettiin valmiiksi, sotki ne siirtolistalle lisättyjä rivejä (menivät var P / J). Myytävissä määrä kuitenkin kuuluu siirtolistariville, mikäli myyntirivin lisäyksen aikana määrä riitti.
