### PR TITLE
Ei toimipaikkaa rajaus toimi väärin

### DIFF
--- a/yllapito.php
+++ b/yllapito.php
@@ -1055,6 +1055,10 @@ for ($i=0; $i<=$count; $i++) {
       $tarkkahaku = TRUE;
       $hakuehto = " = '{$haku[$i]}' ";
     }
+    elseif ($toim == 'asiakas' and $array[$i] == "toimipaikka") {
+      $tarkkahaku = FALSE;
+      $hakuehto = " = '{$haku[$i]}' ";
+    }
     else {
       $tarkkahaku = FALSE;
       $hakuehto = " like '%{$haku[$i]}%' ";


### PR DESCRIPTION
Jos asiakkaan toimipaikkanumerossa oli nolla (esim. 40), otettiin mukaan ei toimipaikka -rajauksella
