### PR TITLE
Näytetään toimitusosoitteen postitoimpaikka

### DIFF
--- a/muokkaatilaus.php
+++ b/muokkaatilaus.php
@@ -847,10 +847,8 @@ else {
   }
 
   if ($asiakastiedot == "toimitus") {
-    $asiakasstring = "  concat_ws('<br>', lasku.ytunnus, lasku.nimi, lasku.nimitark,
-                          if(lasku.nimi != lasku.toim_nimi,
-                            concat_ws(' ', lasku.toim_nimi, lasku.toim_nimitark, lasku.toim_postitp),
-                            NULL))";
+    $asiakasstring = "  concat_ws('<br>', lasku.ytunnus, concat_ws(' ', lasku.nimi, lasku.nimitark),
+                        concat_ws(' ', lasku.toim_nimi, lasku.toim_nimitark, lasku.toim_postitp))";
     $assel1 = "";
     $assel2 = "CHECKED";
   }


### PR DESCRIPTION
Muokkaa tilausta näkymässä valittaessa "Näytä myös toimitusasiakkaan tiedot" näytetään toimitusosoitteen paikkakunta silti vaikka laskutusosoitteen ja toimitusosoiteen toimipakka olisikin sama. Helpottaa oikean tilauksen löytämistä myös niissä tapauksissa joissa toimitus ja lasku menossa samalle paikkakunnalle (vaikka eri osoitteisiin//eri asiakkaille)
