### PR TITLE
BUGFIX: Kuittaa siirtolista vastaanotetuksi

### DIFF
--- a/tilauskasittely/vastaanota.php
+++ b/tilauskasittely/vastaanota.php
@@ -1074,13 +1074,13 @@ if (empty($id) and $echotaanko) {
 
   $ed_lahto = $ed_vastaanottonro = null;
 
-  $_tulostustapa = $yhtiorow['siirtolistan_tulostustapa'];
+  $_tulostustapa = ($yhtiorow['siirtolistan_tulostustapa'] == 'U');
 
   while ($tilrow = mysql_fetch_assoc($tilre)) {
 
     $_suljettu_lahto = (!is_null($tilrow['lahdon_aktiivi']) and $tilrow['lahdon_aktiivi'] != 'S');
 
-     if ($_tulostustapa == 'U' and $_suljettu_lahto) {
+     if ($_tulostustapa and $_suljettu_lahto) {
         //Jos siirtolistan_tulostustapa = Siirtolistat tulostetaan keräyserien kautta
         //Ei näytetä siirtolistoja, joihin on liitetty aukioleva lähtö
         continue;


### PR DESCRIPTION
Jos siirtolistat tulostetaan keräyserien kautta ja siirtolistalla on lähtö, niin lähdön pitää olla aktiivi jotta se näkyy listassa.
