### PR TITLE
Ei huomioida konversioissa muodostuneita tapahtumia

### DIFF
--- a/epakuranttiajo.php
+++ b/epakuranttiajo.php
@@ -216,12 +216,14 @@ if ($php_cli or (isset($ajo_tee) and ($ajo_tee == "NAYTA" or $ajo_tee == "NAYTAP
       }
 
       // Haetaan tuotteen viimeisin laskutus (ei huomioida hyvityksiä)
+      // Ei myöskään huomioida fuusioissa muodostuneita tapahtumia (rivitunnus 0 tai -1)
       $query  = "SELECT laadittu
                  FROM tapahtuma
                  WHERE yhtio = '$kukarow[yhtio]'
                  AND laji    in ('laskutus', 'kulutus')
                  AND tuoteno = '$epakurantti_row[tuoteno]'
                  AND kpl     < 0
+                 AND rivitunnus not in ('0', '-1')
                  ORDER BY laadittu DESC
                  LIMIT 1;";
       $tapres = pupe_query($query);

--- a/epakuranttiajo.php
+++ b/epakuranttiajo.php
@@ -223,7 +223,7 @@ if ($php_cli or (isset($ajo_tee) and ($ajo_tee == "NAYTA" or $ajo_tee == "NAYTAP
                  AND laji    in ('laskutus', 'kulutus')
                  AND tuoteno = '$epakurantti_row[tuoteno]'
                  AND kpl     < 0
-                 AND rivitunnus not in ('0', '-1')
+                 AND rivitunnus not in (0, -1)
                  ORDER BY laadittu DESC
                  LIMIT 1;";
       $tapres = pupe_query($query);


### PR DESCRIPTION
Jos kaksi yritystä on fuusioitunut ja molempien tapahtumat on siirretty saman yrityksen alle, niin fuusiossa on voitu luoda tapahtumia. Tämmöisiä tapahtumia ei kuulu huomioida epäkuranttilaskelmissa kun tutkitaan koska tuotetta on vimeksi esim myyty.