### PR TITLE
Edifact91.1 tilausrivien sisäänluvun korjaus

### DIFF
--- a/tilauskasittely/editilaus_in.inc
+++ b/tilauskasittely/editilaus_in.inc
@@ -354,7 +354,6 @@ while ($tietue = fgets($fd)) {
   $next_tietue = fgets($fd);
   $next_tunnus = trim(substr($next_tietue, 0, 3));
   fseek($fd, $positio);
-echo "357 $crossdock911 <br><br>";
 
   $rivinvaihto = $edi_tyyppi == "edifact911";
   $rivinvaihto = ($rivinvaihto and $tunnus == "QTY");


### PR DESCRIPTION
Edifact91.1 tyyppisten editilausten sisäänluvussa oli bugi, jonka takia tämäntyyppisten editilausten viimeinen rivi ohitettiin kokonaan. Ongelma on nyt korjattu ja nyt kaikki tilauksen tuoterivit käsitellään oikein.
