### PR TITLE
Ostotilausten tulostuksen liitenimet kuntoon

### DIFF
--- a/tilauskasittely/tulosta_ostotilaus.inc
+++ b/tilauskasittely/tulosta_ostotilaus.inc
@@ -634,8 +634,14 @@ else {
           $liite = $pdffilenimi;
           $kutsu = t("Ostotilaus", $kieli)." $laskurow[tunnus]";
 
+          $korvattavat = array("/", "\\");
+          $laskunimi = ", ";
+          $laskunimi .= trim(str_replace($korvattavat, " ", $laskurow["nimi"]));
+          $laskunimi .= ", ";
+          $laskunimi .= trim(str_replace($korvattavat, " ", $laskurow["toim_nimi"]));
+
           if ($yhtiorow["liitetiedostojen_nimeaminen"] == "N") {
-            $kutsu .= ", ".trim($laskurow["nimi"]).", ".trim($laskurow["toim_nimi"]);
+            $kutsu .= $laskunimi;
           }
 
           require "inc/sahkoposti.inc";


### PR DESCRIPTION
Poistetaan tiedostojen nimistä / ja \ merkit, jotta liitetiedoston nimeä ei tämän takia lyhennettäisi, kun luulaan että liitetiedoston nimeen kuuluva / tai \ merkki on osa tiedostopolun jakoa.
