### PR TITLE
Sisäiset laskut -emailista jätetään liite pois

### DIFF
--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -2898,11 +2898,7 @@ else {
           "subject" => t("Pupesoft-Finvoice-aineiston siirto eteenpäin"),
           "ctype" => "text",
           "body" => $verkkolasmail,
-          "attachements" => array(
-            array(
-              "filename" => $ftpfile,
-            ),
-          ),
+          "attachements" => "",
         );
 
         pupesoft_sahkoposti($_params);


### PR DESCRIPTION
Sisäisistä laskuista tehdään yksi tiedosto, joka siirretään verkkolaskujen sisäänluku-hakemistoon.

Tämän jälkeen alkuperäistä laskuaineistoa ei ole liitettäväksi laskutuksesta lähtetään emailiin, joten liitettä ei enää yritetä lähettää