### PR TITLE
Kerattyaika nätimmin näytätilausta

### DIFF
--- a/raportit/naytatilaus.inc
+++ b/raportit/naytatilaus.inc
@@ -332,7 +332,7 @@ if ($laskurow["tila"] != "O" and $laskurow["tila"] != "K") {
 if (($laskurow["tila"] == "L" or $laskurow["tila"] == "N") and $kukarow["extranet"] == "") {
 
   $query = "SELECT
-            max(if(tilausrivi.keratty = 'saldoton', '9999-99-99 23:25:59', tilausrivi.kerattyaika)) kerattyaika,
+            max(tilausrivi.kerattyaika) kerattyaika,
             max(tilausrivi.toimaika) toimaika,
             max(tilausrivi.toimitettuaika) toimitettuaika
             FROM tilausrivi


### PR DESCRIPTION
Ei laiteta siihen kerättyaika kenttään 9999-99-99, vaikka saldoton tuota koska muuten jos on rahtia niin silloin näytetään tilauksen kerättyaikana 9999-99-99. Selkeämpää vaan näyttää se sinne riveille setattu kerättyaika myös saldottomien tuotteiden tapauksesssa
