### PR TITLE
Korkoerittelykopiokin vastaamaan korkolaskua

### DIFF
--- a/myyntires/korkolasku.php
+++ b/myyntires/korkolasku.php
@@ -113,9 +113,9 @@ if ($tee == "ALOITAKOROTUS") {
                 AND tiliointi.tapvm > lasku.erpcm AND tiliointi.korjattu = '')
             WHERE lasku.tunnus     = laskut.tunnus
             $konslisa
-            GROUP BY asiakas.ytunnus, asiakas.nimi, asiakas.nimitark, asiakas.osoite, asiakas.postino, asiakas.postitp, asiakas.tunnus
+            GROUP BY asiakas.ytunnus, asiakas.nimi, asiakas.nimitark, asiakas.osoite, asiakas.postino, asiakas.postitp
             HAVING korkosumma > 0 $korkolisa
-            ORDER BY asiakas.ytunnus, asiakas.tunnus";
+            ORDER BY asiakas.ytunnus";
   $result = pupe_query($query);
 
   $korotettavat = array();

--- a/myyntires/tulosta_korkoerittely.inc
+++ b/myyntires/tulosta_korkoerittely.inc
@@ -219,21 +219,14 @@ if (basename($_SERVER["SCRIPT_FILENAME"]) == 'muutosite.php') {
   $result = pupe_query($query);
   $yrow = mysql_fetch_assoc($result);
   $yhteyshenkilo = $yrow['tunnus'];
-
-  $query = "SELECT group_concat(tunnus) tunnukset
-            FROM asiakas
-            WHERE yhtio = '$kukarow[yhtio]'
-            and ytunnus = '$trow[ytunnus]'";
-  $result = pupe_query($query);
-  $asiakasrow2 = mysql_fetch_assoc($result);
-
+  
   $query = "SELECT l.tunnus, l.liitostunnus, t.summa*-1 summa, l.erpcm, l.yhtio_toimipaikka,
             l.laskunro, t.tapvm mapvm, l.tapvm tapvm, l.tunnus, l.viikorkopros, to_days(t.tapvm) - to_days(l.erpcm) as ika,
             round(l.viikorkopros * t.summa * -1 * (to_days(t.tapvm)-to_days(l.erpcm)) / 36500,2) as korkosumma, l.maksuehto
             FROM lasku l
             join tiliointi t use index (tositerivit_index) on (t.yhtio = l.yhtio and t.tilino in ('$yhtiorow[myyntisaamiset]', '$yhtiorow[factoringsaamiset]') and t.tapvm > l.erpcm and t.tapvm <= '$trow[tapvm]' and l.tunnus = t.ltunnus)
             LEFT JOIN maksuehto me on (me.yhtio=l.yhtio and me.tunnus=l.maksuehto)
-            WHERE l.liitostunnus in ($asiakasrow2[tunnukset])
+            WHERE l.liitostunnus in ($trow[liitostunnus])
             and l.yhtio          = '$kukarow[yhtio]'
             and l.tila           = 'U'
             and l.mapvm          > '0000-00-00'


### PR DESCRIPTION
Kun korkoerittely otetaan jälkeenpäin korkolaskun kautta, on sen vastattava alkuperäistä korkoerittelyä.
