### PR TITLE
Tuloutus aina oletuspaikalle

### DIFF
--- a/mobiili/hyllytys.php
+++ b/mobiili/hyllytys.php
@@ -16,29 +16,48 @@ if (empty($ostotilaus) or empty($tilausrivi)) {
 # Haetaan tilausrivin ja laskun tiedot
 /* Ostotilausten_kohdistus rivi 847 - 895 */
 $query = "SELECT
-          tilausrivi.varattu+tilausrivi.kpl siskpl,
+          tilausrivi.varattu+tilausrivi.kpl AS siskpl,
           tilausrivi.tuoteno,
-          round((tilausrivi.varattu+tilausrivi.kpl) * if (tuotteen_toimittajat.tuotekerroin<=0 or tuotteen_toimittajat.tuotekerroin is null,1,tuotteen_toimittajat.tuotekerroin),2) ulkkpl,
+          round((tilausrivi.varattu+tilausrivi.kpl) * 
+            if (tuotteen_toimittajat.tuotekerroin <= 0 
+              OR tuotteen_toimittajat.tuotekerroin is null, 1, tuotteen_toimittajat.tuotekerroin), 
+            2) AS ulkkpl,
           tuotteen_toimittajat.toim_tuoteno,
           tuotteen_toimittajat.tuotekerroin,
-          concat_ws(' ',tilausrivi.hyllyalue, tilausrivi.hyllynro, tilausrivi.hyllyvali, tilausrivi.hyllytaso) as kerayspaikka,
+          concat_ws(' ',
+            tuotepaikat.hyllyalue, 
+            tuotepaikat.hyllynro, 
+            tuotepaikat.hyllyvali, 
+            tuotepaikat.hyllytaso) AS kerayspaikka,
           tilausrivi.varattu,
           tilausrivi.yksikko,
           tilausrivi.suuntalava,
           tilausrivi.uusiotunnus,
           lasku.liitostunnus,
           toimi.selaus,
-          IFNULL(tilausrivin_lisatiedot.suoraan_laskutukseen, 'NORM') as tilausrivi_tyyppi,
-          IFNULL(tilausrivin_lisatiedot.tilausrivitunnus, 0) as tilausrivitunnus
+          IFNULL(tilausrivin_lisatiedot.suoraan_laskutukseen, 'NORM') AS tilausrivi_tyyppi,
+          IFNULL(tilausrivin_lisatiedot.tilausrivitunnus, 0) AS tilausrivitunnus
           FROM lasku
-          JOIN tilausrivi ON tilausrivi.yhtio=lasku.yhtio and tilausrivi.otunnus=lasku.tunnus and tilausrivi.tyyppi='O'
-          JOIN tuotteen_toimittajat on (tuotteen_toimittajat.tuoteno=tilausrivi.tuoteno and tuotteen_toimittajat.yhtio=tilausrivi.yhtio)
-          JOIN toimi ON (toimi.yhtio = tuotteen_toimittajat.yhtio AND toimi.tunnus = tuotteen_toimittajat.liitostunnus)
+          JOIN tilausrivi 
+            ON (tilausrivi.yhtio = lasku.yhtio 
+              AND tilausrivi.otunnus = lasku.tunnus 
+              AND tilausrivi.tyyppi='O')
+          JOIN tuotteen_toimittajat 
+            ON (tuotteen_toimittajat.tuoteno = tilausrivi.tuoteno 
+              AND tuotteen_toimittajat.yhtio = tilausrivi.yhtio)
+          JOIN toimi 
+            ON (toimi.yhtio = tuotteen_toimittajat.yhtio 
+              AND toimi.tunnus = tuotteen_toimittajat.liitostunnus)
           LEFT JOIN tilausrivin_lisatiedot
-          ON ( tilausrivin_lisatiedot.yhtio = lasku.yhtio AND tilausrivin_lisatiedot.tilausrivilinkki = tilausrivi.tunnus )
-          WHERE tilausrivi.tunnus='{$tilausrivi}'
-          AND tilausrivi.yhtio='{$kukarow['yhtio']}'
-          AND lasku.tunnus='{$ostotilaus}'
+            ON (tilausrivin_lisatiedot.yhtio = lasku.yhtio 
+              AND tilausrivin_lisatiedot.tilausrivilinkki = tilausrivi.tunnus)
+          JOIN tuotepaikat 
+            ON (tuotepaikat.yhtio = lasku.yhtio 
+              AND tuotepaikat.tuoteno = tilausrivi.tuoteno
+              AND tuotepaikat.oletus = 'X') 
+          WHERE tilausrivi.tunnus = '{$tilausrivi}'
+          AND tilausrivi.yhtio = '{$kukarow['yhtio']}'
+          AND lasku.tunnus = '{$ostotilaus}'
           AND lasku.vanhatunnus = '{$kukarow['toimipaikka']}'";
 $result = pupe_query($query);
 $row = mysql_fetch_assoc($result);

--- a/mobiili/vahvista_kerayspaikka.php
+++ b/mobiili/vahvista_kerayspaikka.php
@@ -35,9 +35,19 @@ if (!empty($alusta_tunnus)) {
 if(!isset($row)) {
   $query = "SELECT
             tilausrivi.*,
+            tuotepaikat.hyllyalue,
+            tuotepaikat.hyllynro,
+            tuotepaikat.hyllyvali,
+            tuotepaikat.hyllytaso,
             tuotteen_toimittajat.toim_tuoteno
             FROM tilausrivi
-            LEFT JOIN tuotteen_toimittajat on (tuotteen_toimittajat.tuoteno=tilausrivi.tuoteno and tuotteen_toimittajat.yhtio=tilausrivi.yhtio)
+            LEFT JOIN tuotteen_toimittajat
+              ON (tuotteen_toimittajat.tuoteno=tilausrivi.tuoteno
+                AND tuotteen_toimittajat.yhtio=tilausrivi.yhtio)
+            JOIN tuotepaikat
+              ON (tuotepaikat.yhtio = tilausrivi.yhtio
+                AND tuotepaikat.tuoteno = tilausrivi.tuoteno
+                AND tuotepaikat.oletus = 'X')
             WHERE tilausrivi.tunnus='{$tilausrivi}'
             AND tilausrivi.yhtio='{$kukarow['yhtio']}'";
   $row = mysql_fetch_assoc(pupe_query($query));


### PR DESCRIPTION
Tehdään tuloutus aina oletuspaikalle. 

Lisättiin siis seuraava JOINi rivin 18//hyllytys.php hakuun ja rivin 36//vahvista_kerayspaikka.php hakuihi, että saadaan oletuspaikka siksi paikaksi jolle ollaan tulouttamassa.
JOIN tuotepaikat 
ON (tuotepaikat.yhtio = lasku.yhtio 
AND tuotepaikat.tuoteno = tilausrivi.tuoteno
AND tuotepaikat.oletus = 'X')

Samalla myös korjattiin rivien pituudet ja muutenkin query yms. jutut ohjeen mukaisiksi näissä queryissä joihin tehtiin muutoksia.
