### PR TITLE
Poistettu tuotepaikka laskun monistuksessa

### DIFF
--- a/monistalasku.php
+++ b/monistalasku.php
@@ -1668,13 +1668,44 @@ if ($tee == 'MONISTA') {
         $presult = pupe_query($pquery);
 
         if (mysql_num_rows($presult) == 0) {
+          // Jos paikkaa ei ole olemassa perustetaan sellainen varaston oletustietojen perusteella
+          $query = "SELECT alkuhyllyalue, alkuhyllynro
+                    FROM varastopaikat
+                    WHERE yhtio = '{$kukarow['yhtio']}'
+                    AND tunnus  = '{$rivirow['varasto']}'";
+          $oletus_tuotepaikka_res = pupe_query($query);
+          $oletus_tuotepaikka_row = mysql_fetch_assoc($oletus_tuotepaikka_res);
+
+          lisaa_tuotepaikka($rivirow['tuoteno'], $oletus_tuotepaikka_row['alkuhyllyalue'], $oletus_tuotepaikka_row['alkuhyllynro'], 0, 0, "Tuotetta lis‰tt‰ess‰", "", 0, 0, 0);
+
+          $p_hyllyalue  = $oletus_tuotepaikka_row["alkuhyllyalue"];
+          $p_hyllynro    = $oletus_tuotepaikka_row["alkuhyllynro"];
+          $p_hyllyvali  = '0';
+          $p_hyllytaso  = '0';
+
+          // Varmistetaan viel‰ ett‰ todella luotiin varastopaikka
           $p2query = "SELECT hyllyalue, hyllynro, hyllyvali, hyllytaso
                       FROM tuotepaikat
-                      WHERE yhtio  = '{$monistarow['yhtio']}'
-                      AND tuoteno  = '{$rivirow['tuoteno']}'
-                      AND oletus  != ''
+                      WHERE yhtio   = '{$monistarow['yhtio']}'
+                      AND tuoteno   = '{$rivirow['tuoteno']}'
+                      AND hyllyalue =  '{$p_hyllyalue}'
+                      AND hyllynro  = '{$p_hyllynro}'
+                      AND hyllyvali =  '{$p_hyllyvali}'
+                      AND hyllytaso =  '{$p_hyllytaso}'
                       LIMIT 1";
           $p2result = pupe_query($p2query);
+
+          // Pidet‰‰n viel‰ supersafetyna t‰m‰, ett‰ jos ei onnistuta tuota varastopaikkaa
+          // perustamaan niin laitetaan se sitten tuonne oletuspaikalle
+          if (mysql_num_rows($p2result) == 0) {
+            $p2query = "SELECT hyllyalue, hyllynro, hyllyvali, hyllytaso
+                        FROM tuotepaikat
+                        WHERE yhtio  = '{$monistarow['yhtio']}'
+                        AND tuoteno  = '{$rivirow['tuoteno']}'
+                        AND oletus  != ''
+                        LIMIT 1";
+            $p2result = pupe_query($p2query);
+          }
 
           if (mysql_num_rows($p2result) == 1) {
             $paikka2row = mysql_fetch_assoc($p2result);

--- a/monistalasku.php
+++ b/monistalasku.php
@@ -1666,15 +1666,29 @@ if ($tee == 'MONISTA') {
         $presult = pupe_query($pquery);
 
         if (mysql_num_rows($presult) == 0) {
-          // Jos paikkaa ei ole olemassa perustetaan sellainen varaston oletustietojen perusteella
-          $query = "SELECT alkuhyllyalue, alkuhyllynro
-                    FROM varastopaikat
-                    WHERE yhtio = '{$kukarow['yhtio']}'
-                    AND tunnus  = '{$rivirow['varasto']}'";
-          $oletus_tuotepaikka_res = pupe_query($query);
-          $oletus_tuotepaikka_row = mysql_fetch_assoc($oletus_tuotepaikka_res);
+          // Onko alkuperäisessä vcarastossa toinen/uusi paikka?
+          $pquery = "SELECT *
+                     FROM tuotepaikat
+                     WHERE yhtio = '{$monistarow['yhtio']}'
+                     AND tuoteno = '{$rivirow['tuoteno']}'
+                     AND varasto = '{$rivirow['varasto']}'
+                     LIMIT 1";
+          $presult = pupe_query($pquery);
 
-          $uusipaikka = lisaa_tuotepaikka($rivirow['tuoteno'], $oletus_tuotepaikka_row['alkuhyllyalue'], $oletus_tuotepaikka_row['alkuhyllynro'], 0, 0, "", "", 0, 0, 0);
+          if (mysql_num_rows($presult) == 1) {
+            $uusipaikka = mysql_fetch_assoc($presult);
+          }
+          else {
+            // Jos paikkaa ei ole olemassa perustetaan sellainen varaston oletustietojen perusteella
+            $query = "SELECT alkuhyllyalue, alkuhyllynro
+                      FROM varastopaikat
+                      WHERE yhtio = '{$kukarow['yhtio']}'
+                      AND tunnus  = '{$rivirow['varasto']}'";
+            $oletus_tuotepaikka_res = pupe_query($query);
+            $oletus_tuotepaikka_row = mysql_fetch_assoc($oletus_tuotepaikka_res);
+
+            $uusipaikka = lisaa_tuotepaikka($rivirow['tuoteno'], $oletus_tuotepaikka_row['alkuhyllyalue'], $oletus_tuotepaikka_row['alkuhyllynro'], 0, 0, "", "", 0, 0, 0);
+          }
 
           $rivirow["hyllyalue"] = $uusipaikka["hyllyalue"];
           $rivirow["hyllynro"]  = $uusipaikka["hyllynro"];

--- a/monistalasku.php
+++ b/monistalasku.php
@@ -1653,18 +1653,16 @@ if ($tee == 'MONISTA') {
       }
 
       foreach ($_rivit as $rivirow) {
-        $paikkavaihtu = 0;
         $uusikpl = 0;
 
         $pquery = "SELECT tunnus
                    FROM tuotepaikat
                    WHERE yhtio   = '{$monistarow['yhtio']}'
                    AND tuoteno   = '{$rivirow['tuoteno']}'
-                   AND hyllyalue =  '{$rivirow['hyllyalue']}'
+                   AND hyllyalue = '{$rivirow['hyllyalue']}'
                    AND hyllynro  = '{$rivirow['hyllynro']}'
-                   AND hyllyvali =  '{$rivirow['hyllyvali']}'
-                   AND hyllytaso =  '{$rivirow['hyllytaso']}'
-                   LIMIT 1";
+                   AND hyllyvali = '{$rivirow['hyllyvali']}'
+                   AND hyllytaso = '{$rivirow['hyllytaso']}'";
         $presult = pupe_query($pquery);
 
         if (mysql_num_rows($presult) == 0) {
@@ -1676,36 +1674,12 @@ if ($tee == 'MONISTA') {
           $oletus_tuotepaikka_res = pupe_query($query);
           $oletus_tuotepaikka_row = mysql_fetch_assoc($oletus_tuotepaikka_res);
 
-          $oletus_tuotepaikka_row[0] = lisaa_tuotepaikka($rivirow['tuoteno'], $oletus_tuotepaikka_row['alkuhyllyalue'], $oletus_tuotepaikka_row['alkuhyllynro'], 0, 0, "", "", 0, 0, 0);
+          $uusipaikka = lisaa_tuotepaikka($rivirow['tuoteno'], $oletus_tuotepaikka_row['alkuhyllyalue'], $oletus_tuotepaikka_row['alkuhyllynro'], 0, 0, "", "", 0, 0, 0);
 
-          // Varmistetaan viel‰ ett‰ todella luotiin varastopaikka
-          $p2query = "SELECT hyllyalue, hyllynro, hyllyvali, hyllytaso
-                      FROM tuotepaikat
-                      WHERE yhtio   = '{$monistarow['yhtio']}'
-                      AND tuoteno   = '{$rivirow['tuoteno']}'
-                      AND hyllyalue =  '{$oletus_tuotepaikka_row[0]['hyllyalue']}'
-                      AND hyllynro  = '{$oletus_tuotepaikka_row[0]['hyllynro']}'
-                      AND hyllyvali =  '{$oletus_tuotepaikka_row[0]['hyllyvali']}'
-                      AND hyllytaso =  '{$oletus_tuotepaikka_row[0]['hyllytaso']}'
-                      LIMIT 1";
-          $p2result = pupe_query($p2query);
-
-          // Pidet‰‰n viel‰ supersafetyna t‰m‰, ett‰ jos ei onnistuta tuota varastopaikkaa
-          // perustamaan niin laitetaan se sitten tuonne oletuspaikalle
-          if (mysql_num_rows($p2result) == 0) {
-            $p2query = "SELECT hyllyalue, hyllynro, hyllyvali, hyllytaso
-                        FROM tuotepaikat
-                        WHERE yhtio  = '{$monistarow['yhtio']}'
-                        AND tuoteno  = '{$rivirow['tuoteno']}'
-                        AND oletus  != ''
-                        LIMIT 1";
-            $p2result = pupe_query($p2query);
-          }
-
-          if (mysql_num_rows($p2result) == 1) {
-            $paikka2row = mysql_fetch_assoc($p2result);
-            $paikkavaihtu = 1;
-          }
+          $rivirow["hyllyalue"] = $uusipaikka["hyllyalue"];
+          $rivirow["hyllynro"]  = $uusipaikka["hyllynro"];
+          $rivirow["hyllyvali"] = $uusipaikka["hyllyvali"];
+          $rivirow["hyllytaso"] = $uusipaikka["hyllytaso"];
         }
 
         $rfields = "yhtio";
@@ -1788,38 +1762,6 @@ if ($tee == 'MONISTA') {
             }
             else {
               $rvalues .= ", '".($rivirow["kpl"] + $rivirow["jt"] + $rivirow["varattu"])."'";
-            }
-            break;
-          case 'hyllyalue':
-            if ($paikkavaihtu == 1) {
-              $rvalues .= ", '{$paikka2row['hyllyalue']}'";
-            }
-            else {
-              $rvalues .= ", '{$rivirow['hyllyalue']}'";
-            }
-            break;
-          case 'hyllynro':
-            if ($paikkavaihtu == 1) {
-              $rvalues .= ", '{$paikka2row['hyllynro']}'";
-            }
-            else {
-              $rvalues .= ", '{$rivirow['hyllynro']}'";
-            }
-            break;
-          case 'hyllyvali':
-            if ($paikkavaihtu == 1) {
-              $rvalues .= ", '{$paikka2row['hyllyvali']}'";
-            }
-            else {
-              $rvalues .= ", '{$rivirow['hyllyvali']}'";
-            }
-            break;
-          case 'hyllytaso':
-            if ($paikkavaihtu == 1) {
-              $rvalues .= ", '{$paikka2row['hyllytaso']}'";
-            }
-            else {
-              $rvalues .= ", '{$rivirow['hyllytaso']}'";
             }
             break;
           case 'alv':

--- a/monistalasku.php
+++ b/monistalasku.php
@@ -1893,38 +1893,31 @@ if ($tee == 'MONISTA') {
               $uusi_tunken = "ostorivitunnus";
             }
 
-            $query = "SELECT sarjanumeroseuranta FROM tuote WHERE yhtio = '{$kukarow['yhtio']}' AND tuoteno = '{$rivirow['tuoteno']}'";
+            $query = "SELECT sarjanumeroseuranta
+                      FROM tuote
+                      WHERE yhtio = '{$kukarow['yhtio']}'
+                      AND tuoteno = '{$rivirow['tuoteno']}'";
             $sarjatuoteres = pupe_query($query);
             $sarjatuoterow = mysql_fetch_assoc($sarjatuoteres);
 
             if ($sarjatuoterow["sarjanumeroseuranta"] == "E" or $sarjatuoterow["sarjanumeroseuranta"] == "F" or $sarjatuoterow["sarjanumeroseuranta"] == "G") {
               $query = "INSERT INTO sarjanumeroseuranta
-                        SET yhtio    = '{$kukarow['yhtio']}',
-                        tuoteno       = '{$rivirow['tuoteno']}',
-                        sarjanumero   = '{$sarjarow['sarjanumero']}',
-                        lisatieto     = '{$sarjarow['lisatieto']}',
-                        kaytetty      = '{$sarjarow['kaytetty']}',
-                        {$uusi_tunken}  = '{$insid}',
-                        takuu_alku    = '{$sarjarow['takuu_alku']}',
-                        takuu_loppu   = '{$sarjarow['takuu_loppu']}',
-                        parasta_ennen = '{$sarjarow['parasta_ennen']}',
-                        era_kpl       = '{$sarjarow['era_kpl']}',";
-
-              if ($paikkavaihtu == 1) {
-                $query .= "  hyllyalue   = '{$paikka2row['hyllyalue']}',
-                      hyllynro    = '{$paikka2row['hyllynro']}',
-                      hyllytaso   = '{$paikka2row['hyllytaso']}',
-                      hyllyvali   = '{$paikka2row['hyllyvali']}',";
-              }
-              else {
-                $query .= "  hyllyalue   = '{$rivirow['hyllyalue']}',
-                      hyllynro    = '{$rivirow['hyllynro']}',
-                      hyllytaso   = '{$rivirow['hyllytaso']}',
-                      hyllyvali   = '{$rivirow['hyllyvali']}',";
-              }
-
-              $query .= "  laatija      = '{$kukarow['kuka']}',
-                    luontiaika    = now()";
+                        SET yhtio      = '{$kukarow['yhtio']}',
+                        tuoteno        = '{$rivirow['tuoteno']}',
+                        sarjanumero    = '{$sarjarow['sarjanumero']}',
+                        lisatieto      = '{$sarjarow['lisatieto']}',
+                        kaytetty       = '{$sarjarow['kaytetty']}',
+                        {$uusi_tunken} = '{$insid}',
+                        takuu_alku     = '{$sarjarow['takuu_alku']}',
+                        takuu_loppu    = '{$sarjarow['takuu_loppu']}',
+                        parasta_ennen  = '{$sarjarow['parasta_ennen']}',
+                        era_kpl        = '{$sarjarow['era_kpl']}',
+                        hyllyalue      = '{$rivirow['hyllyalue']}',
+                        hyllynro       = '{$rivirow['hyllynro']}',
+                        hyllytaso      = '{$rivirow['hyllytaso']}',
+                        hyllyvali      = '{$rivirow['hyllyvali']}',
+                        laatija        = '{$kukarow['kuka']}',
+                        luontiaika     = now()";
               $sres = pupe_query($query);
             }
             else {
@@ -1942,53 +1935,33 @@ if ($tee == 'MONISTA') {
                 $sarjarow1 = mysql_fetch_assoc($sarjares1);
 
                 $query = "UPDATE sarjanumeroseuranta
-                          SET {$uusi_tunken} = '{$insid}', ";
-
-                if ($paikkavaihtu == 1) {
-                  $query .= "  hyllyalue   = '{$paikka2row['hyllyalue']}',
-                        hyllynro    = '{$paikka2row['hyllynro']}',
-                        hyllytaso   = '{$paikka2row['hyllytaso']}',
-                        hyllyvali   = '{$paikka2row['hyllyvali']}'";
-                }
-                else {
-                  $query .= "  hyllyalue   = '{$rivirow['hyllyalue']}',
-                        hyllynro    = '{$rivirow['hyllynro']}',
-                        hyllytaso   = '{$rivirow['hyllytaso']}',
-                        hyllyvali   = '{$rivirow['hyllyvali']}'";
-                }
-
-                $query .= "  WHERE tunnus   = '{$sarjarow1['tunnus']}'
-                      AND yhtio    = '{$kukarow['yhtio']}'";
+                          SET {$uusi_tunken} = '{$insid}',
+                          hyllyalue   = '{$rivirow['hyllyalue']}',
+                          hyllynro    = '{$rivirow['hyllynro']}',
+                          hyllytaso   = '{$rivirow['hyllytaso']}',
+                          hyllyvali   = '{$rivirow['hyllyvali']}'
+                          WHERE tunnus = '{$sarjarow1['tunnus']}'
+                          AND yhtio    = '{$kukarow['yhtio']}'";
                 $sres = pupe_query($query);
               }
               else {
                 $query = "INSERT INTO sarjanumeroseuranta
-                          SET yhtio    = '{$kukarow['yhtio']}',
-                          tuoteno       = '{$rivirow['tuoteno']}',
-                          sarjanumero   = '{$sarjarow['sarjanumero']}',
-                          lisatieto     = '{$sarjarow['lisatieto']}',
-                          kaytetty      = '{$sarjarow['kaytetty']}',
-                          {$uusi_tunken}  = '{$insid}',
-                          takuu_alku    = '{$sarjarow['takuu_alku']}',
-                          takuu_loppu   = '{$sarjarow['takuu_loppu']}',
-                          parasta_ennen = '{$sarjarow['parasta_ennen']}',
-                          era_kpl       = '{$sarjarow['era_kpl']}',";
-
-                if ($paikkavaihtu == 1) {
-                  $query .= "  hyllyalue   = '{$paikka2row['hyllyalue']}',
-                        hyllynro    = '{$paikka2row['hyllynro']}',
-                        hyllytaso   = '{$paikka2row['hyllytaso']}',
-                        hyllyvali   = '{$paikka2row['hyllyvali']}',";
-                }
-                else {
-                  $query .= "  hyllyalue   = '{$rivirow['hyllyalue']}',
-                        hyllynro    = '{$rivirow['hyllynro']}',
-                        hyllytaso   = '{$rivirow['hyllytaso']}',
-                        hyllyvali   = '{$rivirow['hyllyvali']}',";
-                }
-
-                $query .= "  laatija      = '{$kukarow['kuka']}',
-                      luontiaika    = now()";
+                          SET yhtio      = '{$kukarow['yhtio']}',
+                          tuoteno        = '{$rivirow['tuoteno']}',
+                          sarjanumero    = '{$sarjarow['sarjanumero']}',
+                          lisatieto      = '{$sarjarow['lisatieto']}',
+                          kaytetty       = '{$sarjarow['kaytetty']}',
+                          {$uusi_tunken} = '{$insid}',
+                          takuu_alku     = '{$sarjarow['takuu_alku']}',
+                          takuu_loppu    = '{$sarjarow['takuu_loppu']}',
+                          parasta_ennen  = '{$sarjarow['parasta_ennen']}',
+                          era_kpl        = '{$sarjarow['era_kpl']}',
+                          hyllyalue      = '{$rivirow['hyllyalue']}',
+                          hyllynro       = '{$rivirow['hyllynro']}',
+                          hyllytaso      = '{$rivirow['hyllytaso']}',
+                          hyllyvali      = '{$rivirow['hyllyvali']}',
+                          laatija        = '{$kukarow['kuka']}',
+                          luontiaika     = now()";
                 $sres = pupe_query($query);
               }
             }
@@ -2085,7 +2058,6 @@ if ($tee == 'MONISTA') {
         $cores = pupe_query($query);
       }
 
-
       // Korjataanko rahdit?
       if ($toim == '' and $kumpi == 'MONISTA' and $korjrahdit == 'on' and $monistarow['laskunro'] > 0 and $yhtiorow['rahti_hinnoittelu'] == '') {
 
@@ -2166,6 +2138,7 @@ if ($tee == 'MONISTA') {
       }
     }
   }
+
   $tee = ''; //menn‰‰n alkuun
 }
 

--- a/monistalasku.php
+++ b/monistalasku.php
@@ -1676,22 +1676,17 @@ if ($tee == 'MONISTA') {
           $oletus_tuotepaikka_res = pupe_query($query);
           $oletus_tuotepaikka_row = mysql_fetch_assoc($oletus_tuotepaikka_res);
 
-          lisaa_tuotepaikka($rivirow['tuoteno'], $oletus_tuotepaikka_row['alkuhyllyalue'], $oletus_tuotepaikka_row['alkuhyllynro'], 0, 0, "Tuotetta lisättäessä", "", 0, 0, 0);
-
-          $p_hyllyalue  = $oletus_tuotepaikka_row["alkuhyllyalue"];
-          $p_hyllynro    = $oletus_tuotepaikka_row["alkuhyllynro"];
-          $p_hyllyvali  = '0';
-          $p_hyllytaso  = '0';
+          $oletus_tuotepaikka_row[0] = lisaa_tuotepaikka($rivirow['tuoteno'], $oletus_tuotepaikka_row['alkuhyllyalue'], $oletus_tuotepaikka_row['alkuhyllynro'], 0, 0, "", "", 0, 0, 0);
 
           // Varmistetaan vielä että todella luotiin varastopaikka
           $p2query = "SELECT hyllyalue, hyllynro, hyllyvali, hyllytaso
                       FROM tuotepaikat
                       WHERE yhtio   = '{$monistarow['yhtio']}'
                       AND tuoteno   = '{$rivirow['tuoteno']}'
-                      AND hyllyalue =  '{$p_hyllyalue}'
-                      AND hyllynro  = '{$p_hyllynro}'
-                      AND hyllyvali =  '{$p_hyllyvali}'
-                      AND hyllytaso =  '{$p_hyllytaso}'
+                      AND hyllyalue =  '{$oletus_tuotepaikka_row[0]['hyllyalue']}'
+                      AND hyllynro  = '{$oletus_tuotepaikka_row[0]['hyllynro']}'
+                      AND hyllyvali =  '{$oletus_tuotepaikka_row[0]['hyllyvali']}'
+                      AND hyllytaso =  '{$oletus_tuotepaikka_row[0]['hyllytaso']}'
                       LIMIT 1";
           $p2result = pupe_query($p2query);
 

--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -2495,7 +2495,8 @@ if ($toimittamatta > 0 or trim($var) != '' or $rivityyppi == 'O') {
       $yhtiorow['tee_siirtolista_myyntitilaukselta'] == 'K' and
       $laskurow["tilaustyyppi"] != "U" and
       ($_tarjouksella or $_osto_myyntitilaukselta or $_extranetista) and
-      !in_array($var, array('V', 'H', 'P'))) {
+      !in_array($var, array('V', 'H', 'P'))
+      and $kpl > 0) {
 
       if (!empty($laskurow['varasto'])) {
         $kohde_varastot = array($laskurow['varasto']);
@@ -2554,7 +2555,7 @@ if ($toimittamatta > 0 or trim($var) != '' or $rivityyppi == 'O') {
           $myy_hyllynro_temp = $tuotepaikka['hyllynro'];
           $myy_hyllytaso_temp = $tuotepaikka['hyllytaso'];
           $myy_hyllyvali_temp = $tuotepaikka['hyllyvali'];
-
+echo "2558 <br><br>";
           $paivita_hyllyt_varastosiirto = true;
           break;
         }

--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -2227,11 +2227,11 @@ if ($rivityyppi != 'O' and trim($var) == "" and $trow["tuoteno"] != "") {
                 }
               }
 
-              $rivitunnus = 0;              
+              $rivitunnus = 0;
               $tuotenimitys_force = "";
               $omalle_tilaukselle = "";
               $ale_peruste = "";
-              
+
               if ($toimittamatta == 0) {
                 $kommentti = "";
                 $tuotenimitys = "";
@@ -2555,7 +2555,7 @@ if ($toimittamatta > 0 or trim($var) != '' or $rivityyppi == 'O') {
           $myy_hyllynro_temp = $tuotepaikka['hyllynro'];
           $myy_hyllytaso_temp = $tuotepaikka['hyllytaso'];
           $myy_hyllyvali_temp = $tuotepaikka['hyllyvali'];
-echo "2558 <br><br>";
+
           $paivita_hyllyt_varastosiirto = true;
           break;
         }


### PR DESCRIPTION
Kun laskua monistettaessa alkuperäisen laskun varastopaikkaa ei jollain tuotteella enää ole olemassa meni tälläinen tuote tuotteen oletuspaikalta. Muutettu niin, että perustetaan tarvittaessa tuotteella paikka laskun monistuksen yhteydessä.

Samalla korjattiin ettei ehdoteta hyvitysriveille varastosiirtoa, jos tee_automaattinen_siirto_myyntitilaukselta on päällä.