### PR TITLE
Näytä tiliensaldot excelsarakkeiden korjaus

### DIFF
--- a/inc/tilisaldot.inc
+++ b/inc/tilisaldot.inc
@@ -227,6 +227,7 @@ if ($tee == '1') {
         $worksheet->write($excelrivi, $iiiiii, $trow["tilino"]);
         $iiiiii++;
         $worksheet->write($excelrivi, $iiiiii, $trow["nimi"]);
+        $iiiiii++;
 
         if ($kustannuspaikoittain != "") {
           $worksheet->write($excelrivi, $iiiiii, $trow["kustp"]);
@@ -237,7 +238,6 @@ if ($tee == '1') {
           $iiiiii++;
         }
 
-        $iiiiii++;
         $worksheet->write($excelrivi, $iiiiii, $trow["Vientejä"]);
         $iiiiii++;
         $worksheet->write($excelrivi, $iiiiii, $trow["Saldo"]);


### PR DESCRIPTION
Kun näytä tilien saldot ohjelma ajettiin kustannuspaikoittain menivät kustannuspaikkojen tiedot vääriin sarakkeisiin excelissä. Excelin sarakkeet on nyt korjattu niin, että oikeat tiedot näkyvät oikeissa sarakkeissa. 
