### PR TITLE
Maksuehdon tarkistus tilauksen otsikolla selkeämmäksi

### DIFF
--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -229,18 +229,11 @@ if ($kukarow['kesken'] > 0 and isset($laskurow) and (($laskurow['tila'] == 'N' a
   $tarkistus_meapu = pupe_query($tarkistus_apuqu);
   $tarkistus_meapu_row = mysql_fetch_assoc($tarkistus_meapu);
 
-  $tarkistus_apuqu = "SELECT * from maksuehto where yhtio='{$kukarow['yhtio']}' and tunnus='{$edellinen_maksuehto}'";
-  $tarkistus_meapu2 = pupe_query($tarkistus_apuqu);
-  $tarkistus_meapu_row2 = mysql_fetch_assoc($tarkistus_meapu2);
-
-  $a = $tarkistus_meapu_row['kateinen'];
-  $b = $tarkistus_meapu_row2['kateinen'];
-
-  $c = $tarkistus_meapu_row['jv'];
-  $d = $tarkistus_meapu_row2['jv'];
+  $_kateis = $tarkistus_meapu_row['kateinen'];
+  $_jv = $tarkistus_meapu_row['jv'];
 
   // Jos uusi maksuehto ei ole käteinen eikä jv, niin katsotaan luottoraja
-  if (((empty($a) and !empty($b)) or empty($a)) and ((empty($c) and !empty($d)) or empty($c))) {
+  if (empty($_kateis) and empty($_jv)) {
 
     // Parametrejä saatanat.php:lle
     $sytunnus       = $laskurow['ytunnus'];


### PR DESCRIPTION
Siistimistä ja kaunistelua tarkistukselle jossa katsotaan tarviiko saatavia tarkastaa riippuen millainen maksuehto on kyseessä. Käteiselle ja jälkivaatimukselle ei tarvii tarkastusta.
