### PR TITLE
Extranet: korjaus alvprosentin hakuun verovelvolliseen vientiin

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -3783,8 +3783,10 @@ if (!function_exists("alehinta")) {
     // oletetaan tuotteen alvi ja valuutta
     $alehinta_val = $yhtiorow["valkoodi"];
 
-    // jos meillä on lasku menossa ulkomaille
-    if ($laskurow["maa"] != "" and $laskurow["maa"] != $yhtiorow["maa"]) {
+    // Jos meillä on lasku menossa ulkomaille
+    // Tietyissä tapauksissa yhtiorow maa voi olla sama kuin laskun maa, mutta vat_numerosta tiedetään,
+    // että ollaan verovelsollisia tähä maahan
+    if ($yhtiorow["vat_numero"] != "" or ($laskurow["maa"] != "" and $laskurow["maa"] != $yhtiorow["maa"])) {
 
       // tutkitaan ollaanko siellä alv-rekisteröity
       $query = "SELECT * from yhtion_toimipaikat where yhtio='$kukarow[yhtio]' and maa='$laskurow[maa]' and vat_numero != ''";


### PR DESCRIPTION
Extranetin hae ja selaassa lisättyihin tuotteisiin tuli tietyissä tapauksissa kotimaan alvprosentti kohdemaan alvprosentin sijaan. Korjattu nyt niin, että mennään kaikissa tapauksissa kohdemaan alvprosentin mukaan. Tämä koskee siis niitä tapauksia, joissa ollaan verovelvollisia tähän kyseiseen maahan.
