### PR TITLE
Vapautetaan tuoteperheet oikein

### DIFF
--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -1128,6 +1128,7 @@ if (!function_exists("tee_jt_tilaus")) {
                       WHERE yhtio   = '$kukarow[yhtio]'
                       and otunnus   = '$id'
                       and perheid2 != 0
+                      and tyyppi != 'D'
                       GROUP by perheid2";
             $copresult = pupe_query($query);
 


### PR DESCRIPTION
Vapautettaessa tuoteperheitä ja kun ollaan vapauttamassa isätuotetta ja luodaan siinä samalla isätuotteelle uusi rivi niin päivitetään tuoteperheen jäsenille uuden isätuotteen tunnus perheid:ksi jotta saadaan tuoteperhe toimimaan oikein uuden isän mukaan. Aiemmin tietoihin jäi vanhan isän id jolloin uusi isä oli ominaisuuksiltaan tuoteperheen lapsi eikä sen isätuote.
