### PR TITLE
Päätoimittaja Relexiin päätoimittajaksi

### DIFF
--- a/rajapinnat/relex/relex_products.php
+++ b/rajapinnat/relex/relex_products.php
@@ -387,6 +387,7 @@ while ($row = mysql_fetch_assoc($res)) {
   $ttq = "SELECT
           toimi.tunnus toimittaja,
           toimi.ytunnus ytunnus,
+          if(tuotteen_toimittajat.toimitusaika = 0, toimi.oletus_toimaika, tuotteen_toimittajat.toimitusaika) toimitusaika,
           tuotteen_toimittajat.toim_tuoteno,
           tuotteen_toimittajat.toim_nimitys,
           if(tuotteen_toimittajat.osto_era = 0, 1, tuotteen_toimittajat.osto_era) osto_era,
@@ -475,6 +476,14 @@ while ($row = mysql_fetch_assoc($res)) {
 
           $korjattu_ema = round($ema * (1 + $avg_poikpros / 2), 2);
         }
+        else {
+          $korjattu_ema = round($ema, 2);
+        }
+      }
+      else {
+        // laitetaan tuotteen toimittajan takana oleva toimitusaika, tai toimittajan oletus,
+        // mikäli tuotteella ei ole yhtään tuloa
+        $korjattu_ema = round($ttrow['toimitusaika'], 2);
       }
 
       // Hetaan kaikki ostohinnat yhtiön oletusvaluutassa


### PR DESCRIPTION
Laitetaan Relex products tiedostoihin päätoimittajaksi Pupesoftin päätoimittaja. Aikaisemmin pistettiin halvin toimittaja.

Myöhemmin tulee osata joissakin tapauksissa myös laittaa halvin toimittaja päätoimittajaksi, mutta ei vielä (infra jolla tunnistetaan nämä keissit on vielä tekemättä).

Lisäksi korjattu EMA laskennan oletusarvoja, mikäli tuotteella ei ole yhtään tuloa tai on vain yksi tulo.
