### PR TITLE
Maksupäätetapahtumien tallennus

### DIFF
--- a/rajapinnat/lumo_handler.inc
+++ b/rajapinnat/lumo_handler.inc
@@ -157,11 +157,8 @@ foreach($suoritukset as $suoritus) {
         elseif(strpos($kuitti1, "HYVITYS") !== false) {
           $maksutyyppi = "HYVITYS";
         }
-        elseif(strpos($kuitti1, "OSTO") !== false) {
-          $maksutyyppi = "OSTO";
-        }
         else {
-          $maksutyyppi = "FAIL";
+          $maksutyyppi = "OSTO";
         }
 
         break;


### PR DESCRIPTION
* Tallennetaan maksutapahtumat joka tapauksessa kantaan, jos ne menevät läpi, vaikka kuitissa ei lukisikaan sanaa OSTO
* Korjaa bugin, jossa maksutapahtuma on voinu mennä läpi, mutta tapahtumaa ei ole tallentunut kantaan, eikä tulostunut kuitille