### PR TITLE
Tuoteperheiden hinnat verkkolaskulla

### DIFF
--- a/tilauskasittely/uudelleenluo_laskuaineisto.php
+++ b/tilauskasittely/uudelleenluo_laskuaineisto.php
@@ -604,7 +604,10 @@ if (isset($tee) and ($tee == "GENEROI" or $tee == "NAYTATILAUS") and $laskunumer
               // lasketaan isätuotteen riville lapsien hinnat yhteen
               $query = "SELECT
                         sum(tilausrivi.rivihinta) rivihinta,
-                        round(sum(tilausrivi.rivihinta) / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta,
+                        round(sum(tilausrivi.hinta
+                            * (tilausrivi.varattu + tilausrivi.kpl)
+                            * {$query_ale_lisa})
+                          / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta,
                         sum(round(tilausrivi.hinta * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}, $yhtiorow[hintapyoristys])) rivihinta_verollinen,
                         sum((tilausrivi.hinta / {$lasrow["vienti_kurssi"]}) / if ('$yhtiorow[alv_kasittely]'  = '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}) rivihinta_valuutassa
                         FROM tilausrivi

--- a/tilauskasittely/uudelleenluo_laskuaineisto.php
+++ b/tilauskasittely/uudelleenluo_laskuaineisto.php
@@ -605,7 +605,7 @@ if (isset($tee) and ($tee == "GENEROI" or $tee == "NAYTATILAUS") and $laskunumer
               $query = "SELECT
                         sum(tilausrivi.rivihinta) rivihinta,
                         round(sum(tilausrivi.hinta
-                            * (tilausrivi.varattu + tilausrivi.kpl)
+                            * tilausrivi.kpl
                             * {$query_ale_lisa})
                           / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta,
                         sum(round(tilausrivi.hinta * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}, $yhtiorow[hintapyoristys])) rivihinta_verollinen,

--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -2359,7 +2359,7 @@ else {
                     $query = "SELECT
                               sum(tilausrivi.rivihinta) rivihinta,
                               round(sum(tilausrivi.hinta
-                                  * (tilausrivi.varattu + tilausrivi.kpl)
+                                  * tilausrivi.kpl
                                   * {$query_ale_lisa})
                                 / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta,
                               sum(round(tilausrivi.hinta * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}, $yhtiorow[hintapyoristys])) rivihinta_verollinen,

--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -2358,7 +2358,10 @@ else {
                     // lasketaan isätuotteen riville lapsien hinnat yhteen
                     $query = "SELECT
                               sum(tilausrivi.rivihinta) rivihinta,
-                              round(sum(tilausrivi.rivihinta * if ('$yhtiorow[alv_kasittely]' = '', (1 + tilausrivi.alv / 100), 1)) / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta,
+                              round(sum(tilausrivi.hinta
+                                  * (tilausrivi.varattu + tilausrivi.kpl)
+                                  * {$query_ale_lisa})
+                                / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta,
                               sum(round(tilausrivi.hinta * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}, $yhtiorow[hintapyoristys])) rivihinta_verollinen,
                               sum((tilausrivi.hinta / {$lasrow["vienti_kurssi"]}) / if ('$yhtiorow[alv_kasittely]'  = '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}) rivihinta_valuutassa
                               FROM tilausrivi

--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -2499,7 +2499,6 @@ else {
               // Yksikköhinta on laskulla aina veroton
               if ($yhtiorow["alv_kasittely"] == '') {
                 $tilrow["hinta"] = $tilrow["hinta"] / (1 + $tilrow["alv"] / 100);
-
               }
 
               // Veron määrä

--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -2358,7 +2358,7 @@ else {
                     // lasketaan isätuotteen riville lapsien hinnat yhteen
                     $query = "SELECT
                               sum(tilausrivi.rivihinta) rivihinta,
-                              round(sum(tilausrivi.rivihinta) / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta,
+                              round(sum(tilausrivi.rivihinta * if ('$yhtiorow[alv_kasittely]' = '', (1 + tilausrivi.alv / 100), 1)) / $tilrow[kpl], '$yhtiorow[hintapyoristys]') hinta,
                               sum(round(tilausrivi.hinta * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}, $yhtiorow[hintapyoristys])) rivihinta_verollinen,
                               sum((tilausrivi.hinta / {$lasrow["vienti_kurssi"]}) / if ('$yhtiorow[alv_kasittely]'  = '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * tilausrivi.kpl * {$query_ale_lisa}) rivihinta_valuutassa
                               FROM tilausrivi
@@ -2499,6 +2499,7 @@ else {
               // Yksikköhinta on laskulla aina veroton
               if ($yhtiorow["alv_kasittely"] == '') {
                 $tilrow["hinta"] = $tilrow["hinta"] / (1 + $tilrow["alv"] / 100);
+
               }
 
               // Veron määrä


### PR DESCRIPTION
Näytettäessä laskulla vain perheen isä ja summattaessa lasten hinnat perheen isälle, käsiteltiin tuoteperheiden hintoja verottominan, vaikka yhtiöllä olisikin käytössä verolliset myyntihinnat. Tämä johti siihen, että kun yhtiöllä on käytössä verolliset myyntihinnat laskettiin vero kahteen kertaan pois hinnoista ja esimerkiksi verkkolaskulle meni liian alhaiset kappalehinnat. Tämä on nyt korjattu ja jatkossa tälläisetkin tuoteperheet käsitellään oikein.