### PR TITLE
Tiedostosta kohdistuksen korjaus

### DIFF
--- a/tilauskasittely/ostotilausten_rivien_kohdistus_tiedostosta.inc
+++ b/tilauskasittely/ostotilausten_rivien_kohdistus_tiedostosta.inc
@@ -183,7 +183,7 @@ if ($faarao == 'TUTKHM') {
               // Testataan kolmanneks, lˆytyykˆ edes tuotenumero ja kappale m‰tchi‰ jossa kpl:‰‰ on riitt‰v‰sti
               // T‰nne ei menn‰ ollenkaan, jos loput j‰tet‰‰n JT:seen ja kohdistettavan m‰‰r‰ on nolla,
               // koska turha tehd‰ mit‰‰n kun koko rivi j‰‰ kuitenkin JT:seen
-              if ($rivirow['varattu'] > $apukpl and ($hyvaksy == "LOP" or ($apukpl != 0 and $hyvaksy == "LOJ"))) {
+              if ($rivirow['varattu'] > $apukpl and ($hyvaksy == "LOP" or ($apukpl > 0 and $hyvaksy == "LOJ"))) {
 
                 $filehinta = $hinta;
 
@@ -197,7 +197,7 @@ if ($faarao == 'TUTKHM') {
 
                 // Jos ollaan poistamassa loput & kohdistettava m‰‰r‰ on 0,
                 // niin ei menn‰ tekem‰‰n uusia rivej‰ koska niist‰ tulisi 0-rivej‰
-                if ($hyvaksy == "LOP" and $apukpl == 0) {
+                if ($hyvaksy == "LOP" and $apukpl <= 0) {
                   break;
                 }
 


### PR DESCRIPTION
Ostotilauksen rivejä saapumiselle tiedostosta kohdistettaessa kappalemäärän puuttuessa ja jos oli valittuna, että "loput jätetään JT:seen" luotiin uusi 0 kappalemääräinen rivi ostotilaukselle, joka kohdistettiin saapumiseen. Tälläisiin 0 riveihin ei pääse mistään käsiksi.

Korjaus: 
Katsotaan onko valittuna, että loppu rivi jätetään JT:seen vai onko niin, että loppu rivi poistetaan. Rivin määrän ollessa nolla (tai pienempi kuin nolla) ja jos loppu rivi jätetään JT:seen ei kannata poistaa ja tehdä uutta riviä, koska koko rivi jää kuitenkin JT:seen. Jos taas loput poistetaan ja kohdistettava määrä on nolla (tai pienempi kuin nolla), niin silloin ei uutta riviä myöskään tehdä, koska yhtään kappaletta ei ole haluttu kohdistaa.
