### PR TITLE
Haetaan avainsanat yhtiön kielen mukaan

### DIFF
--- a/inc/asiakashinta.inc
+++ b/inc/asiakashinta.inc
@@ -8,35 +8,29 @@ if ($from == "") {
   $kentat = "asiakashinta.tunnus,
   concat_ws('<br>', asiakashinta.asiakas,
   (SELECT asiakas.nimi
-  FROM asiakas
-  WHERE asiakashinta.yhtio = asiakas.yhtio
-    AND asiakashinta.asiakas = asiakas.tunnus))
-  Asiakas, asiakashinta.ytunnus 'Ytunnus',
-#   concat_ws('<br>', asiakashinta.ytunnus,
-#   (SELECT group_concat(distinct asiakas.nimi separator '<br>')
-#   FROM asiakas
-#   WHERE asiakashinta.yhtio = asiakas.yhtio
-#     AND asiakashinta.ytunnus = asiakas.ytunnus
-#     AND asiakas.ytunnus != '')) 'Ytunnus',
+   FROM asiakas
+   WHERE asiakashinta.yhtio = asiakas.yhtio
+   AND asiakashinta.asiakas = asiakas.tunnus)) Asiakas,
+  asiakashinta.ytunnus 'Ytunnus',
   (SELECT concat(dynaaminen_puu.tunnus, '<br>', dynaaminen_puu.nimi)
-  FROM dynaaminen_puu
-  WHERE dynaaminen_puu.tunnus = asiakashinta.asiakas_segmentti
-    AND dynaaminen_puu.yhtio = asiakashinta.yhtio) 'Asiakaspuu',
+   FROM dynaaminen_puu
+   WHERE dynaaminen_puu.tunnus = asiakashinta.asiakas_segmentti
+   AND dynaaminen_puu.yhtio = asiakashinta.yhtio) 'Asiakaspuu',
   (SELECT concat(avainsana.selite, '<br>', avainsana.selitetark) FROM avainsana
-  WHERE avainsana.laji = 'asiakasryhma'
-    AND avainsana.selite = asiakashinta.asiakas_ryhma
-    AND avainsana.yhtio = asiakashinta.yhtio
-    AND avainsana.kieli = '{$yhtiorow["kieli"]}') 'Asiakasryhma',
+   WHERE avainsana.laji = 'asiakasryhma'
+   AND avainsana.selite = asiakashinta.asiakas_ryhma
+   AND avainsana.yhtio = asiakashinta.yhtio
+   AND avainsana.kieli = '{$yhtiorow["kieli"]}') 'Asiakasryhma',
   (SELECT concat(avainsana.selite, '<br>', avainsana.selitetark)
-  FROM avainsana
-  WHERE avainsana.laji = 'piiri'
-    AND avainsana.selite = asiakashinta.piiri
-    AND avainsana.yhtio = asiakashinta.yhtio
-    AND avainsana.kieli = '{$yhtiorow["kieli"]}') 'Piiri',
+   FROM avainsana
+   WHERE avainsana.laji = 'piiri'
+   AND avainsana.selite = asiakashinta.piiri
+   AND avainsana.yhtio = asiakashinta.yhtio
+   AND avainsana.kieli = '{$yhtiorow["kieli"]}') 'Piiri',
   (SELECT concat(tuote.tuoteno, '<br>', LEFT (tuote.nimitys,35))
-  FROM tuote
-  WHERE tuote.tuoteno = asiakashinta.tuoteno
-    AND tuote.yhtio = asiakashinta.yhtio) 'Tuoteno',
+   FROM tuote
+   WHERE tuote.tuoteno = asiakashinta.tuoteno
+   AND tuote.yhtio = asiakashinta.yhtio) 'Tuoteno',
   asiakashinta.ryhma 'Alennusryhmä',
   asiakashinta.hinta,
   asiakashinta.laji,


### PR DESCRIPTION
Asiakashintojen haussa haetaan avainsanaliitokset yhtiön kielen mukaan, jotta avainsanojen mahdolliset eri kieliversiot eivät rikkoisi queryä.

Samalla tehtiin kyseisen queryn kenttä osion ohjeenmukaistus.
