### PR TITLE
Magento-rajapinnan päivitys

### DIFF
--- a/rajapinnat/tuote_export.php
+++ b/rajapinnat/tuote_export.php
@@ -851,6 +851,11 @@ if (isset($verkkokauppatyyppi) and $verkkokauppatyyppi == "magento") {
     $magento_client->setVerkkokauppatuotteetErikoisparametrit($verkkokauppatuotteet_erikoisparametrit);
   }
 
+  // Magentossa k‰sin hallitut kategoriat jotka s‰ilytet‰‰n aina tuotep‰ivityksess‰
+  if(isset($magento_sticky_kategoriat) and count($magento_sticky_kategoriat) > 0) {
+    $magento_client->setStickyKategoriat($magento_sticky_kategoriat);
+  }
+
   // lisaa_kategoriat
   if (count($dnstuoteryhma) > 0) {
     echo date("d.m.Y @ G:i:s")." - P‰ivitet‰‰n tuotekategoriat\n";


### PR DESCRIPTION
- Magenton tarjoushinta(special_price) voidaan määritellä tulemaan esimerkiksi hinnastosta tai kentästä tuotteen takaa
- Asetuksissa annetut custom-parametrit siirtyvät myös configurable-tuotteelle
- Asetuksissa voi antaa Magenton kategoria id:t joita ei koskaan poisteta tuotteelta product_updatessa. Tämä siksi että käsin hallinnoidut tuoteryhmien/tuotepuun ulkopuoliset kategoriat säilyvät tuotetta päivittäessä.
