### PR TITLE
JT siirtolistojen automaattivapautuksen korjaus

### DIFF
--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -222,6 +222,9 @@ if (!function_exists("tee_jt_tilaus")) {
           $atlisa = "";
         }
 
+        $lisatjoin  = "";
+        $lisatehdot = "";
+
         // Laskun lisätietoja ei ole siirtolistoilla,
         // joten joinataan laskun lisätiedot vain kun ei siirtolista
         if ($otsikkorivi["tila"] != 'G') {


### PR DESCRIPTION
JT siirtolistarivien vapautuksessa luotiin virheellisesti jokaista vapautettavaa siirtolistariviä kohden uusi siirtolista vaikka nämä rivit olisivta vapautuneet samalta alkuperäiseltä siirtolistalta. Korjattu toimimaan niin, että siirtolistojen JT-rivien vapautuksessa tarkistetaan oikein onko olemassa olevaa käyttökelpoista siirtolistaa jo valmiina jolle vapautettava JT-siirtolistarivi voitaisiin lisätä eikä turhaan tehdä aina uusia siirtolistoja jokaisesta vapautettavasta rivistä

---

Teknisempi puoli:
Muutos tehtiin tee_jt_tilaus.inc:ssä tehtävään tarkistukseen. Ei yritetä etsiä siirtolistoille laskun_lisatietoja, koska siirtolistoilal ei laskun lisätietoja ole.
