### PR TITLE
Varastosiirroissa kohdevarasto on pakollinen

### DIFF
--- a/tilauskasittely/otsik_siirtolista.inc
+++ b/tilauskasittely/otsik_siirtolista.inc
@@ -29,13 +29,14 @@ if ($toim == "VALMISTAVARASTOON" and isset($jatka) and $clearing != "" and $vara
 }
 
 $laaja_toim_kasittely = ($yhtiorow['toimipaikkakasittely'] == 'L');
+
 if ($toim == 'SIIRTOLISTA' and isset($jatka) and $laaja_toim_kasittely and $varasto == '') {
-  echo "<font class='error'>".t("L‰hdevarasto pit‰‰ valita")."!!!</font><br><br>";
+  echo "<br><font class='error'>".t("VIRHE: L‰hdevarasto on valittava")."!</font><br><br>";
   unset($jatka);
 }
 
 if ($toim == 'SIIRTOLISTA' and isset($jatka) and $clearing == '') {
-  echo "<font class='error'>".t("Kohdevarasto pit‰‰ valita")."!!!</font><br><br>";
+  echo "<br><font class='error'>".t("VIRHE: Kohdevarasto on valittava")."!</font><br><br>";
   unset($jatka);
 }
 

--- a/tilauskasittely/otsik_siirtolista.inc
+++ b/tilauskasittely/otsik_siirtolista.inc
@@ -34,6 +34,11 @@ if ($toim == 'SIIRTOLISTA' and isset($jatka) and $laaja_toim_kasittely and $vara
   unset($jatka);
 }
 
+if ($toim == 'SIIRTOLISTA' and isset($jatka) and $clearing == '') {
+  echo "<font class='error'>".t("Kohdevarasto pit‰‰ valita")."!!!</font><br><br>";
+  unset($jatka);
+}
+
 if ($tila == 'Muuta' and !isset($jatka)) {
 
   if ($toim == "SIIRTOLISTA") {


### PR DESCRIPTION
Varastosiirroissa kohdevaraston valinta on aina pakollinen. Tähän on nyt lisätty tarkistus joka estää käyttäjää jatkamasta mikäli varastosiirron kohdevarasto on valitsematta.