### PR TITLE
Uudet otsikkovaihtoehdot pakettikortille

### DIFF
--- a/tilauskasittely/rahtikirja_postitarra_ulkomaa_pdf.inc
+++ b/tilauskasittely/rahtikirja_postitarra_ulkomaa_pdf.inc
@@ -133,7 +133,7 @@ for ($tulostuskpl=1; $tulostuskpl<=$tulostakolli; $tulostuskpl++) {
     $pdf->image_place($image, 560, 70, $firstpage, $logoparam);
   }
   else {
-    $pdf->draw_text(65, 570,  $toitarow['virallinen_selite'], $firstpage, $norm);
+    $pdf->draw_text(65, 570,  $selite_chk, $firstpage, $norm);
   }
 
   if (class_exists("Image_Barcode")) {


### PR DESCRIPTION
Ulkomaan pakettikortille kaksi uutta otsikkovaihtoehtoa "ITELLA EXPRESS BUSINESS DAY PARCEL" & "ITELLA EXPRESS BUSINESS DAY PALLET". Toimitustavalla tulee olla kyseinen nimi, jotta uusi otsikko pakettikortille tulostetaan.
