### PR TITLE
Käyttäjän myyntivaraston tarkistuksen korjaus

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -28328,7 +28328,7 @@ if (!function_exists('sallitut_varastot')) {
     if (trim($kukarow['varasto']) != "" and strpos($kukarow['varasto'], ',') !== false) {
       return explode(",", $kukarow["varasto"]);
     }
-    elseif (!empty($kukarow['varasto']) and $kukarow['varasto'] > 0) {
+    elseif (!empty($kukarow['varasto'])) {
       return array($kukarow['varasto']);
     }
 


### PR DESCRIPTION
Tarkistetaan käyttäjän myyntivarastoasetukset oikein, jotta saadaan tilauksen varasto määriteltyä oikeiden sääntöjen mukaan.

---

Teknisempi kuvaus:
Muokaattiin sallitut_varastot functiota siten, että se käsittelee käyttäjän myyntivarastotietoa oikein. Täällä oli huomioimatta, että arvo "_tyhjä_" ja 0 ovat sama asia eli että käyttäjä saa myydä kaikista normaalivarastoista. Nyt siis huomioidaan, että 0 sama asia kuin "_tyhjä_".
