### PR TITLE
Saldottomat isät näkyviin perheineen

### DIFF
--- a/tilauskasittely/jtselaus.php
+++ b/tilauskasittely/jtselaus.php
@@ -1002,8 +1002,7 @@ if ($tee == "JATKA") {
                 WHERE tilausrivi.yhtio     = '$kukarow[yhtio]'
                 AND tilausrivi.tyyppi      IN ('L','G')
                 AND tilausrivi.var         = 'J'
-                AND (tilausrivi.keratty = ''
-                  OR (tuote.ei_saldoa != '' AND tilausrivi.tunnus = tilausrivi.perheid))
+                AND tilausrivi.keratty IN ('', 'saldoton')
                 AND tilausrivi.uusiotunnus = 0
                 AND tilausrivi.kpl         = 0
                 AND tilausrivi.jt + tilausrivi.varattu  > 0
@@ -1070,8 +1069,7 @@ if ($tee == "JATKA") {
                 WHERE tilausrivi.yhtio     = '$kukarow[yhtio]'
                 AND tilausrivi.tyyppi      IN ('L','G')
                 AND tilausrivi.var         = 'J'
-                AND (tilausrivi.keratty = ''
-                  OR (tuote.ei_saldoa != '' AND tilausrivi.tunnus = tilausrivi.perheid))
+                AND tilausrivi.keratty IN ('', 'saldoton')
                 AND tilausrivi.uusiotunnus = 0
                 AND tilausrivi.kpl         = 0
                 AND tilausrivi.jt  + tilausrivi.varattu  > 0


### PR DESCRIPTION
Näytetään saldottomat isät perheineen JT-selauksessa, jotta päästään myös tätä kautta vapauttamaan tälläiset JT-rivit.

Tämän lisäksi putsattiin kyseessä olevat queryt ohjeen mukaisiksi.

---

Note:
Varsinaiset muutokset riveillä 1005-1006 ja 1073-1074
