### PR TITLE
Tilauksen otsikolla maksuehdon vaihto

### DIFF
--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -239,7 +239,8 @@ if ($kukarow['kesken'] > 0 and isset($laskurow) and (($laskurow['tila'] == 'N' a
   $c = $tarkistus_meapu_row['jv'];
   $d = $tarkistus_meapu_row2['jv'];
 
-  if (((empty($a) and !empty($b)) or empty($a)) or ((empty($c) and !empty($d)) or empty($c))) {
+  // Jos uusi maksuehto ei ole käteinen eikä jv, niin katsotaan luottoraja
+  if (((empty($a) and !empty($b)) or empty($a)) and ((empty($c) and !empty($d)) or empty($c))) {
 
     // Parametrejä saatanat.php:lle
     $sytunnus       = $laskurow['ytunnus'];


### PR DESCRIPTION
Tilauksen otsikolla maksuehdon vaihdossa tarkastetaan onko käteinen ja jv tyhjää. Jos, niin tarkastetaan luottorajat. Tällä taklataan tilanne että ollaan ylitetty luottoraja käteismaksuehdollisella tilauksella myynnin ollessa kuitenkin ok, mutta sitten yritetään vaihtaa maksuehto ei-käteiseksi joka ei ole ok.
