### PR TITLE
* Verkkokaupan hintojen verollisuus

### DIFF
--- a/rajapinnat/edi.php
+++ b/rajapinnat/edi.php
@@ -179,10 +179,10 @@ class Edi {
         $edi_order .= "OSTOTILRIV.OTR_TILATTUMAARA:$kpl\n";
 
         // Verottomat hinnat
+        $edi_order .= "OSTOTILRIV.OTR_VEROKANTA:$alvprosentti\n";
         $edi_order .= "OSTOTILRIV.OTR_RIVISUMMA:$rivihinta_veroton\n";
         $edi_order .= "OSTOTILRIV.OTR_OSTOHINTA:$veroton_hinta\n";
-        $edi_order .= "OSTOTILRIV.OTR_ALENNUS:$alennusprosentti\n";
-        $edi_order .= "OSTOTILRIV.OTR_VEROKANTA:$alvprosentti\n";
+        $edi_order .= "OSTOTILRIV.OTR_ALENNUS:$alennusprosentti\n";        
 
         $edi_order .= "OSTOTILRIV.OTR_VIITE:\n";
         $edi_order .= "OSTOTILRIV.OTR_OSATOIMITUSKIELTO:\n";

--- a/tilauskasittely/editilaus_in.inc
+++ b/tilauskasittely/editilaus_in.inc
@@ -178,6 +178,7 @@ $verkkokauppa                 = "";
 $verkkokauppavarasto          = "";
 $verkkokauppavarasto_li       = "";
 $veromaara                    = "";
+$verokanta                    = "";
 $viite                        = "";
 $yhteyshenkilon_puhelin       = "";
 $ovt_tunnus                   = "";
@@ -1917,6 +1918,11 @@ while ($tietue = fgets($fd)) {
     $edi_nimitys = $type[4]; // rivin nelj‰nness‰ segmentiss‰ tulee oikee info
     break;
 
+  case 'OSTOTILRIV.OTR_VEROKANTA':
+    // magento-keisiss‰, tilausrivin veron m‰‰r‰
+    $verokanta = (int) trim($tieto);
+    break;
+
   case 'OSTOTILRIV.OTR_OSTOHINTA' :
     // Kun tullaan magentosta ja meill‰ on rahtikulu, niin otetaan hinta talteeen
     // TAI kun tullaan magentosta ja me luotetaan verkkokaupan hintoihin.
@@ -1926,6 +1932,11 @@ while ($tietue = fgets($fd)) {
 
       if ($yhtiorow["alv_kasittely"] == '' and !isset($verkkokauppa_hinnatedifailistaverollisina)) {
         $editilaus_hinta = round($editilaus_hinta * (1 + $laskurow["alv"]/100), 2);
+      }
+      // Jos saatu hinta kuitenkin sis‰lt‰‰ jo verot ja halutaan laskea ne pois
+      if (isset($verkkokauppa_hinnoistalasketaanverotpois) 
+        and $verkkokauppa_hinnoistalasketaanverotpois == 'JOO' and !empty($verokanta)) {
+        $editilaus_hinta = round($editilaus_hinta / (1 + $verokanta/100), 2);
       }
     }
 
@@ -2480,6 +2491,7 @@ while ($tietue = fgets($fd)) {
     $verkkokauppavarasto          = "";
     $verkkokauppavarasto_li       = "";
     $veromaara                    = "";
+    $verokanta                    = "";
     $viite                        = "";
     $yhteyshenkilon_puhelin       = "";
     $ovt_tunnus                   = "";

--- a/tilauskasittely/editilaus_in.inc
+++ b/tilauskasittely/editilaus_in.inc
@@ -1928,7 +1928,7 @@ while ($tietue = fgets($fd)) {
     // TAI kun tullaan magentosta ja me luotetaan verkkokaupan hintoihin.
     if ($edi_tyyppi == "magento" and ((isset($verkkokauppa_hinnatedifailista) and $verkkokauppa_hinnatedifailista == "JOO") or strtolower($tuoteno) == strtolower($yhtiorow['rahti_tuotenumero'])) and $tieto != '') {
       // T‰m‰ hinta on aina veroton, joten lasketaan vero p‰‰lle jos myyntihinnat ovat verollisia
-      $editilaus_hinta = (float) trim($tieto);
+      $editilaus_hinta = (float) trim(str_replace( ",", ".", $tieto));
 
       if ($yhtiorow["alv_kasittely"] == '' and !isset($verkkokauppa_hinnatedifailistaverollisina)) {
         $editilaus_hinta = round($editilaus_hinta * (1 + $laskurow["alv"]/100), 2);

--- a/tilauskasittely/editilaus_in.inc
+++ b/tilauskasittely/editilaus_in.inc
@@ -1930,12 +1930,13 @@ while ($tietue = fgets($fd)) {
       // Tämä hinta on aina veroton, joten lasketaan vero päälle jos myyntihinnat ovat verollisia
       $editilaus_hinta = (float) trim(str_replace( ",", ".", $tieto));
 
+      // Käytössä on verolliset myyntihinnat, mutta edifailissa hinnat ovat verottomia
       if ($yhtiorow["alv_kasittely"] == '' and !isset($verkkokauppa_hinnatedifailistaverollisina)) {
         $editilaus_hinta = round($editilaus_hinta * (1 + $laskurow["alv"]/100), 2);
       }
-      // Jos saatu hinta kuitenkin sisältää jo verot ja halutaan laskea ne pois
-      if (isset($verkkokauppa_hinnoistalasketaanverotpois) 
-        and $verkkokauppa_hinnoistalasketaanverotpois == 'JOO' and !empty($verokanta)) {
+
+      // Käytössä on verottomat myyntihinnat, mutta edifailissa hinta kuitenkin sisältää verot ja halutaan laskea ne pois
+      if ($yhtiorow["alv_kasittely"] != '' and isset($verkkokauppa_hinnatedifailistaverollisina) and !empty($verokanta)) {
         $editilaus_hinta = round($editilaus_hinta / (1 + $verokanta/100), 2);
       }
     }


### PR DESCRIPTION
- salasanat.php:n muuttujalla $verkkokauppa_hinnatedifailistaverollisina voidaan aktivoida tilausrivikohtaisen veron poislaskeminen tuotteen hinnasta tilauksen sisäänluvussa jos verkkokaupan hinnat ovat verollisia ja Pupessa hinnat ovat verottomia.
- vaatii muuttujan lisäksi sen että verkkokaupasta(magentosta) ollaan saatu tilausrivikohtainen verokanta