### PR TITLE
Ei monisteta viitettä

### DIFF
--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -359,6 +359,7 @@ if (!function_exists("tee_jt_tilaus")) {
               $fieldname == 'maksuaika' or
               $fieldname == 'lahetepvm' or
               $fieldname == 'h1time' or
+              $fieldname == 'viite' or
               $fieldname == 'laskunro' or
               $fieldname == 'mapvm' or
               $fieldname == 'kerayslista' or
@@ -378,15 +379,6 @@ if (!function_exists("tee_jt_tilaus")) {
               $fieldname == 'poistumistoimipaikka' or
               $fieldname == 'poistumistoimipaikka_koodi') {
             $query .= $fieldname."='',";
-          }
-          elseif ($fieldname == 'viite') {
-            // Jos asiakkaan tilausnumero huomioida otsikon etsinn‰ss‰, ei nollata viitett‰k‰‰n
-            if ($yhtiorow['jt_asiakkaan_tilausnumero'] == "K") {
-              $query .= $fieldname."='".$otsikkorivi[$fieldname]."',";
-            }
-            else {
-              $query .= $fieldname."='',";
-            }
           }
           elseif ($fieldname == 'kate_korjattu') {
             $query .= $fieldname." = NULL,";


### PR DESCRIPTION
Ei monisteta otsikon viite kentän tietoa koska sinne tallenetaan laskun viitenumero ja se on yksi niistä tiedoista joiden tulee olla tyhjiä, jotta tilaukset katsotaan laskutuskelposiksi -> jos lasku.viite kenttä ei ole tyhjä tilausta ei voida laskuttaa.
