### PR TITLE
Tehtäessä JT-rivejä setataan otsikon varasto fix

### DIFF
--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -3325,7 +3325,7 @@ if ($_yhteen_varastoon and $_sopivatilaustoimi and !in_array($var, array('S', 'U
   $myy_hyllynro_temp  = $myy_hyllynro[0];
 
   $_normi_tyhja       = (empty($myy_hyllyalue) and empty($myy_hyllynro));
-  $_puute_ei_tyhja    = (isset($p_hyllyalue) and isset($p_hyllynro));
+  $_puute_ei_tyhja    = ($p_hyllyalue != "" and $p_hyllynro != "");
   $_puutteesta_hyllyt = ($_normi_tyhja and $_puute_ei_tyhja);
 
   if ($_puutteesta_hyllyt) {


### PR DESCRIPTION
Koska $p_hyllyalue ja $p_hyllynro on molemmat stringejä niin katsotaan vaan suoraan ettei ne ole tyhjiä eikä käytetä empty-funktiota, koska hyllyalue tai hyllynro voi olla myös 0, jolloin empty ei toimi ihan niinkun pitäs...
