### PR TITLE
Mysqlalias oletusarvot

### DIFF
--- a/yllapito.php
+++ b/yllapito.php
@@ -421,6 +421,7 @@ if ($upd == 1) {
                                      WHERE yhtio       = '$kukarow[yhtio]'
                                      and laji          = 'MYSQLALIAS'
                                      and selite        = '$toim.$al_nimi'
+                                     and selitetark_2  = '$alias_set'
                                      and selitetark_4 != ''";
           $oletus_tarkistus_result = pupe_query($oletus_tarkistus_query);
 


### PR DESCRIPTION
Korjattu virhe mysqlaliaksien oletusarvojen haussa. Querystä puuttui alias_set. Tarkoittaa sitä, että jos oli tehty useampia eri mysqlaliaksia joissa samoille kentille määritelty oletuksia, saattoi tietueen perustuksessa tulla väärän mysqlaliaksen oletusarvoja, esim tuotteen perustuksessa.