### PR TITLE
Myynti, tuoteperheen lapsituotteen saldotarkistus

### DIFF
--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -2511,8 +2511,12 @@ if ($toimittamatta > 0 or trim($var) != '' or $rivityyppi == 'O') {
 
       foreach ($siirto_varastot as $siirto_varasto) {
         $saldo_myytavissa = $siirto_varasto['tuote']['myytavissa'];
-        if ($_onko_isatuote or $_onko_lapsituote) {
+        if ($_onko_isatuote) {
           $tuoteperhe_saldomyytavissa = tuoteperhe_myytavissa($isatuoteno, '', '', $siirto_varasto['lahde_tunnus']);
+          $saldo_myytavissa = $tuoteperhe_saldomyytavissa[$siirto_varasto['lahde_nimi']];
+        }
+        elseif ($_onko_lapsituote) {
+          $tuoteperhe_saldomyytavissa = tuoteperhe_myytavissa($tuoteno, '', '', $siirto_varasto['lahde_tunnus']);
           $saldo_myytavissa = $tuoteperhe_saldomyytavissa[$siirto_varasto['lahde_nimi']];
         }
 

--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -2515,10 +2515,6 @@ if ($toimittamatta > 0 or trim($var) != '' or $rivityyppi == 'O') {
           $tuoteperhe_saldomyytavissa = tuoteperhe_myytavissa($isatuoteno, '', '', $siirto_varasto['lahde_tunnus']);
           $saldo_myytavissa = $tuoteperhe_saldomyytavissa[$siirto_varasto['lahde_nimi']];
         }
-        elseif ($_onko_lapsituote) {
-          $tuoteperhe_saldomyytavissa = tuoteperhe_myytavissa($tuoteno, '', '', $siirto_varasto['lahde_tunnus']);
-          $saldo_myytavissa = $tuoteperhe_saldomyytavissa[$siirto_varasto['lahde_nimi']];
-        }
 
         //Jos tilausrivin toimittajan_tunnus ja siirto_varasto.tunnus on samat,
         //tarkoittaa se että tilausriville on valittu kyseinen siirtovarasto


### PR DESCRIPTION
Toimipaikalta myydään tuoteperhe, jolla ei ole riittävästi saldo toimipaikan varastossa.

Päävarastossa on tuoteperhettä saman verran kuin toimipaikalla oli myyty -> tehdään varastosiirto tuoteperheen tuotteista: tarkistetaan isätuotteen saldon riittävyys ja varataan isätuotteelle koko päävaraston saldo. Myös lapsituotten kohdalla tutkittiin isätuotteen myytävissä saldoa, jota ei enää ole, koska se varattiin juuri isätuoteriville, eikä lapsi riville saada tehtyä varastosiirtoa.

Korjattu, että lapsen kohdalla tutkitaan lapsen saldoa ja saadaan tehtyä varastosiirto myös lapsiriville.