### PR TITLE
Tilausvahvistustyypin vaihdoin logiikka oikein

### DIFF
--- a/inc/valitse_tulostin.inc
+++ b/inc/valitse_tulostin.inc
@@ -111,7 +111,9 @@ if ($toim == "LAHETE" and $yhtiorow["lahete_tyyppi_tulostus"] != '' and $otunnus
   $mista = 'asiakas';
 }
 
-if ($toim == "TILAUSVAHVISTUS" and $yhtiorow["tilausvahvistus_tyyppi_tulostus"] == '' and $otunnus != '') {
+if ($toim == "TILAUSVAHVISTUS"
+  and $yhtiorow["tilausvahvistus_tyyppi_tulostus"] != ''
+  and $otunnus != '') {
 
   $query2 = "SELECT tilausvahvistus, liitostunnus
              FROM lasku


### PR DESCRIPTION
Tilausvahvistuksen kopion tulostuksessa katsotaan yhtiön parametristä "tilausvahvistus_tyyppi_tulostus" saako kopion tulostuksessa vaihtaa tilausvahvistuksen tyyppiä. Nyt tulostuksessa meni vaan logiikka väärin päin koska "saa vaihtaa" on parametrin arvolla "K" ja "ei saa vaihtaa" on parametrin arvolla "_tyhjä_". Eli kun saa vaihtaa tyyppiä niin silloin parametri ei saa olla _tyhja_.
