### PR TITLE
* Oman kustannuspaikan tuloslaskelma & pääkirja

### DIFF
--- a/inc/laskuhaku.inc
+++ b/inc/laskuhaku.inc
@@ -370,19 +370,16 @@ if ($tee != '') {
   else {
     $tiliointilisa = '';
   }
-  
-  // Rajataan AINA käyttäjän osaston kustannuspaikalla
-  $vainomakustp_lisa = "";
-
-  if (!empty($vainomakustp)) {    
-    $vainomakustp_lisa = " and tiliointi.kustp = '{$kukarow["osasto"]}' ";
-  }
 
   if ($rajaus == "" or !is_numeric($rajaus)) {
     $rajaus = 50;
   }
   else {
     $rajaus = round($rajaus);
+  }
+  
+  if (!empty($jarj)) {
+    $jarj .= ", tunnus";
   }
 
   $query = "SELECT DISTINCT lasku.tapvm, lasku.erpcm, concat_ws('<br>', lasku.nimi, lasku.nimitark) nimi,
@@ -393,7 +390,6 @@ if ($tee != '') {
             WHERE $ehto
             and lasku.yhtio = '$kukarow[yhtio]'
             $lisa
-            $vainomakustp_lisa
             ORDER BY $jarj
             LIMIT $alku, $rajaus";
   $result = pupe_query($query);

--- a/inc/paakirja.inc
+++ b/inc/paakirja.inc
@@ -29,7 +29,7 @@ if ($toim_ytunnus != '' or $toimittajaid != '') {
 
 echo "<font class='head'>".t("P‰‰- ja p‰iv‰kirja")."</font><hr>
     <form name = 'valinta' action = 'raportit.php' method='post'>
-    <input type = 'hidden' name = 'toim' value = 'paakirja'>
+    <input type = 'hidden' name = 'toim' value = '$toim'>
     <input type = 'hidden' name = 'lopetus' value = '$lopetus'>
     <table><tr>
     <th>".t("Tyyppi")."</th>
@@ -418,7 +418,7 @@ if ($tee != "") {
 
     // Jos haetaan p‰iv‰m‰‰rill‰ niin nollataan tilikausi
     $tkausi = 0;
-    
+
     $query = "SELECT *
               FROM tilikaudet
               WHERE yhtio         = '$kukarow[yhtio]'

--- a/inc/toimittajahaku.inc
+++ b/inc/toimittajahaku.inc
@@ -311,7 +311,7 @@ if ($tee == 'A') {
       if ($limit != "NO") {
         $limlis = " LIMIT $alku, 50 ";
       }
-      
+
       if (isset($lisa) and strpos($lisa, "tiliointi.") !== FALSE or !empty($vainomakustp)) {
         $tiliointilisa = " JOIN tiliointi ON (tiliointi.yhtio = lasku.yhtio
                              AND tiliointi.ltunnus = lasku.tunnus
@@ -321,13 +321,6 @@ if ($tee == 'A') {
       else {
         $tiliointilisa = '';
       }
-      
-      // Rajataan AINA käyttäjän osaston kustannuspaikalla
-      $vainomakustp_lisa = "";
-  
-      if (!empty($vainomakustp)) {
-        $vainomakustp_lisa = " and tiliointi.kustp = '{$kukarow["osasto"]}' ";
-      }                  
 
       $query = "SELECT DISTINCT lasku.tapvm, lasku.erpcm, lasku.summa, lasku.valkoodi, lasku.vienti,
                 concat_ws(' ', lasku.viite, lasku.viesti) 'viite/viesti', lasku.ebid, lasku.tila, lasku.tunnus,
@@ -339,7 +332,6 @@ if ($tee == 'A') {
                 $toimiliilisa
                 $th_lisa
                 $aikalisa
-                $vainomakustp_lisa
                 and lasku.tila in ('H', 'M', 'P', 'Q', 'Y')
                 ORDER BY lasku.tapvm desc
                 $limlis";

--- a/raportit.php
+++ b/raportit.php
@@ -42,8 +42,9 @@ $cleantoim = $toim;
 if (substr($toim, -4) == '_OKP') {
   // käyttäjän osasto kertoo oletuskustannuspaikan
   $vainomakustp = TRUE;
-  $mul_kustp[] = $kukarow["osasto"];
-  $cleantoim = substr($toim, 0, -4);
+  $mul_kustp    = array();
+  $mul_kustp[]  = $kukarow["osasto"];
+  $cleantoim    = substr($toim, 0, -4);
 }
 
 // Livesearch jutut

--- a/tilauskasittely/monivalintalaatikot.inc
+++ b/tilauskasittely/monivalintalaatikot.inc
@@ -2125,9 +2125,16 @@ foreach ($monivalintalaatikot as $monivalintalaatikko) {
         }
       </script> ";
 
+    $omakustprajaus = "";
+
+    if (!empty($vainomakustp)) {
+        $omakustprajaus = " and kustannuspaikka.tunnus = {$kukarow["osasto"]} ";
+    }
+
     $query = "SELECT tunnus, nimi, koodi, isa_tarkenne
               FROM kustannuspaikka
               WHERE yhtio   = '$kukarow[yhtio]'
+              {$omakustprajaus}
               and kaytossa != 'E'
               and tyyppi    = 'K'
               ORDER BY isa_tarkenne, koodi+0, koodi, nimi";


### PR DESCRIPTION
Voidaan rajata tuloslaskelma/tase ja pääkirja näyttämään vain käyttäjän oman osaston, eli kustannuspaikan laskuja. Tämä ominaisuus toimii myös laskuhaku-ohjelmassa ja toimittajahaku-ohjelmassa.

Valikkoihin tulee perustaa uudet rivit:
raportit/tuloslaskelma.php, alatila --> _OKP
raportit.php, alatila --> paakirja_OKP