### PR TITLE
Heti-tulostus -toimitustavalla keräyksestä suoraan rahtikirjan syöttöön

### DIFF
--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -160,7 +160,6 @@ else {
               and toimitustapa.yhtio         = '$kukarow[yhtio]'
               and lasku.tunnus               = '$id'
               and ((toimitustapa.nouto is null or toimitustapa.nouto='') or lasku.vienti!='')
-              and toimitustapa.tulostustapa != 'H'
               and maksuehto.jv               = ''";
     $result = pupe_query($query);
 


### PR DESCRIPTION
Jos yhtiön parametri: karayksesta_rahtikirjasyottoon = Keräyksestä siirrytään suoraan rahtikirjan syöttöön, silloin siirrytään keräyksestä rahtikirjan syöttöön myös niillä toimitustavoilla, joille on määritelty Hetitulostus.

Vain jos toimitustapa on määritelty Noudoksi, ei mennä automaattisesti rahtikirjan syöttöön kotimaan toimituksissa.