### PR TITLE
Myyntitilauksen luottorajaesto

### DIFF
--- a/tilauskasittely/tilaus-valmis.inc
+++ b/tilauskasittely/tilaus-valmis.inc
@@ -174,7 +174,7 @@ while ($rekisterinumero_row = mysql_fetch_assoc($rekisterinumero_result)) {
   pupe_query($query);
 }
 
-if (!empty($ylivito) and in_array($yhtiorow['erapaivan_ylityksen_toimenpide'], array('J','L'))) {
+if ($ylivito > 0 and in_array($yhtiorow['erapaivan_ylityksen_toimenpide'], array('J','L'))) {
   $luottorajavirhe_ylivito_valmis = false;
 }
 elseif (!empty($luottorajavirhe) and in_array($yhtiorow['luottorajan_ylitys'], array('J','L'))) {


### PR DESCRIPTION
Myyntitilaus saattoi jäädä erheellisesti auki ruudulle kun se laitettiin valmiiksi ja myös ruudulle tuli virheellisesti ilmoitus puutteellisista laskutustiedoista vaikka laskutustiedot olivat kunnossa. Tämä on nyt korjattu ja tilaukset saa laitettua oikein valmiiksi.