### PR TITLE
REKLAMAATIO: Koontipurkulista

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -30445,6 +30445,81 @@ if (!function_exists('hae_lahete_printteri')) {
   }
 }
 
+if (!function_exists('varaston_lapsivarastot')) {
+  function varaston_lapsivarastot($varasto, $tuoteno, $alkuhyllyalue, $alkuhyllynro, $loppuhyllyalue, $loppuhyllynro) {
+    global $kukarow, $yhtiorow;
+
+    // katsotaan onko vastaanottavalla varastolla lapsivarastoja
+    $lv_query =  "SELECT *
+                  FROM varastopaikat
+                  WHERE yhtio     = '{$kukarow['yhtio']}'
+                  AND isa_varasto = '{$varasto}'";
+    $lv_res = pupe_query($lv_query);
+
+    if (mysql_num_rows($lv_res) > 0) {
+
+      // katsotaan onko tuotepaikallisia lapsivarastoja
+      $tlv_query = "SELECT GROUP_CONCAT(DISTINCT vp.tunnus)
+                    FROM tuotepaikat AS tp
+                    JOIN varastopaikat AS vp ON vp.yhtio = tp.yhtio AND vp.tunnus = tp.varasto
+                    WHERE tp.yhtio     = '{$kukarow['yhtio']}'
+                    AND vp.isa_varasto = '{$varasto}'
+                    AND tp.tuoteno     = '{$tuoteno}'
+                    GROUP BY tp.yhtio";
+      $tlv_res = pupe_query($tlv_query);
+
+      if (mysql_num_rows($tlv_res) < 1) {
+
+        $tlvlisa = '';
+
+        $lvlisa = " UNION
+                    SELECT tunnus, 'x','x','x','x', 's3' AS status, nimitys
+                    FROM varastopaikat
+                    WHERE yhtio = '{$kukarow['yhtio']}'
+                    AND isa_varasto = '{$varasto}'";
+      }
+      else {
+
+        $tlv_lista = mysql_result($tlv_res, 0);
+
+        $tlvlisa="UNION
+                  SELECT tp.tunnus,
+                  tp.hyllyalue,
+                  tp.hyllynro,
+                  tp.hyllyvali,
+                  tp.hyllytaso,
+                  's2' AS status,
+                  'x' AS nimitys
+                  FROM tuotepaikat AS tp
+                  JOIN varastopaikat AS vp ON vp.yhtio = tp.yhtio AND vp.tunnus = tp.varasto
+                  WHERE tp.yhtio = '{$kukarow['yhtio']}'
+                  AND vp.isa_varasto = '{$varasto}'
+                  AND tp.tuoteno = '{$tuoteno}'";
+
+        $lvlisa= "UNION
+                  SELECT tunnus, 'x','x','x','x', 's3' AS status, vp.nimitys
+                  FROM varastopaikat AS vp
+                  WHERE vp.yhtio = '{$kukarow['yhtio']}'
+                  AND vp.isa_varasto = '{$varasto}'
+                  AND vp.tunnus NOT IN ({$tlv_lista})";
+      }
+    }
+    else {
+      $lvlisa = $tlvlisa = '';
+    }
+
+    $query = "SELECT tunnus, hyllyalue, hyllynro, hyllyvali, hyllytaso, 's1' AS status, 'x' AS nimitys
+              FROM tuotepaikat
+              WHERE yhtio = '{$kukarow['yhtio']}'
+              AND tuoteno = '{$tuoteno}'
+              and concat(rpad(upper('{$alkuhyllyalue}'),  5, '0'),lpad(upper('{$alkuhyllynro}'),  5, '0')) <= concat(rpad(upper(tuotepaikat.hyllyalue), 5, '0'),lpad(upper(tuotepaikat.hyllynro), 5, '0'))
+              and concat(rpad(upper('{$loppuhyllyalue}'), 5, '0'),lpad(upper('{$loppuhyllynro}'), 5, '0')) >= concat(rpad(upper(tuotepaikat.hyllyalue), 5, '0'),lpad(upper(tuotepaikat.hyllynro), 5, '0'))
+              $lvlisa
+              $tlvlisa";
+    return pupe_query($query);
+  }
+}
+
 if (!function_exists("hae_viimeiset_hyvaksyjat")) {
   function hae_viimeiset_hyvaksyjat($laskurow) {
     $hyvaksyja_kentat = array();

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -30461,29 +30461,30 @@ if (!function_exists('hae_lahete_printteri')) {
 }
 
 if (!function_exists('varaston_lapsivarastot')) {
-  function varaston_lapsivarastot($varasto, $tuoteno, $alkuhyllyalue, $alkuhyllynro, $loppuhyllyalue, $loppuhyllynro) {
+  function varaston_lapsivarastot($varasto, $tuoteno) {
     global $kukarow, $yhtiorow;
 
     // katsotaan onko vastaanottavalla varastolla lapsivarastoja
-    $lv_query =  "SELECT *
+    $lv_query =  "SELECT GROUP_CONCAT(tunnus) lapsivarastot
                   FROM varastopaikat
                   WHERE yhtio     = '{$kukarow['yhtio']}'
                   AND isa_varasto = '{$varasto}'";
     $lv_res = pupe_query($lv_query);
+    $lv_row = mysql_fetch_assoc($lv_res);
 
-    if (mysql_num_rows($lv_res) > 0) {
+    if (!empty($lv_row['lapsivarastot'])) {
 
       // katsotaan onko tuotepaikallisia lapsivarastoja
-      $tlv_query = "SELECT GROUP_CONCAT(DISTINCT vp.tunnus)
-                    FROM tuotepaikat AS tp
-                    JOIN varastopaikat AS vp ON vp.yhtio = tp.yhtio AND vp.tunnus = tp.varasto
-                    WHERE tp.yhtio     = '{$kukarow['yhtio']}'
-                    AND vp.isa_varasto = '{$varasto}'
-                    AND tp.tuoteno     = '{$tuoteno}'
-                    GROUP BY tp.yhtio";
+      $tlv_query = "SELECT GROUP_CONCAT(DISTINCT varasto) varastot
+                    FROM tuotepaikat
+                    WHERE yhtio     = '{$kukarow['yhtio']}'
+                    AND varasto IN ({$lv_row['lapsivarastot']})
+                    AND tuoteno     = '{$tuoteno}'
+                    GROUP BY yhtio";
       $tlv_res = pupe_query($tlv_query);
+      $tlv_lista = mysql_fetch_assoc($tlv_res);
 
-      if (mysql_num_rows($tlv_res) < 1) {
+      if (empty($tlv_lista['varastot'])) {
 
         $tlvlisa = '';
 
@@ -30494,8 +30495,6 @@ if (!function_exists('varaston_lapsivarastot')) {
                     AND isa_varasto = '{$varasto}'";
       }
       else {
-
-        $tlv_lista = mysql_result($tlv_res, 0);
 
         $tlvlisa="UNION
                   SELECT tp.tunnus,
@@ -30516,7 +30515,7 @@ if (!function_exists('varaston_lapsivarastot')) {
                   FROM varastopaikat AS vp
                   WHERE vp.yhtio = '{$kukarow['yhtio']}'
                   AND vp.isa_varasto = '{$varasto}'
-                  AND vp.tunnus NOT IN ({$tlv_lista})";
+                  AND vp.tunnus NOT IN ({$tlv_lista['varastot']})";
       }
     }
     else {
@@ -30527,8 +30526,7 @@ if (!function_exists('varaston_lapsivarastot')) {
               FROM tuotepaikat
               WHERE yhtio = '{$kukarow['yhtio']}'
               AND tuoteno = '{$tuoteno}'
-              and concat(rpad(upper('{$alkuhyllyalue}'),  5, '0'),lpad(upper('{$alkuhyllynro}'),  5, '0')) <= concat(rpad(upper(tuotepaikat.hyllyalue), 5, '0'),lpad(upper(tuotepaikat.hyllynro), 5, '0'))
-              and concat(rpad(upper('{$loppuhyllyalue}'), 5, '0'),lpad(upper('{$loppuhyllynro}'), 5, '0')) >= concat(rpad(upper(tuotepaikat.hyllyalue), 5, '0'),lpad(upper(tuotepaikat.hyllynro), 5, '0'))
+              AND varasto = '{$varasto}'
               $lvlisa
               $tlvlisa
               ORDER BY status, nimitys";

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -30515,7 +30515,8 @@ if (!function_exists('varaston_lapsivarastot')) {
               and concat(rpad(upper('{$alkuhyllyalue}'),  5, '0'),lpad(upper('{$alkuhyllynro}'),  5, '0')) <= concat(rpad(upper(tuotepaikat.hyllyalue), 5, '0'),lpad(upper(tuotepaikat.hyllynro), 5, '0'))
               and concat(rpad(upper('{$loppuhyllyalue}'), 5, '0'),lpad(upper('{$loppuhyllynro}'), 5, '0')) >= concat(rpad(upper(tuotepaikat.hyllyalue), 5, '0'),lpad(upper(tuotepaikat.hyllynro), 5, '0'))
               $lvlisa
-              $tlvlisa";
+              $tlvlisa
+              ORDER BY status, nimitys";
     return pupe_query($query);
   }
 }

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -30468,7 +30468,8 @@ if (!function_exists('varaston_lapsivarastot')) {
     $lv_query =  "SELECT GROUP_CONCAT(tunnus) lapsivarastot
                   FROM varastopaikat
                   WHERE yhtio     = '{$kukarow['yhtio']}'
-                  AND isa_varasto = '{$varasto}'";
+                  AND isa_varasto = '{$varasto}'
+                  AND isa_varasto != 0";
     $lv_res = pupe_query($lv_query);
     $lv_row = mysql_fetch_assoc($lv_res);
 

--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -3486,18 +3486,12 @@ if ($fieldname == "ostoera_pyoristys" ) {
 
 if ($fieldname == "reklamaation_kasittely") {
 
-  $sela = $selb = "";
+  $sel = array($trow[$i] => 'selected') + array('' => '', 'U' => '', 'X' => '');
 
-  if ($trow[$i] == 'U') {
-    $selb = "selected";
-  }
-  else {
-    $sela = "selected";
-  }
-
-  $ulos = "<td><select name='$nimi' ".js_alasvetoMaxWidth($nimi, 400).">
-        <option value = '' $sela>".t("Reklamaation k‰sittelyss‰ k‰ytet‰‰n lyhyemp‰‰ prosessia")."</option>
-        <option value = 'U' $selb>".t("Reklamaation k‰sittelyss‰ k‰ytet‰‰n laajempaa prosessia vastaanotolla, purkulistalla ja vastaanottokuittauksella")."</option>
+  $ulos = "<td><select name='{$nimi}' ".js_alasvetoMaxWidth($nimi, 400).">
+        <option value = ''>".t("Reklamaation k‰sittelyss‰ k‰ytet‰‰n lyhyemp‰‰ prosessia")."</option>
+        <option value = 'U' {$sel['U']}>".t("Reklamaation k‰sittelyss‰ k‰ytet‰‰n laajempaa prosessia vastaanotolla, purkulistalla ja vastaanottokuittauksella")."</option>
+        <option value = 'X' {$sel['X']}>".t("Reklamaation k‰sittelyss‰ k‰ytet‰‰n laajempaa prosessia purkulistalla ja vastaanottokuittauksella")."</option>
       </select></td>";
 
   $jatko = 0;

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -2648,10 +2648,10 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
             $_tp_res = hae_yhtion_toimipaikat($kukarow['yhtio'], $row['yhtio_toimipaikka']);
             $_tp_row = mysql_fetch_assoc($_tp_res);
 
-            echo "<{$ero}>{$_tp_row['nimi']}</{$ero}>";
+            echo "<td valign='top'>{$_tp_row['nimi']}</td>";
           }
           else {
-            echo "<{$ero}></{$ero}>";
+            echo "<td valign='top'></td>";
           }
         }
 

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -2534,6 +2534,7 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
                 min(lasku.lahetepvm) lahetepvm,
                 min(lasku.kerayspvm) kerayspvm,
                 min(lasku.toimaika) toimaika,
+                min(lasku.yhtio_toimipaikka) yhtio_toimipaikka,
                 group_concat(DISTINCT lasku.laatija) laatija,
                 group_concat(DISTINCT lasku.toimitustapa SEPARATOR '<br>') toimitustapa,
                 group_concat(DISTINCT concat_ws('\n\n', if (comments!='',concat('".t("Lähetteen lisätiedot").":\n',comments),NULL), if (sisviesti2!='',concat('".t("Keräyslistan lisätiedot").":\n',sisviesti2),NULL)) SEPARATOR '\n') ohjeet,
@@ -2588,6 +2589,11 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
       if ($logistiikka_yhtio != '') {
         echo "<th valign='top'><a href='#' onclick=\"getElementById('jarj').value='yhtio'; document.forms['find'].submit();\">", t("Yhtiö"), "</a></th>";
       }
+
+      if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+        echo "<th valign='top'><a href='#' onclick=\"getElementById('jarj').value='yhtio_toimipaikka'; document.forms['find'].submit();\">", t("Toimipaikka"), "</a></th>";
+      }
+
       echo "<th valign='top'><a href='#' onclick=\"getElementById('jarj').value='prioriteetti'; document.forms['find'].submit();\">", t("Pri"), "</a><br>";
       //echo "<a href='#' onclick=\"getElementById('jarj').value='varastonimi'; document.forms['find'].submit();\">".t("Varastoon")."</a></th>";
 
@@ -2635,6 +2641,18 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
 
         if ($logistiikka_yhtio != '') {
           echo "<td valign='top'>{$row['yhtio_nimi']}</td>";
+        }
+
+        if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+          if (!empty($row['yhtio_toimipaikka'])) {
+            $_tp_res = hae_yhtion_toimipaikat($kukarow['yhtio'], $row['yhtio_toimipaikka']);
+            $_tp_row = mysql_fetch_assoc($_tp_res);
+
+            echo "<{$ero}>{$_tp_row['nimi']}</{$ero}>";
+          }
+          else {
+            echo "<{$ero}></{$ero}>";
+          }
         }
 
         if (isset($row['ohjeet']) and trim($row["ohjeet"]) != "") {

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -3209,16 +3209,7 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
 
           if ($toim == 'VASTAANOTA_REKLAMAATIO') {
 
-            $_varow = hae_varasto($otsik_row['varasto']);
-
-            $vares = varaston_lapsivarastot(
-              $otsik_row['varasto'],
-              $row['tuoteno'],
-              $_varow['alkuhyllyalue'],
-              $_varow['alkuhyllynro'],
-              $_varow['loppuhyllyalue'],
-              $_varow['loppuhyllynro']
-            );
+            $vares = varaston_lapsivarastot($otsik_row['varasto'], $row['puhdas_tuoteno']);
 
             $s1_options = array();
             $s2_options = array();

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -2843,7 +2843,7 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
           if ($toim == 'VASTAANOTA_REKLAMAATIO') {
             echo "<br><form action='tilaus_myynti.php' method='POST'>";
             echo "<input type='hidden' name='toim' value = 'REKLAMAATIO'>";
-            echo "<input type='hidden' name='tilausnumero' value = '{$tilausnumeroita}'>";
+            echo "<input type='hidden' name='tilausnumero' value = '{$otsik_row['tunnus']}'>";
             echo "<input type='hidden' name='mista' value = 'keraa'>";
             echo "<input type='submit' value='", t("Muokkaa"), "'/> ";
             echo "</form>";

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -7,7 +7,7 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
   js_popup();
 }
 
-if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] != 'U') {
+if ($toim == "VASTAANOTA_REKLAMAATIO" and !in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))) {
   echo "<font class='error'>", t("HUOM: Ohjelma on käytössä vain kun käytetään laajaa reklamaatioprosessia"), "!</font>";
   exit;
 }
@@ -599,7 +599,7 @@ if ($tee == 'P') {
 
           // Alkuperäinen perheid talteen, nollataan se myöhemmin, jos lapsia saa jättää ykis jt:ksi
           $rperheid  = $tilrivirow['perheid'];
-          
+
           //Aloitellaan tilausrivi päivitysqueryä
           $query = "UPDATE tilausrivi
                     SET yhtio = yhtio ";
@@ -702,7 +702,7 @@ if ($tee == 'P') {
                 $keratty    = "''";
                 $kerattyaik = "''";
                 $rkomm      = $tilrivirow["kommentti"];
-                
+
                 if ($yhtiorow["kerayserat"] == '' and $tilrivirow["perheid"] != 0) {
                    $rperheid = 0;
                 }
@@ -768,7 +768,7 @@ if ($tee == 'P') {
                 $keratty  = "''";
                 $kerattyaik  = "''";
                 $rkomm     = $tilrivirow["kommentti"];
-                
+
                 if ($yhtiorow["kerayserat"] == '' and $tilrivirow["perheid"] != 0) {
                    $rperheid = 0;
                 }
@@ -879,7 +879,7 @@ if ($tee == 'P') {
                   $keratty  = "''";
                   $kerattyaik  = "''";
                   $rkomm     = $tilrivirow['kommentti'];
-                 
+
                   if ($yhtiorow["kerayserat"] == '' and $tilrivirow["perheid"] != 0) {
                      $rperheid = 0;
                   }

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -2665,7 +2665,12 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
           echo "<td valign='top'>{$row['keraysera']}{$_moduuli}</td>";
         }
 
-        echo "<td valign='top'>{$row['tunnus']}</td>";
+        if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+          echo "<td valign='top'>{$row['tunnukset']}</td>";
+        }
+        else {
+          echo "<td valign='top'>{$row['tunnus']}</td>";
+        }
 
         if ($yhtiorow['kerayserat'] == 'K' and $toim == "") {
           echo "<td valign='top'>{$row['asiakas']}</td>";

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -1235,11 +1235,11 @@ if ($tee == 'P') {
           if ($toim == 'VASTAANOTA_REKLAMAATIO' and $keraysvirhe == 0) {
 
             if (trim($varastorekla[$apui]) != '' and trim($vertaus_hylly[$apui]) != trim($varastorekla[$apui])) {
-              // Ollaan valittu varastopaikka dropdownista
 
+              // Ollaan valittu varastopaikka dropdownista
               if (isset($varastorekla[$apui]) and $varastorekla[$apui] != 'x' and $varastorekla[$apui] != '' and strpos($varastorekla[$apui], "###") === false) {
                 // tehd‰‰n uusi paikka jos valittiin paikaton lapsivarasto
-                if (substr($rivivarasto[$tun], 0, 1) == 'V') {
+                if (substr($varastorekla[$apui], 0, 1) == 'V') {
                   $uusi_paikka = lisaa_tuotepaikka($tilrivirow["tuoteno"], '', '', '', '', '', '', 0, 0, substr($varastorekla[$apui], 1));
                   $ptunnus = $uusi_paikka['tuotepaikan_tunnus'];
                 }

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -2590,7 +2590,7 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
         echo "<th valign='top'><a href='#' onclick=\"getElementById('jarj').value='yhtio'; document.forms['find'].submit();\">", t("Yhtiö"), "</a></th>";
       }
 
-      if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+      if ($toim == "VASTAANOTA_REKLAMAATIO") {
         echo "<th valign='top'><a href='#' onclick=\"getElementById('jarj').value='yhtio_toimipaikka'; document.forms['find'].submit();\">", t("Toimipaikka"), "</a></th>";
       }
 
@@ -2643,7 +2643,7 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
           echo "<td valign='top'>{$row['yhtio_nimi']}</td>";
         }
 
-        if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+        if ($toim == "VASTAANOTA_REKLAMAATIO") {
           if (!empty($row['yhtio_toimipaikka'])) {
             $_tp_res = hae_yhtion_toimipaikat($kukarow['yhtio'], $row['yhtio_toimipaikka']);
             $_tp_row = mysql_fetch_assoc($_tp_res);
@@ -2684,7 +2684,7 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
           echo "<td valign='top'>{$row['keraysera']}{$_moduuli}</td>";
         }
 
-        if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+        if ($toim == "VASTAANOTA_REKLAMAATIO") {
           echo "<td valign='top'>{$row['tunnukset']}</td>";
         }
         else {
@@ -2694,7 +2694,7 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
         if ($yhtiorow['kerayserat'] == 'K' and $toim == "") {
           echo "<td valign='top'>{$row['asiakas']}</td>";
         }
-        elseif ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X' and $row['tilauksia'] > 1) {
+        elseif ($toim == "VASTAANOTA_REKLAMAATIO" and $row['tilauksia'] > 1) {
           echo "<td valign='top'>",t("Useita"),"</td>";
         }
         else {
@@ -2845,7 +2845,7 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
       echo "<tr><th>", t("Tilaus"), "</th><th>", t("Ostaja"), "</th><th>", t("Toimitusosoite"), "</th></tr>";
 
       $_ker_chk = ($yhtiorow['kerayserat'] == 'K' and $toim == "");
-      $_rek_chk = ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X');
+      $_rek_chk = ($toim == "VASTAANOTA_REKLAMAATIO");
 
       $_ker_rek = ($_ker_chk or $_rek_chk);
 

--- a/tilauskasittely/lahetteen_tulostusjono.php
+++ b/tilauskasittely/lahetteen_tulostusjono.php
@@ -969,7 +969,7 @@ if ($tee2 == '') {
     $grouppi .= ", lasku.varasto, lasku.tulostusalue";
   }
 
-  if ($toim == "VASTAANOTA_REKLAMAATIO") {
+  if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
     $grouppi = "GROUP BY lasku.varasto, lasku.yhtio_toimipaikka";
   }
 

--- a/tilauskasittely/lahetteen_tulostusjono.php
+++ b/tilauskasittely/lahetteen_tulostusjono.php
@@ -1137,7 +1137,7 @@ if ($tee2 == '') {
       echo "<$ero valign='top'>".str_replace(',', '<br>', $tilrow["otunnus"])."</$ero>";
 
       if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X' and $tilrow['tilauksia'] > 1) {
-        echo "<{$ero} valign='top'>",t("Useita"),"<{$ero}>";
+        echo "<{$ero} valign='top'>",t("Useita"),"</{$ero}>";
       }
       else {
         echo "<$ero valign='top'>$tilrow[ytunnus]";
@@ -1342,6 +1342,10 @@ if ($tee2 == '') {
     echo "<th>".$riveja_yht."</th>";
 
     $spanni = ($yhtiorow["pakkaamolokerot"] != "" or $logistiikka_yhtio != '') ? 4 : 3;
+
+    if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+      $spanni++;
+    }
 
     echo "<th colspan='$spanni'></th>";
     echo "</tr>";

--- a/tilauskasittely/lahetteen_tulostusjono.php
+++ b/tilauskasittely/lahetteen_tulostusjono.php
@@ -969,7 +969,7 @@ if ($tee2 == '') {
     $grouppi .= ", lasku.varasto, lasku.tulostusalue";
   }
 
-  if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+  if ($toim == "VASTAANOTA_REKLAMAATIO") {
     $grouppi = "GROUP BY lasku.varasto, lasku.yhtio_toimipaikka";
   }
 
@@ -1047,7 +1047,7 @@ if ($tee2 == '') {
       echo "<th valign='top'><a href='#' onclick=\"getElementById('jarj').value='yhtio'; document.forms['find'].submit();\">".t("Yhtiö")."</a></th>";
     }
 
-    if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+    if ($toim == "VASTAANOTA_REKLAMAATIO") {
       echo "<th valign='top'><a href='#' onclick=\"getElementById('jarj').value='yhtio_toimipaikka'; document.forms['find'].submit();\">".t("Toimipaikka")."</a></th>";
     }
 
@@ -1102,7 +1102,7 @@ if ($tee2 == '') {
         echo "<$ero valign='top'>$tilrow[yhtio_nimi]</$ero>";
       }
 
-      if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+      if ($toim == "VASTAANOTA_REKLAMAATIO") {
         if (!empty($tilrow['yhtio_toimipaikka'])) {
           $_tp_res = hae_yhtion_toimipaikat($kukarow['yhtio'], $tilrow['yhtio_toimipaikka']);
           $_tp_row = mysql_fetch_assoc($_tp_res);
@@ -1136,7 +1136,7 @@ if ($tee2 == '') {
 
       echo "<$ero valign='top'>".str_replace(',', '<br>', $tilrow["otunnus"])."</$ero>";
 
-      if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X' and $tilrow['tilauksia'] > 1) {
+      if ($toim == "VASTAANOTA_REKLAMAATIO" and $tilrow['tilauksia'] > 1) {
         echo "<{$ero} valign='top'>",t("Useita"),"</{$ero}>";
       }
       else {
@@ -1343,7 +1343,7 @@ if ($tee2 == '') {
 
     $spanni = ($yhtiorow["pakkaamolokerot"] != "" or $logistiikka_yhtio != '') ? 4 : 3;
 
-    if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+    if ($toim == "VASTAANOTA_REKLAMAATIO") {
       $spanni++;
     }
 

--- a/tilauskasittely/lahetteen_tulostusjono.php
+++ b/tilauskasittely/lahetteen_tulostusjono.php
@@ -990,6 +990,7 @@ if ($tee2 == '') {
   }
 
   $query = "SELECT lasku.yhtio, lasku.yhtio_nimi, lasku.ytunnus, lasku.toim_ovttunnus, lasku.toim_nimi, lasku.toim_nimitark, lasku.nimi, lasku.nimitark, lasku.toim_osoite, lasku.toim_postino, lasku.toim_postitp, lasku.toim_maa, lasku.varasto,
+            lasku.yhtio_toimipaikka,
             if (tila = 'V', lasku.viesti, lasku.toimitustapa) toimitustapa,
             if (maksuehto.jv!='', lasku.tunnus, '') jvgrouppi,
             if (lasku.vienti!='', lasku.tunnus, '') vientigrouppi,
@@ -1045,6 +1046,11 @@ if ($tee2 == '') {
     if ($logistiikka_yhtio != '') {
       echo "<th valign='top'><a href='#' onclick=\"getElementById('jarj').value='yhtio'; document.forms['find'].submit();\">".t("Yhtiö")."</a></th>";
     }
+
+    if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+      echo "<th valign='top'><a href='#' onclick=\"getElementById('jarj').value='yhtio_toimipaikka'; document.forms['find'].submit();\">".t("Toimipaikka")."</a></th>";
+    }
+
     echo "<th valign='top'><a href='#' onclick=\"getElementById('jarj').value='prioriteetti'; document.forms['find'].submit();\">".t("Pri")."</a><br>
           <a href='#' onclick=\"getElementById('jarj').value='varastonimi'; document.forms['find'].submit();\">".t("Varastoon")."</a></th>";
 
@@ -1094,6 +1100,18 @@ if ($tee2 == '') {
 
       if ($logistiikka_yhtio != '') {
         echo "<$ero valign='top'>$tilrow[yhtio_nimi]</$ero>";
+      }
+
+      if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+        if (!empty($tilrow['yhtio_toimipaikka'])) {
+          $_tp_res = hae_yhtion_toimipaikat($kukarow['yhtio'], $tilrow['yhtio_toimipaikka']);
+          $_tp_row = mysql_fetch_assoc($_tp_res);
+
+          echo "<{$ero}>{$_tp_row['nimi']}</{$ero}>";
+        }
+        else {
+          echo "<{$ero}></{$ero}>";
+        }
       }
 
       echo "<$ero valign='top' align='right'>$tilrow[t_tyyppi] $tilrow[prioriteetti] ";

--- a/tilauskasittely/lahetteen_tulostusjono.php
+++ b/tilauskasittely/lahetteen_tulostusjono.php
@@ -8,7 +8,7 @@ if (isset($tee) and $tee == "TILAA_AJAX") {
   require_once "inc/tilaa_ajax.inc";
 }
 
-if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] != 'U') {
+if ($toim == "VASTAANOTA_REKLAMAATIO" and !in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))) {
   echo "<font class='error'>".t("HUOM: Ohjelma on käytössä vain kun käytetään laajaa reklamaatioprosessia")."!</font>";
   exit;
 }
@@ -967,6 +967,10 @@ if ($tee2 == '') {
 
   if ($yhtiorow["pakkaamolokerot"] != "") {
     $grouppi .= ", lasku.varasto, lasku.tulostusalue";
+  }
+
+  if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
+    $grouppi .= ", lasku.varasto, lasku.yhtio_toimipaikka";
   }
 
   $tilausrivi_tuoteno_join = '';

--- a/tilauskasittely/lahetteen_tulostusjono.php
+++ b/tilauskasittely/lahetteen_tulostusjono.php
@@ -1117,13 +1117,19 @@ if ($tee2 == '') {
       echo "</$ero>";
 
       echo "<$ero valign='top'>".str_replace(',', '<br>', $tilrow["otunnus"])."</$ero>";
-      echo "<$ero valign='top'>$tilrow[ytunnus]";
 
-      if ($toim == 'SIIRTOLISTA' or $toim == 'SIIRTOTYOMAARAYS') {
-        echo "<br>$tilrow[nimi]</$ero>";
+      if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X' and $tilrow['tilauksia'] > 1) {
+        echo "<{$ero} valign='top'>",t("Useita"),"<{$ero}>";
       }
       else {
-        echo "<br>$tilrow[toim_nimi]</$ero>";
+        echo "<$ero valign='top'>$tilrow[ytunnus]";
+
+        if ($toim == 'SIIRTOLISTA' or $toim == 'SIIRTOTYOMAARAYS') {
+          echo "<br>$tilrow[nimi]</$ero>";
+        }
+        else {
+          echo "<br>$tilrow[toim_nimi]</$ero>";
+        }
       }
 
       $laadittu_e   = tv1dateconv($tilrow["laadittu"], "P", "LYHYT");

--- a/tilauskasittely/lahetteen_tulostusjono.php
+++ b/tilauskasittely/lahetteen_tulostusjono.php
@@ -970,7 +970,7 @@ if ($tee2 == '') {
   }
 
   if ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X') {
-    $grouppi .= ", lasku.varasto, lasku.yhtio_toimipaikka";
+    $grouppi = "GROUP BY lasku.varasto, lasku.yhtio_toimipaikka";
   }
 
   $tilausrivi_tuoteno_join = '';

--- a/tilauskasittely/tilaus-valmis-tulostus.inc
+++ b/tilauskasittely/tilaus-valmis-tulostus.inc
@@ -252,8 +252,6 @@ if ((int) $chk_row["ok"] == (int) $chk_row["kaikki"] and (int) $chk_row["ok"] !=
     $kerayslistatyyppi = "EXCEL1";
   }
 
-  $tyyppi = "";
-
   // keräyslistalle ei oletuksena tulosteta saldottomia tuotteita
   if ($yhtiorow["kerataanko_saldottomat"] == '') {
     $lisa1 = " and tuote.ei_saldoa = '' ";

--- a/tilauskasittely/tilaus-valmis-tulostus.inc
+++ b/tilauskasittely/tilaus-valmis-tulostus.inc
@@ -51,7 +51,7 @@ else {
   $siirtoalatila = "KJ";
 }
 
-if ($toim == 'VASTAANOTA_REKLAMAATIO' and $yhtiorow['reklamaation_kasittely'] == 'U') {
+if ($toim == 'VASTAANOTA_REKLAMAATIO' and in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))) {
   $queryc = "SELECT sum(if(tila='C' and alatila='B', 1, 0)) ok, count(*) kaikki
              FROM lasku
              WHERE tunnus in ($tilausnumeroita)
@@ -88,7 +88,7 @@ if ((int) $chk_row["ok"] == (int) $chk_row["kaikki"] and (int) $chk_row["ok"] !=
   }
 
   // P‰ivitet‰‰n tilaus pois jonosta ja avataan lukot
-  if ($toim == 'VASTAANOTA_REKLAMAATIO' and $yhtiorow['reklamaation_kasittely'] == 'U') {
+  if ($toim == 'VASTAANOTA_REKLAMAATIO' and in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))) {
     $query = "UPDATE lasku SET
               alatila     = 'C',
               lahetepvm   = now(),
@@ -564,7 +564,7 @@ if ((int) $chk_row["ok"] == (int) $chk_row["kaikki"] and (int) $chk_row["ok"] !=
     echo "<br><font class='error'>".t("L‰hetteen tulostus ep‰onnistui")."! ".t("Tilaus")." $laskurow[tunnus] ".t("siirrettiin tulostusjonoon").". ".t("K‰y tulostamassa l‰hete tulostusjonosta").": <a href='lahetteen_tulostusjono.php'>".t("Tulostusjono")."</a>.</font><br><br>";
     $virheellinen = "X";
 
-    if ($toim == 'VASTAANOTA_REKLAMAATIO' and $yhtiorow['reklamaation_kasittely'] == 'U') {
+    if ($toim == 'VASTAANOTA_REKLAMAATIO' and in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))) {
       $query = "UPDATE lasku SET
                 alatila     = 'B',
                 lahetepvm   = '0000-00-00 00:00:00',

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -9747,9 +9747,18 @@ if ($tee == '') {
         $napin_teksti = $laskurow['tilaustyyppi'] == 'U' ? "Takuu" : "Reklamaatio";
 
         if ($mista == 'keraa') {
+
+          $query = "SELECT GROUP_CONCAT(tunnus) tunnukset
+                    FROM lasku
+                    WHERE yhtio = '{$kukarow['yhtio']}'
+                    AND kerayslista != 0
+                    AND kerayslista = '{$laskurow['kerayslista']}'";
+          $takaisin_keraa_res = pupe_query($query);
+          $takaisin_keraa_row = mysql_fetch_assoc($takaisin_keraa_res);
+
           echo "<td class='back' valign='top'>
               <form method='post' action='keraa.php'>
-              <input type='hidden' name='id' value = '$tilausnumero'>
+              <input type='hidden' name='id' value = '{$takaisin_keraa_row['tunnukset']}'>
               <input type='hidden' name='toim' value = 'VASTAANOTA_REKLAMAATIO'>
               <input type='hidden' name='lasku_yhtio' value = '$kukarow[yhtio]'>
               <input type='submit' name='tila' value = '".t("Takaisin Hyllytykseen")."'>";

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -9752,7 +9752,9 @@ if ($tee == '') {
                     FROM lasku
                     WHERE yhtio = '{$kukarow['yhtio']}'
                     AND kerayslista != 0
-                    AND kerayslista = '{$laskurow['kerayslista']}'";
+                    AND kerayslista = '{$laskurow['kerayslista']}'
+                    AND tila = 'C'
+                    AND alatila = ''C";
           $takaisin_keraa_res = pupe_query($query);
           $takaisin_keraa_row = mysql_fetch_assoc($takaisin_keraa_res);
 

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -9748,19 +9748,25 @@ if ($tee == '') {
 
         if ($mista == 'keraa') {
 
-          $query = "SELECT GROUP_CONCAT(tunnus) tunnukset
-                    FROM lasku
-                    WHERE yhtio = '{$kukarow['yhtio']}'
-                    AND kerayslista != 0
-                    AND kerayslista = '{$laskurow['kerayslista']}'
-                    AND tila = 'C'
-                    AND alatila = 'C'";
-          $takaisin_keraa_res = pupe_query($query);
-          $takaisin_keraa_row = mysql_fetch_assoc($takaisin_keraa_res);
+          $_takaisin_tunnus = $tilausnumero;
+
+          if (!empty($laskurow['kerayslista'])) {
+            $query = "SELECT GROUP_CONCAT(tunnus) tunnukset
+                      FROM lasku
+                      WHERE yhtio = '{$kukarow['yhtio']}'
+                      AND kerayslista != 0
+                      AND kerayslista = '{$laskurow['kerayslista']}'
+                      AND tila = 'C'
+                      AND alatila = 'C'";
+            $takaisin_keraa_res = pupe_query($query);
+            $takaisin_keraa_row = mysql_fetch_assoc($takaisin_keraa_res);
+
+            $_takaisin_tunnus = $takaisin_keraa_row['tunnukset'];
+          }
 
           echo "<td class='back' valign='top'>
               <form method='post' action='keraa.php'>
-              <input type='hidden' name='id' value = '{$takaisin_keraa_row['tunnukset']}'>
+              <input type='hidden' name='id' value = '{$_takaisin_tunnus}'>
               <input type='hidden' name='toim' value = 'VASTAANOTA_REKLAMAATIO'>
               <input type='hidden' name='lasku_yhtio' value = '$kukarow[yhtio]'>
               <input type='submit' name='tila' value = '".t("Takaisin Hyllytykseen")."'>";

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -9754,7 +9754,7 @@ if ($tee == '') {
                     AND kerayslista != 0
                     AND kerayslista = '{$laskurow['kerayslista']}'
                     AND tila = 'C'
-                    AND alatila = ''C";
+                    AND alatila = 'C'";
           $takaisin_keraa_res = pupe_query($query);
           $takaisin_keraa_row = mysql_fetch_assoc($takaisin_keraa_res);
 

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -1674,7 +1674,7 @@ if ($tee == "VALMIS" and ($muokkauslukko == "" or $toim == "PROJEKTI")) {
     $query  = "UPDATE kuka set kesken=0 where yhtio='$kukarow[yhtio]' and kuka='$kukarow[kuka]'";
     $result = pupe_query($query);
 
-    if ($yhtiorow['reklamaation_kasittely'] == 'U') {
+    if (in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))) {
       $oslapp = "email";
       $oslappkpl = 1;
       require "osoitelappu_pdf.inc";
@@ -1850,11 +1850,11 @@ if ($tee == "VALMIS" and ($muokkauslukko == "" or $toim == "PROJEKTI")) {
   }
 }
 
-if ($kukarow["extranet"] == "" and ((($toim == "TYOMAARAYS" or $toim == "TYOMAARAYS_ASENTAJA") and $tee == "LEPAA") or ($toim == "REKLAMAATIO" and $tee == "LEPAA" and $yhtiorow['reklamaation_kasittely'] != 'U'))) {
+if ($kukarow["extranet"] == "" and ((($toim == "TYOMAARAYS" or $toim == "TYOMAARAYS_ASENTAJA") and $tee == "LEPAA") or ($toim == "REKLAMAATIO" and $tee == "LEPAA" and !in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))))) {
   require "tyomaarays/tyomaarays.inc";
 }
 
-if ($kukarow["extranet"] == "" and $toim == "REKLAMAATIO" and $tee == "LEPAA" and $yhtiorow['reklamaation_kasittely'] == 'U') {
+if ($kukarow["extranet"] == "" and $toim == "REKLAMAATIO" and $tee == "LEPAA" and in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))) {
 
   $query  = "UPDATE kuka set kesken='0' where yhtio='$kukarow[yhtio]' and kuka='$kukarow[kuka]' and kesken = '$tilausnumero'";
   $result = pupe_query($query);
@@ -1885,11 +1885,11 @@ if ($kukarow["extranet"] == "" and $toim == "REKLAMAATIO" and $tee == "ODOTTAA" 
 
 if ($kukarow["extranet"] == "" and $toim == 'REKLAMAATIO'
   and ($tee == 'VASTAANOTTO' or $tee == 'VALMIS')
-  and $yhtiorow['reklamaation_kasittely'] == 'U') {
+  and in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))) {
   // Joka tarkoittaa ett‰ "Reklamaatio on vastaanotettu
   // t‰m‰n j‰lkeen kun seuraavassa vaiheessa tullaan niin "Tulostetaan Purkulista"
 
-  if ($tee == 'VALMIS') {
+  if ($tee == 'VALMIS' or $yhtiorow['reklamaation_kasittely'] == 'X') {
     $alatila_lisa = "AND alatila = ''";              // takuu
   }
   else {
@@ -1930,7 +1930,7 @@ if ($kukarow["extranet"] == "" and $toim == 'REKLAMAATIO'
 
 if ($kukarow["extranet"] == "" and $toim == 'REKLAMAATIO'
   and ($tee == 'VALMIS_VAINSALDOTTOMIA' or $tee == 'VALMIS')
-  and $yhtiorow['reklamaation_kasittely'] == 'U') {
+  and in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))) {
   // Reklamaatio/takuu on valmis laskutettavaksi
   // katsotaan onko tilausrivit Unikko-j‰rjestelm‰‰n
   if ($laskurow['tilaustyyppi'] == 'U' or $laskurow['tilaustyyppi'] == 'R') {
@@ -5995,7 +5995,7 @@ if ($tee == '') {
     }
 
     // tarkistetaan kuuluuko kaikki reklamaation rivit samaan varastoon
-    if ($kukarow["extranet"] == "" and $toim == "REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'U') {
+    if ($kukarow["extranet"] == "" and $toim == "REKLAMAATIO" and in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))) {
 
       $varasto_chk_array = array();
       $reklamaatio_saldoton_count = 0;
@@ -9742,7 +9742,7 @@ if ($tee == '') {
       elseif ($maksuehtorow['jaksotettu'] != '' and mysql_num_rows($jaksoresult) == 0) {
         echo "<font class='error'>".t("VIRHE: Tilauksella ei ole maksusopimusta!")."</font>";
       }
-      elseif ($kukarow["extranet"] == "" and $toim == 'REKLAMAATIO' and $yhtiorow['reklamaation_kasittely'] == 'U') {
+      elseif ($kukarow["extranet"] == "" and $toim == 'REKLAMAATIO' and in_array($yhtiorow['reklamaation_kasittely'], array('U','X'))) {
 
         $napin_teksti = $laskurow['tilaustyyppi'] == 'U' ? "Takuu" : "Reklamaatio";
 
@@ -9785,7 +9785,8 @@ if ($tee == '') {
                 <input type='hidden' name='orig_tila' value='$orig_tila'>
                 <input type='hidden' name='orig_alatila' value='$orig_alatila'>";
 
-            if ($mista == 'vastaanota' and ($laskurow["alatila"] == "A" or $laskurow["alatila"] == "B" or $laskurow["alatila"] == "C")) {
+            if (($mista == 'vastaanota' and in_array($laskurow["alatila"], array('A','B','C'))) or
+              ($yhtiorow['reklamaation_kasittely'] == 'X' and in_array($laskurow["alatila"], array('','A','B','C')))) {
               echo "<input type='hidden' name='tee' value='VASTAANOTTO'>";
               echo "<input type='submit' value='* ".t("{$napin_teksti} Vastaanotettu")." *'>";
             }
@@ -9797,7 +9798,7 @@ if ($tee == '') {
           echo "</form></td>";
         }
       }
-      elseif ($kukarow['tilaus_valmis'] != "4" and ($toim != 'REKLAMAATIO' or $yhtiorow['reklamaation_kasittely'] != 'U')) {
+      elseif ($kukarow['tilaus_valmis'] != "4" and ($toim != 'REKLAMAATIO' or !in_array($yhtiorow['reklamaation_kasittely'], array('U','X')))) {
 
         if (($kateinen == "X" and $kukarow["kassamyyja"] != "") or $laskurow["sisainen"] != "") {
           $laskelisa = " / ".t("Laskuta")." $otsikko";

--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -94,12 +94,12 @@ if (!function_exists('alku_kerayslista')) {
 
       tulosta_logo_pdf($pdf, $thispage, $laskurow);
 
-      $_ker_chk = ($yhtiorow['kerayserat'] == 'K');
+      $_ker_chk = ($yhtiorow['kerayserat'] == 'K' and isset($kerayseran_numero) and $kerayseran_numero > 0);
       $_rek_chk = ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X');
 
       $_ker_rek = ($_ker_chk or $_rek_chk);
 
-      if ($_ker_rek and isset($kerayseran_numero) and $kerayseran_numero > 0) {
+      if ($_ker_rek) {
 
         $query = "SELECT count(distinct liitostunnus) asiakkaita
                   FROM lasku

--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -95,7 +95,7 @@ if (!function_exists('alku_kerayslista')) {
       tulosta_logo_pdf($pdf, $thispage, $laskurow);
 
       $_ker_chk = ($yhtiorow['kerayserat'] == 'K' and isset($kerayseran_numero) and $kerayseran_numero > 0);
-      $_rek_chk = ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X');
+      $_rek_chk = ($toim == "VASTAANOTA_REKLAMAATIO" and in_array($yhtiorow['reklamaation_kasittely'], array('U','X')));
 
       $_ker_rek = ($_ker_chk or $_rek_chk);
 

--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -94,7 +94,12 @@ if (!function_exists('alku_kerayslista')) {
 
       tulosta_logo_pdf($pdf, $thispage, $laskurow);
 
-      if ($yhtiorow['kerayserat'] == 'K' and isset($kerayseran_numero) and $kerayseran_numero > 0) {
+      $_ker_chk = ($yhtiorow['kerayserat'] == 'K');
+      $_rek_chk = ($toim == "VASTAANOTA_REKLAMAATIO" and $yhtiorow['reklamaation_kasittely'] == 'X');
+
+      $_ker_rek = ($_ker_chk or $_rek_chk);
+
+      if ($_ker_rek and isset($kerayseran_numero) and $kerayseran_numero > 0) {
 
         $query = "SELECT count(distinct liitostunnus) asiakkaita
                   FROM lasku
@@ -192,7 +197,13 @@ if (!function_exists('alku_kerayslista')) {
       else {
         list($ff_string, $ff_font) = pdf_fontfit($tilausnumeroita, 270, $pdf, $boldi);
         $pdf->draw_text(310, 792, t("Tilausnumero(t)", $kieli),     $thispage, $pieni);
-        $pdf->draw_text(310, 782, $ff_string,              $thispage, $ff_font);
+
+        if ($_rek_chk and count(explode(",", $tilausnumeroita)) > 3) {
+          $pdf->draw_text(310, 782, t("Useita"), $thispage, $boldi);
+        }
+        else {
+          $pdf->draw_text(310, 782, $ff_string, $thispage, $ff_font);
+        }
       }
 
       $pdf->draw_rectangle(779, 300, 758, 580, $thispage, $rectparam);

--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -197,13 +197,7 @@ if (!function_exists('alku_kerayslista')) {
       else {
         list($ff_string, $ff_font) = pdf_fontfit($tilausnumeroita, 270, $pdf, $boldi);
         $pdf->draw_text(310, 792, t("Tilausnumero(t)", $kieli),     $thispage, $pieni);
-
-        if ($_rek_chk and count(explode(",", $tilausnumeroita)) > 3) {
-          $pdf->draw_text(310, 782, t("Useita"), $thispage, $boldi);
-        }
-        else {
-          $pdf->draw_text(310, 782, $ff_string, $thispage, $ff_font);
-        }
+        $pdf->draw_text(310, 782, $ff_string, $thispage, $ff_font);
       }
 
       $pdf->draw_rectangle(779, 300, 758, 580, $thispage, $rectparam);

--- a/tilauskasittely/vastaanota.php
+++ b/tilauskasittely/vastaanota.php
@@ -1542,14 +1542,7 @@ if (!empty($id) and $echotaanko) {
         echo "<td><input type='text' id='t3[$rivirow[tunnus]]' name='t3[$rivirow[tunnus]]' value='$privirow[t3]' maxlength='5' size='5'></td>";
         echo "<td><input type='text' id='t4[$rivirow[tunnus]]' name='t4[$rivirow[tunnus]]' value='$privirow[t4]' maxlength='5' size='5'></td>";
 
-        $vares = varaston_lapsivarastot(
-          $varow2['tunnus'],
-          $rivirow['tuoteno'],
-          $varow2['alkuhyllyalue'],
-          $varow2['alkuhyllynro'],
-          $varow2['loppuhyllyalue'],
-          $varow2['loppuhyllynro']
-        );
+        $vares = varaston_lapsivarastot($varow2['tunnus'], $rivirow['tuoteno']);
 
         $s1_options = array();
         $s2_options = array();

--- a/tilauskasittely/vastaanota.php
+++ b/tilauskasittely/vastaanota.php
@@ -1519,7 +1519,7 @@ if (!empty($id) and $echotaanko) {
         $hyllyalue = $rivirow["kohde_hyllyalue"];
         $hyllynro  = $rivirow["kohde_hyllynro"];
         $hyllyvali = $rivirow["kohde_hyllyvali"];
-        $hyllytaso = $rivirow["kohde_hyllytaso"];  
+        $hyllytaso = $rivirow["kohde_hyllytaso"];
        }
 
       echo "<td>";
@@ -1542,73 +1542,14 @@ if (!empty($id) and $echotaanko) {
         echo "<td><input type='text' id='t3[$rivirow[tunnus]]' name='t3[$rivirow[tunnus]]' value='$privirow[t3]' maxlength='5' size='5'></td>";
         echo "<td><input type='text' id='t4[$rivirow[tunnus]]' name='t4[$rivirow[tunnus]]' value='$privirow[t4]' maxlength='5' size='5'></td>";
 
-        // katsotaan onko vastaanottavalla varastolla lapsivarastoja
-        $lv_query =  "SELECT *
-                      FROM varastopaikat
-                      WHERE yhtio     = '$kukarow[yhtio]'
-                      AND isa_varasto = $varow2[tunnus]";
-        $lv_res = pupe_query($lv_query);
-
-        if (mysql_num_rows($lv_res) > 0) {
-
-          // katsotaan onko tuotepaikallisia lapsivarastoja
-          $tlv_query = "SELECT GROUP_CONCAT(DISTINCT vp.tunnus)
-                        FROM tuotepaikat AS tp
-                        JOIN varastopaikat AS vp ON vp.yhtio = tp.yhtio AND vp.tunnus = tp.varasto
-                        WHERE tp.yhtio     = '$kukarow[yhtio]'
-                        AND vp.isa_varasto = $varow2[tunnus]
-                        AND tp.tuoteno     = '$rivirow[tuoteno]'
-                        GROUP BY tp.yhtio";
-          $tlv_res = pupe_query($tlv_query);
-
-          if (mysql_num_rows($tlv_res) < 1) {
-
-            $tlvlisa = '';
-
-            $lvlisa = " UNION
-                        SELECT tunnus, 'x','x','x','x', 's3' AS status, nimitys
-                        FROM varastopaikat
-                        WHERE yhtio = '$kukarow[yhtio]'
-                        AND isa_varasto = $varow2[tunnus]";
-          }
-          else {
-
-            $tlv_lista = mysql_result($tlv_res, 0);
-
-            $tlvlisa="UNION
-                      SELECT tp.tunnus,
-                      tp.hyllyalue,
-                      tp.hyllynro,
-                      tp.hyllyvali,
-                      tp.hyllytaso,
-                      's2' AS status,
-                      'x' AS nimitys
-                      FROM tuotepaikat AS tp
-                      JOIN varastopaikat AS vp ON vp.yhtio = tp.yhtio AND vp.tunnus = tp.varasto
-                      WHERE tp.yhtio = '$kukarow[yhtio]'
-                      AND vp.isa_varasto = $varow2[tunnus]
-                      AND tp.tuoteno = '$rivirow[tuoteno]'";
-
-            $lvlisa= "UNION
-                      SELECT tunnus, 'x','x','x','x', 's3' AS status, vp.nimitys
-                      FROM varastopaikat AS vp
-                      WHERE vp.yhtio = '$kukarow[yhtio]'
-                      AND vp.isa_varasto = $varow2[tunnus]
-                      AND vp.tunnus NOT IN ($tlv_lista)";
-          }
-        }
-        else {
-          $lvlisa = $tlvlisa = '';
-        }
-
-        $query = "SELECT tunnus, hyllyalue, hyllynro, hyllyvali, hyllytaso, 's1' AS status, 'x' AS nimitys
-                  FROM tuotepaikat
-                  WHERE yhtio = '$kukarow[yhtio]'
-                  AND tuoteno = '$rivirow[tuoteno]'
-                  $lisa
-                  $lvlisa
-                  $tlvlisa";
-        $vares = pupe_query($query);
+        $vares = varaston_lapsivarastot(
+          $varow2['tunnus'],
+          $rivirow['tuoteno'],
+          $varow2['alkuhyllyalue'],
+          $varow2['alkuhyllynro'],
+          $varow2['loppuhyllyalue'],
+          $varow2['loppuhyllynro']
+        );
 
         $s1_options = array();
         $s2_options = array();


### PR DESCRIPTION
Uusi ominaisuus jossa purkulistan tulostusjonossa reklamaatiot kasaantuvat yhdeksi purkulistaksi per varasto ja toimipaikka. Purun kuittaus muistaa mitkä reklamaatiot on tulostettu yhdelle purkulistalle ja kuittaus tehdään per lista. Kuittauksessa on myös mahdollisuus vaihtaa tuote lapsivaraston paikoille (tai tehdä purun yhteydessä se automaattisesti).

Tämä ominaisuus kytketään päälle "reklamaation käsittely" -yhtiön parametrin uudella optiolla: "Reklamaation käsittelyssä käytetään laajempaa prosessia purkulistalla ja vastaanottokuittauksella". Tämä toimii kuten laaja reklamaatiokäsittely, mutta "odottaa tuotteita" -vaihe ohitetaan ja reklamaatio menee purkulistan tulostusjonoon heti reklamaation valmiiksi laittamisen jälkeen.

