### PR TITLE
BUGFIX: Siirtorivien sisäänluku

### DIFF
--- a/tilauskasittely/mikrotilaus_siirtolista.inc
+++ b/tilauskasittely/mikrotilaus_siirtolista.inc
@@ -105,6 +105,7 @@ if ($tee == "file") {
           $toimaika  = '';
           $paikka    = '';
           $alv    = 'X';
+          unset($kohde_alue);
 
           for ($alepostfix = 1; $alepostfix <= $yhtiorow['myynnin_alekentat']; $alepostfix++) {
             ${'ale'.$alepostfix} = '';


### PR DESCRIPTION
Unsetataan kohdealue muuttuja joka rivin lisäyksen lopussa, jotta seuraaville riville ei mene samaa kohdealuetta.
