### PR TITLE
* CRM-asiakashinnasto tuotehinnastoryhmittäin

### DIFF
--- a/extranet/asiakashinnasto.php
+++ b/extranet/asiakashinnasto.php
@@ -417,7 +417,7 @@ else {
           $excelsarake++;
           $worksheet->writeNumber($excelrivi, $excelsarake, $veroton);
           $excelsarake++;
-          $worksheet->writeNumber($excelrivi, $excelsarake0, $verollinen);
+          $worksheet->writeNumber($excelrivi, $excelsarake, $verollinen);
           $excelsarake++;
         }
         else {


### PR DESCRIPTION
Tuotteille voi lisätä avainsanoina tuotehinnastoryhmiä. Jos näitä on lisätty, näytetään asiakashinnastossa valikko josta saa valita esitetäänkö hinnasto normaalisti vai ryhmiteltynä tuotehinnastoryhmittäin.

Jotta pääsee perustamaan tuotteelle tuoteryhmähinnasto-avainsanoja, täytyy ensin luoda tavallinen avainsana jonka laji on TUOTEULK ja selite on tuoteryhmaosasto
