### PR TITLE
ZF - sscc -korjaus

### DIFF
--- a/sisaanlue_teccom_asn.php
+++ b/sisaanlue_teccom_asn.php
@@ -89,8 +89,8 @@ if (!function_exists('teccom_asn_paketti')) {
         }
       }
 
-      $laatikkoind = $laatikko;
-      $sscc = $laatikko;
+      $_laatikkoind = $laatikko;
+      $_sscc = $laatikko;
     }
     elseif ($tavarantoimittajanumero == "123220" or $tavarantoimittajanumero == "123080") {
       $_laatikkoind = $asn_numero;


### PR DESCRIPTION
Kentät nimet oli väärin niin, että ZF:n sscc:t eivät päivittyneet kantaan lainkaan.
