### PR TITLE
* Hae ja selaa-ohjelmaan toimittajarajaus

### DIFF
--- a/tilauskasittely/monivalintalaatikot.inc
+++ b/tilauskasittely/monivalintalaatikot.inc
@@ -866,7 +866,7 @@ foreach ($monivalintalaatikot as $monivalintalaatikko) {
       $query = "SELECT distinct avainsana.selite,
                 $kieli_selitetark
                 FROM tuote
-                JOIN avainsana ON (avainsana.yhtio = tuote.yhtio and tuote.try = avainsana.selite and avainsana.laji = 'OSASTO' and avainsana.kieli in ('$yhtiorow[kieli]', '') $avainlisa)
+                JOIN avainsana ON (avainsana.yhtio = tuote.yhtio and tuote.osasto = avainsana.selite and avainsana.laji = 'OSASTO' and avainsana.kieli in ('$yhtiorow[kieli]', '') $avainlisa)
                 WHERE tuote.yhtio = '$kukarow[yhtio]'
                 $lisa_haku_toimi
                 $kieltolisa


### PR DESCRIPTION
Hae ja selaa osiossa voi nyt rajata tuotteita myös tuotteen toimittajan mukaan.

Ei toimi oletuksena, vaan pitää luoda "HAE_JA_SELAA" -lajin avainsana jossa kerrotaan että toimittajalle tehdään oma monivalintalaatikko.
