### PR TITLE
Korjaus iltasiivouksen tuotepaikkapoistoon

### DIFF
--- a/iltasiivo.php
+++ b/iltasiivo.php
@@ -785,17 +785,29 @@ $avoimet_rivit = array();
 // Jos on poistettavia, haetaan avoimet
 if (mysql_num_rows($poistettavat_tuotepaikat) > 0) {
 
-  // Haetaan avoimet tilausrivit arrayseen (myynti, osto, siirtolistat, valmistukset)
+  // Haetaan avoimet tilausrivit arrayseen (myynti, osto, siirtolistat)
   $query = "SELECT CONCAT(tuoteno, hyllyalue, hyllynro, hyllytaso, hyllyvali) AS id
             FROM tilausrivi
             WHERE yhtio        = '{$kukarow['yhtio']}'
             AND laskutettuaika = '0000-00-00'
-            AND tyyppi         IN ('L','O','G','V','W','M')";
+            AND tyyppi         IN ('L','O','G','M')";
   $avoinrivi_result = pupe_query($query);
 
   while ($avoinrivi = mysql_fetch_assoc($avoinrivi_result)) {
     $avoimet_rivit[] = $avoinrivi['id'];
   }
+
+    // Haetaan avoimet tilausrivit arrayseen (valmistukset)
+    $query = "SELECT CONCAT(tuoteno, hyllyalue, hyllynro, hyllytaso, hyllyvali) AS id
+              FROM tilausrivi
+              WHERE yhtio        = '{$kukarow['yhtio']}'
+              AND toimitettuaika = '0000-00-00'
+              AND tyyppi         IN ('V','W')";
+    $avoinrivi_result = pupe_query($query);
+
+    while ($avoinrivi = mysql_fetch_assoc($avoinrivi_result)) {
+      $avoimet_rivit[] = $avoinrivi['id'];
+    }
 
   // Haetaan avoimet tilausrivit arrayseen (siirtolistojen kohdepaikka)
   $query = "SELECT CONCAT(tilausrivi.tuoteno, tilausrivin_lisatiedot.kohde_hyllyalue, tilausrivin_lisatiedot.kohde_hyllynro, tilausrivin_lisatiedot.kohde_hyllytaso, tilausrivin_lisatiedot.kohde_hyllyvali) AS id

--- a/iltasiivo.php
+++ b/iltasiivo.php
@@ -785,12 +785,12 @@ $avoimet_rivit = array();
 // Jos on poistettavia, haetaan avoimet
 if (mysql_num_rows($poistettavat_tuotepaikat) > 0) {
 
-  // Haetaan avoimet tilausrivit arrayseen (myynti, osto, siirtolistat)
+  // Haetaan avoimet tilausrivit arrayseen (myynti & osto)
   $query = "SELECT CONCAT(tuoteno, hyllyalue, hyllynro, hyllytaso, hyllyvali) AS id
             FROM tilausrivi
             WHERE yhtio        = '{$kukarow['yhtio']}'
             AND laskutettuaika = '0000-00-00'
-            AND tyyppi         IN ('L','O','G')
+            AND tyyppi         IN ('L','O')
             AND var != 'P'";
   $avoinrivi_result = pupe_query($query);
 
@@ -798,12 +798,12 @@ if (mysql_num_rows($poistettavat_tuotepaikat) > 0) {
     $avoimet_rivit[] = $avoinrivi['id'];
   }
 
-    // Haetaan avoimet tilausrivit arrayseen (valmistukset)
+    // Haetaan avoimet tilausrivit arrayseen (valmistukset & siirtolistat)
     $query = "SELECT CONCAT(tuoteno, hyllyalue, hyllynro, hyllytaso, hyllyvali) AS id
               FROM tilausrivi
               WHERE yhtio        = '{$kukarow['yhtio']}'
               AND toimitettuaika = '0000-00-00 00:00:00'
-              AND tyyppi         IN ('V','W','M')
+              AND tyyppi         IN ('V','W','M','G')
               AND var != 'P'";
     $avoinrivi_result = pupe_query($query);
 
@@ -816,7 +816,7 @@ if (mysql_num_rows($poistettavat_tuotepaikat) > 0) {
             FROM tilausrivi
             JOIN tilausrivin_lisatiedot ON (tilausrivin_lisatiedot.yhtio = tilausrivi.yhtio AND tilausrivin_lisatiedot.tilausrivitunnus = tilausrivi.tunnus AND tilausrivin_lisatiedot.kohde_hyllyalue != '')
             WHERE tilausrivi.yhtio        = '{$kukarow['yhtio']}'
-            AND tilausrivi.laskutettuaika = '0000-00-00'
+            AND tilausrivi.toimitettuaika = '0000-00-00 00:00:00'
             AND tilausrivi.tyyppi         = 'G'
             AND var != 'P'";
   $avoinrivi_result = pupe_query($query);

--- a/iltasiivo.php
+++ b/iltasiivo.php
@@ -790,7 +790,8 @@ if (mysql_num_rows($poistettavat_tuotepaikat) > 0) {
             FROM tilausrivi
             WHERE yhtio        = '{$kukarow['yhtio']}'
             AND laskutettuaika = '0000-00-00'
-            AND tyyppi         IN ('L','O','G','M')";
+            AND tyyppi         IN ('L','O','G')
+            AND var != 'P'";
   $avoinrivi_result = pupe_query($query);
 
   while ($avoinrivi = mysql_fetch_assoc($avoinrivi_result)) {
@@ -801,8 +802,9 @@ if (mysql_num_rows($poistettavat_tuotepaikat) > 0) {
     $query = "SELECT CONCAT(tuoteno, hyllyalue, hyllynro, hyllytaso, hyllyvali) AS id
               FROM tilausrivi
               WHERE yhtio        = '{$kukarow['yhtio']}'
-              AND toimitettuaika = '0000-00-00'
-              AND tyyppi         IN ('V','W')";
+              AND toimitettuaika = '0000-00-00 00:00:00'
+              AND tyyppi         IN ('V','W','M')
+              AND var != 'P'";
     $avoinrivi_result = pupe_query($query);
 
     while ($avoinrivi = mysql_fetch_assoc($avoinrivi_result)) {
@@ -815,7 +817,8 @@ if (mysql_num_rows($poistettavat_tuotepaikat) > 0) {
             JOIN tilausrivin_lisatiedot ON (tilausrivin_lisatiedot.yhtio = tilausrivi.yhtio AND tilausrivin_lisatiedot.tilausrivitunnus = tilausrivi.tunnus AND tilausrivin_lisatiedot.kohde_hyllyalue != '')
             WHERE tilausrivi.yhtio        = '{$kukarow['yhtio']}'
             AND tilausrivi.laskutettuaika = '0000-00-00'
-            AND tilausrivi.tyyppi         = 'G'";
+            AND tilausrivi.tyyppi         = 'G'
+            AND var != 'P'";
   $avoinrivi_result = pupe_query($query);
 
   while ($avoinrivi = mysql_fetch_assoc($avoinrivi_result)) {


### PR DESCRIPTION
Tarkistetaan iltasiivossa valmistuksien varaukset tuotepaikoille oikein, jotta saadaan poistettua sellaiset paikat joille ei todellisuudessa ole varauksia. Aiemmin tarkistukset olivat siis liiankin tiukat ja varastopaikkoja jäi poistamatta.