### PR TITLE
Eränumerotunnus myyntitilauksella fix

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -3885,7 +3885,7 @@ if ($tee == '') {
         }
 
         // Otetaan sarjanumero talteen, jotta osataan muokkauksen j‰lkeen palauttaa oikea er‰ jos se viel‰ riitt‰‰
-        if (isset($myy_sarjatunnus)) {
+        if (isset($myy_sarjatunnus) and $myy_sarjatunnus != "") {
           $query = "SELECT sarjanumero
                     FROM sarjanumeroseuranta
                     WHERE yhtio = '{$kukarow['yhtio']}'


### PR DESCRIPTION
Myyntitilauksella eränumeron muistiinottamisen seurauksena rivin poistaminen ei toiminut. Tämä korjaa sen ja nyt rivit saa taas poistettua.

---

Tekninen puoli:
Tarkistetaan, että eränumerotunnus muuttuja on setattu JA ettei se ole tyhjä!
