### PR TITLE
Kirjanpidollinen varastosiirto seuraa laskutuspäivää.

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -24767,6 +24767,9 @@ if (!function_exists('hyllysiirto')) {
 
     if (!isset($params['tun'])) $error = true;
     else $tun = (int) $params['tun'];
+    
+    if (!isset($params['poikkeavalaskutuspvm'])) $_poikkeavalaskutuspvm = '';
+    else $_poikkeavalaskutuspvm = $params['poikkeavalaskutuspvm'];
 
     if ($error) return false;
 
@@ -24870,6 +24873,15 @@ if (!function_exists('hyllysiirto')) {
       $selite = "";
     }
 
+    if ($_poikkeavalaskutuspvm != '') {
+      $_laadittu = $_poikkeavalaskutuspvm." 23:59:59";
+      $_tapvm = $_poikkeavalaskutuspvm;
+    }
+    else {
+      $_laadittu = date("Y-m-d H:i:s");
+      $_tapvm = date("Y-m-d");
+    }
+
     $query = "INSERT into tapahtuma set
               yhtio      = '{$kukarow['yhtio']}',
               tuoteno    = '{$tuoteno}',
@@ -24883,7 +24895,7 @@ if (!function_exists('hyllysiirto')) {
               rivitunnus = {$tun},
               selite     = '".t("Paikalta")." {$mista_texti} ".t("vähennettiin")." {$kappaleet}{$selite}',
               laatija    = '{$kukarow['kuka']}',
-              laadittu   = now()";
+              laadittu   = '$_laadittu'";
     $result = pupe_query($query);
     $mista_tapa_tunnus = mysql_insert_id($GLOBALS["masterlink"]);
 
@@ -24900,7 +24912,7 @@ if (!function_exists('hyllysiirto')) {
               rivitunnus = {$tun},
               selite     = '".t("Paikalle")." {$minne_texti} ".t("lisättiin")." {$kappaleet}{$selite}',
               laatija    = '{$kukarow['kuka']}',
-              laadittu   = now()";
+              laadittu   = '$_laadittu'";
     $result = pupe_query($query);
     $minne_tapa_tunnus = mysql_insert_id($GLOBALS["masterlink"]);
 
@@ -25021,7 +25033,7 @@ if (!function_exists('hyllysiirto')) {
                       FROM lasku
                       WHERE tila  = 'X'
                       and alatila = 'G'
-                      and tapvm   = current_date
+                      and tapvm   = '$_tapvm'
                       and yhtio   = '$kukarow[yhtio]'";
             $result = pupe_query($query);
 
@@ -25034,11 +25046,11 @@ if (!function_exists('hyllysiirto')) {
           if ($laskuid == 0) {
             $query = "INSERT into lasku set
                       yhtio      = '$kukarow[yhtio]',
-                      tapvm      = now(),
+                      tapvm      = '$_tapvm',
                       tila       = 'X',
                       alatila    = 'G',
                       laatija    = '$kukarow[kuka]',
-                      luontiaika = current_date";
+                      luontiaika = '$_laadittu'";
             $result = pupe_query($query);
             $laskuid = mysql_insert_id($GLOBALS["masterlink"]);
           }
@@ -25051,14 +25063,14 @@ if (!function_exists('hyllysiirto')) {
                     kustp           = '{$mista_kustp}',
                     kohde           = '{$mista_kohde}',
                     projekti        = '{$mista_projekti}',
-                    tapvm           = current_date,
+                    tapvm           = '$_tapvm',
                     summa           = {$varastonmuutos_neg},
                     vero            = 0,
                     lukko           = '',
                     tapahtumatunnus = $mista_tapa_tunnus,
                     selite          = '".t("Paikalta")." {$mista_texti} ".t("vähennettiin")." ".t("tuotetta")." {$tuoteno} {$kappaleet}{$selite}',
                     laatija         = '$kukarow[kuka]',
-                    laadittu        = now()";
+                    laadittu        = '$_laadittu'";
           $result = pupe_query($query);
 
           // Mistä varastonmuutos
@@ -25069,14 +25081,14 @@ if (!function_exists('hyllysiirto')) {
                     kustp           = '{$mista_kustp}',
                     kohde           = '{$mista_kohde}',
                     projekti        = '{$mista_projekti}',
-                    tapvm           = current_date,
+                    tapvm           = '$_tapvm',
                     summa           = {$varastonmuutos},
                     vero            = 0,
                     lukko           = '',
                     tapahtumatunnus = $mista_tapa_tunnus,
                     selite          = '".t("Paikalta")." {$mista_texti} ".t("vähennettiin")." ".t("tuotetta")." {$tuoteno} {$kappaleet}{$selite}',
                     laatija         = '$kukarow[kuka]',
-                    laadittu        = now()";
+                    laadittu        = '$_laadittu'";
           $result = pupe_query($query);
 
           // jos ostotili löytyy, tehdään sinne kirjaukset kanssa
@@ -25089,14 +25101,14 @@ if (!function_exists('hyllysiirto')) {
                       kustp           = '{$mista_kustp}',
                       kohde           = '{$mista_kohde}',
                       projekti        = '{$mista_projekti}',
-                      tapvm           = current_date,
+                      tapvm           = '$_tapvm',
                       summa           = {$varastonmuutos_neg},
                       vero            = 0,
                       lukko           = '',
                       tapahtumatunnus = $mista_tapa_tunnus,
                       selite          = '".t("Paikalta")." {$mista_texti} ".t("vähennettiin")." ".t("tuotetta")." {$tuoteno} {$kappaleet}{$selite}',
                       laatija         = '$kukarow[kuka]',
-                      laadittu        = now()";
+                      laadittu        = '$_laadittu'";
             $result = pupe_query($query);
 
             // Minne ostotili
@@ -25107,14 +25119,14 @@ if (!function_exists('hyllysiirto')) {
                       kustp           = '{$minne_kustp}',
                       kohde           = '{$minne_kohde}',
                       projekti        = '{$minne_projekti}',
-                      tapvm           = current_date,
+                      tapvm           = '$_tapvm',
                       summa           = {$varastonmuutos},
                       vero            = 0,
                       lukko           = '',
                       tapahtumatunnus = $minne_tapa_tunnus,
                       selite          = '".t("Paikalle")." {$minne_texti} ".t("lisättiin")." ".t("tuotetta")." {$tuoteno} {$kappaleet}{$selite}',
                       laatija         = '$kukarow[kuka]',
-                      laadittu        = now()";
+                      laadittu        = '$_laadittu'";
             $result = pupe_query($query);
           }
 
@@ -25126,14 +25138,14 @@ if (!function_exists('hyllysiirto')) {
                     kustp           = '{$minne_kustp}',
                     kohde           = '{$minne_kohde}',
                     projekti        = '{$minne_projekti}',
-                    tapvm           = current_date,
+                    tapvm           = '$_tapvm',
                     summa           = {$varastonmuutos},
                     vero            = 0,
                     lukko           = '',
                     tapahtumatunnus = $minne_tapa_tunnus,
                     selite          = '".t("Paikalle")." {$minne_texti} ".t("lisättiin")." ".t("tuotetta")." {$tuoteno} {$kappaleet}{$selite}',
                     laatija         = '$kukarow[kuka]',
-                    laadittu        = now()";
+                    laadittu        = '$_laadittu'";
           $result = pupe_query($query);
 
           // Minne varastonmuutos
@@ -25144,14 +25156,14 @@ if (!function_exists('hyllysiirto')) {
                     kustp           = '{$minne_kustp}',
                     kohde           = '{$minne_kohde}',
                     projekti        = '{$minne_projekti}',
-                    tapvm           = current_date,
+                    tapvm           = '$_tapvm',
                     summa           = {$varastonmuutos_neg},
                     vero            = 0,
                     lukko           = '',
                     tapahtumatunnus = $minne_tapa_tunnus,
                     selite          = '".t("Paikalle")." {$minne_texti} ".t("lisättiin")." ".t("tuotetta")." {$tuoteno} {$kappaleet}{$selite}',
                     laatija         = '$kukarow[kuka]',
-                    laadittu        = now()";
+                    laadittu        = '$_laadittu'";
           $result = pupe_query($query);
         }
       }
@@ -27753,7 +27765,7 @@ if (!function_exists('array_column')) {
 }
 
 if (!function_exists('tee_kirjanpidollinen_varastosiirto')) {
-  function tee_kirjanpidollinen_varastosiirto($myyntitilaus_tunnus) {
+  function tee_kirjanpidollinen_varastosiirto($myyntitilaus_tunnus, $_poikkeavalaskutuspvm) {
     global $kukarow, $yhtiorow;
 
     if ($yhtiorow['kirjanpidollinen_varastosiirto_myyntitilaukselta'] == '') {
@@ -27769,7 +27781,7 @@ if (!function_exists('tee_kirjanpidollinen_varastosiirto')) {
       require 'tilauskasittely/tilauksesta_varastosiirto.inc';
 
       //Myyntitilaukselle valittu varasto ei ole yhtion toimipaikan varastoissa. Tällöin tehdään kirjanpidollinen varastosiirto
-      tilauksesta_varastosiirto($myyntitilaus_tunnus, 'K');
+      tilauksesta_varastosiirto($myyntitilaus_tunnus, 'K', $_poikkeavalaskutuspvm);
     }
   }
 }

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -584,6 +584,7 @@ if ($tee == 'N') {
       'sarjano_array' => !isset($sarjano_array) ? array() : $sarjano_array,
       'selite' => !isset($selite) ? '' : $selite,
       'tun' => !isset($tun) ? 0 : $tun,
+      'poikkeavalaskutuspvm' => $_poikkeavalaskutuspvm,
     );
 
     hyllysiirto($params);

--- a/tilauskasittely/tilauksesta_varastosiirto.inc
+++ b/tilauskasittely/tilauksesta_varastosiirto.inc
@@ -14,7 +14,7 @@ if (!function_exists("tilauksesta_varastosiirto")) {
    */
 
 
-  function tilauksesta_varastosiirto($myyntitilaus_tunnus, $varastosiirto_tyyppi = 'N') {
+  function tilauksesta_varastosiirto($myyntitilaus_tunnus, $varastosiirto_tyyppi = 'N', $_poikkeavalaskutuspvm = '') {
     global $yhtiorow, $kukarow;
 
     if (empty($myyntitilaus_tunnus)) {
@@ -25,7 +25,7 @@ if (!function_exists("tilauksesta_varastosiirto")) {
     $myyntitilaus['tilausrivit'] = hae_tilausrivit($myyntitilaus_tunnus, $varastosiirto_tyyppi, true);
 
     if ($varastosiirto_tyyppi == 'K') {
-      $ok = kirjanpidollinen_varastosiirto($myyntitilaus);
+      $ok = kirjanpidollinen_varastosiirto($myyntitilaus, $_poikkeavalaskutuspvm);
     }
     elseif ($varastosiirto_tyyppi == 'N') {
       $ok = normaali_varastosiirto($myyntitilaus);
@@ -39,7 +39,7 @@ if (!function_exists("tilauksesta_varastosiirto")) {
 }
 
 if (!function_exists('kirjanpidollinen_varastosiirto')) {
-  function kirjanpidollinen_varastosiirto($myyntitilaus) {
+  function kirjanpidollinen_varastosiirto($myyntitilaus, $_poikkeavalaskutuspvm) {
     global $kukarow, $yhtiorow;
 
     //Kirjanpidollisessa varastosiirrossa yhdellä myyntitilauksella voi olla vain 1 lähde-kohdevarasto kombinaatio.
@@ -77,8 +77,7 @@ if (!function_exists('kirjanpidollinen_varastosiirto')) {
     aseta_kukarow_kesken($myyntitilaus['tunnus']);
 
     $varastosiirtorivit = hae_tilausrivit($varastosiirto['tunnus'], 'K', false);
-
-    $varastosiirtorivit = aseta_varastosiirto_vastaanotetuksi($varastosiirto, $varastosiirtorivit);
+    $varastosiirtorivit = aseta_varastosiirto_vastaanotetuksi($varastosiirto, $varastosiirtorivit, $_poikkeavalaskutuspvm);
     paivita_myyntitilausrivien_tuotepaikat($varastosiirtorivit);
     linkkaa_varastosiirto_myyntitilaukseen($varastosiirto, $myyntitilaus);
 
@@ -327,7 +326,7 @@ if (!function_exists('aseta_kukarow_kesken')) {
 }
 
 if (!function_exists('aseta_varastosiirto_vastaanotetuksi')) {
-  function aseta_varastosiirto_vastaanotetuksi($varastosiirto, $varastosiirtorivit) {
+  function aseta_varastosiirto_vastaanotetuksi($varastosiirto, $varastosiirtorivit, $_poikkeavalaskutuspvm) {
     global $kukarow, $yhtiorow;
 
     if (empty($varastosiirto) or empty($varastosiirtorivit)) {

--- a/tilauskasittely/vastaanota.php
+++ b/tilauskasittely/vastaanota.php
@@ -649,10 +649,20 @@ if ($tee == 'valmis') {
       }
 
       if ($tee != 'X') {
+        
+        if ($_poikkeavalaskutuspvm != '') {
+          $_laadittu = $_poikkeavalaskutuspvm." 23:59:59";
+          $_tapvm = $_poikkeavalaskutuspvm;
+        }
+        else {
+          $_laadittu = date("Y-m-d H:i:s");
+          $_tapvm = date("Y-m-d");
+        }
+        
         // jos kaikki meni ok niin p‰ivitet‰‰n rivi vastaanotetuksi, laitetaan rivihinnaks tuotteen myyntihinat (t‰t‰ k‰ytet‰‰n sit intrastatissa jos on tarve)
         $query = "UPDATE tilausrivi, tuote
                   SET tilausrivi.toimitettu  = '$kukarow[kuka]',
-                  toimitettuaika          = now(),
+                  toimitettuaika          = '$_laadittu',
                   kpl                     = varattu,
                   varattu                 = 0,
                   rivihinta               = round(tilausrivi.kpl * tuote.myyntihinta / if('$yhtiorow[alv_kasittely]' = '', (1+tuote.alv/100), 1), '$yhtiorow[hintapyoristys]')
@@ -795,7 +805,7 @@ if ($tee == 'valmis') {
 
       $query = "UPDATE lasku
                 SET alatila    = 'V',
-                tapvm        = now(),
+                tapvm        = '$_tapvm',
                 summa        = '$apusummarow[rivihinta]'
                 WHERE tunnus = '{$apusummarow['otunnus']}'
                 and yhtio    = '$kukarow[yhtio]'

--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -1716,7 +1716,10 @@ else {
         // laskutus tarttee kukarow[kesken]
         $kukarow['kesken']=$row['tunnus'];
 
-        tee_kirjanpidollinen_varastosiirto($row['tunnus']);
+        $_poikkeavalaskutuspvm = '';
+        if ($poikkeava_pvm != '') $_poikkeavalaskutuspvm = $laskvv."-".$laskkk."-".$laskpp;
+
+        tee_kirjanpidollinen_varastosiirto($row['tunnus'], $_poikkeavalaskutuspvm);
 
         require "laskutus.inc";
         $laskutetttu++;


### PR DESCRIPTION
Siirron tapahtumat, siirtolistan rivien toimitettuaika ja siirtolistan otsikon tapvm laitetaan samalle päivälle / sekunnille kuin kirjanpidollisen varastosiirron triggeröivä myyntilasku. Aikaisemmin ei osattu seurata myyntilaskun poikkeavaa laskutuspäivää, jolloin siirtolistan aikaleimat oli laskutushetkeltä, jonka vuoksi esim tuotteen tapahtumat näyttivät näissä tapauksissa epäselviltä.
