### PR TITLE
"Näytä saldo" saapumisella

### DIFF
--- a/tilauskasittely/keikka.php
+++ b/tilauskasittely/keikka.php
@@ -97,8 +97,10 @@ echo "<script type=\"text/javascript\" charset=\"utf-8\">
           });
 
           $('img.hae_saldo').live('click', function() {
-            var id = $(this).attr('id'),
-                varasto = $('#'+id+'_varasto').val();
+            var id = $(this).attr('id');
+            var varasto = $('#'+id+'_varasto').val(),
+                tuoteno = $('#'+id+'_tuoteno').val();
+
 
             if ($('.saldo_'+id).is(':visible')) {
               $('.saldo_'+id).hide();
@@ -106,7 +108,7 @@ echo "<script type=\"text/javascript\" charset=\"utf-8\">
             else {
               $.post('{$_SERVER['SCRIPT_NAME']}',
                 {   ajax_toiminto: 'hae_saldo_myytavissa',
-                    id: id,
+                    id: tuoteno,
                     varasto: varasto,
                     no_head: 'yes',
                     ohje: 'off' },

--- a/tilauskasittely/ostotilausten_rivien_kohdistus.inc
+++ b/tilauskasittely/ostotilausten_rivien_kohdistus.inc
@@ -2034,9 +2034,12 @@ if ($tila == '') {
     $_src = "{$palvelin2}pics/lullacons/info.png";
     $_title = t("Näytä saldo");
 
-    echo "<img title='{$_title}' src='{$_src}' class='hae_saldo' id='{$rivirow['tuoteno']}' />";
-    echo "<input type='hidden' id='{$rivirow['tuoteno']}_varasto' value='{$rivirow['varasto']}' />";
-    echo "<span class='saldo_{$rivirow['tuoteno']}' style='display:none;'></span>";
+    $id = md5(uniqid());
+
+    echo "<img title='{$_title}' src='{$_src}' class='hae_saldo' id='{$id}' />";
+    echo "<input type='hidden' id='{$id}_tuoteno' value='{$rivirow['tuoteno']}' />";
+    echo "<input type='hidden' id='{$id}_varasto' value='{$rivirow['varasto']}' />";
+    echo "<span class='saldo_{$id}' style='display:none;'></span>";
 
     if ($rivirow["sarjanumeroseuranta"] != "") {
       if ($rivirow["siskpl"] < 0) {


### PR DESCRIPTION
Saapumisilla tuotenumero vieressä sijaitseva "näytä saldo" infopainike ei kaikilla tuotenumeroilla toiminut - linkki ei siis kaikilla tuotteilla tehnyt mitään. Nyt "näytä saldo" linkki on korjattu ja tuotteen saldot tulevat näkyviin kaikilla tuotteilla infopainikkeen klikkauksen jälkeen.