### PR TITLE
Käyttäjäkohtainen maksupäätekone

### DIFF
--- a/kayttajat.php
+++ b/kayttajat.php
@@ -604,6 +604,7 @@ if ($tee == 'MUUTA') {
               kassamyyja                    = '{$kassamyyja}',
               dynaaminen_kassamyynti        = '{$dynaaminen_kassamyynti}',
               maksupaate_kassamyynti        = '{$maksupaate_kassamyynti}',
+              maksupaate_ip                 = '{$maksupaate_ip}',
               jyvitys                       = '{$jyvitys}',
               oletus_ohjelma                = '{$oletus_ohjelma}',
               naytetaan_katteet_tilauksella = '{$naytetaan_katteet_tilauksella}',
@@ -1187,6 +1188,16 @@ if ($tee == 'MUUTA') {
                             {$maksupaate_sel_3}>" . t("K‰ytet‰‰n maksup‰‰tett‰ kassamyynniss‰") . "
                     </option>
                   </select>
+                </td>
+              </tr>";
+
+        echo "<tr>
+                <th align='left'>" . t("Maksup‰‰tteen IP") . ":</th>
+                <td>
+                  <input id='maksupaate_ip'
+                         type='text'
+                         name='maksupaate_ip'
+                         value='{$krow["maksupaate_ip"]}'/>
                 </td>
               </tr>";
 

--- a/kayttajat.php
+++ b/kayttajat.php
@@ -1197,7 +1197,8 @@ if ($tee == 'MUUTA') {
                   <input id='maksupaate_ip'
                          type='text'
                          name='maksupaate_ip'
-                         value='{$krow["maksupaate_ip"]}'/>
+                         value='{$krow["maksupaate_ip"]}'
+                         placeholder='" . t("IP tai IP:portti") . "'/>
                 </td>
               </tr>";
 

--- a/rajapinnat/lumo_handler.inc
+++ b/rajapinnat/lumo_handler.inc
@@ -27,7 +27,12 @@ foreach($suoritukset as $suoritus) {
 
   if ($suoritus == 1) $onnistuuko = false;
 
-  // Jos salasanat.phpst‰ puuttuu lumon osoite tai portti
+  $lumo_ip = explode(":", $kukarow["maksupaate_ip"]);
+  $lumo_service_address = $lumo_ip[0] ? $lumo_ip[0] : $lumo_service_address;
+  $lumo_service_port = $lumo_ip[1] ? $lumo_ip[1] : $lumo_service_port;
+
+  // Jos k‰ytt‰j‰lt‰ puuttuu maksup‰‰tteen IP ja salasanat.phpss‰ ei ole myˆsk‰‰n m‰‰ritelty IP:t‰
+  // ja porttia
   if(!isset($lumo_service_address) or !isset($lumo_service_port)) {
     $onnistuuko = "Maksup‰‰tett‰ ei ole konfiguroitu oikein";
     break;

--- a/rajapinnat/lumo_handler.inc
+++ b/rajapinnat/lumo_handler.inc
@@ -28,13 +28,12 @@ foreach($suoritukset as $suoritus) {
   if ($suoritus == 1) $onnistuuko = false;
 
   $lumo_ip = explode(":", $kukarow["maksupaate_ip"]);
-  $lumo_service_address = $lumo_ip[0] ? $lumo_ip[0] : $lumo_service_address;
-  $lumo_service_port = $lumo_ip[1] ? $lumo_ip[1] : $lumo_service_port;
+  $lumo_service_address = $lumo_ip[0];
+  $lumo_service_port = $lumo_ip[1] ? $lumo_ip[1] : 1234;
 
-  // Jos k‰ytt‰j‰lt‰ puuttuu maksup‰‰tteen IP ja salasanat.phpss‰ ei ole myˆsk‰‰n m‰‰ritelty IP:t‰
-  // ja porttia
-  if(!isset($lumo_service_address) or !isset($lumo_service_port)) {
-    $onnistuuko = "Maksup‰‰tett‰ ei ole konfiguroitu oikein";
+  // Jos k‰ytt‰j‰lt‰ puuttuu maksup‰‰tteen IP
+  if(empty($lumo_service_address)) {
+    $onnistuuko = "Maksup‰‰tett‰ ei ole konfiguroitu oikein t‰lle k‰ytt‰j‰lle";
     break;
   }
 

--- a/tilauskasittely/tulosta_asiakkaan_kuitti.inc
+++ b/tilauskasittely/tulosta_asiakkaan_kuitti.inc
@@ -9,10 +9,10 @@
  * @param array   $params
  *  Esimerkki config parametreistä arvoina defaultit:
  *    array(
- *      "header_teksti"     => false,
- *      "footer_teksti"     => false,
- *      "avaa_lipas_lopuksi => false,
- *      "kateinen"          => false
+ *      "header_teksti"      => false,
+ *      "footer_teksti"      => false,
+ *      "avaa_lipas_lopuksi" => true,
+ *      "kateinen"           => false
  *    );
  *
  * @return bool
@@ -29,7 +29,7 @@ function tulosta_asiakkaan_kuitti($laskunro, $tulostimen_tunnus, $params = array
   $footer_teksti      = empty($params["footer_teksti"]) ? false : $params["footer_teksti"];
   $header_teksti      = empty($params["header_teksti"]) ? false : $params["header_teksti"];
   $kateinen           = empty($params["kateinen"]) ? false : hintapyoristys($params["kateinen"]);
-  $avaa_lipas_lopuksi = $params["avaa_lipas_lopuksi"];
+  $avaa_lipas_lopuksi = empty($params["avaa_lipas_lopuksi"]) ? true : $params["avaa_lipas_lopuksi"];
 
   list($maksupaatetapahtumat, $maksupaatesumma) = hae_maksupaatetapahtumat($laskunro);
   list($tilausrivit, $tilausnumerot, $verot) = hae_tilausrivit($laskunro);


### PR DESCRIPTION
* Käyttäjähallinnasta mahdollisuus määrittää, mitä maksupäätekonetta käytetään
* Jos käyttäjällä ei ole määritelty maksupäätekoneen IP:tä, osoite otetaan salasanat.php:stä
* Laitetaan kassalipas aukeamaan oletuksena kuitin tulostuksen yhteydessä

Vaatii seuraavan kantamuutoksen:

```sql
ALTER TABLE kuka
ADD COLUMN maksupaate_ip VARCHAR(60)
AFTER maksupaate_kassamyynti;
```