### PR TITLE
Maksuehdon muuttaminen

### DIFF
--- a/tilauskasittely/tilaus-valmis.inc
+++ b/tilauskasittely/tilaus-valmis.inc
@@ -750,13 +750,13 @@ else {
       pupesoft_tulosta_lahete($params);
     }
 
-    // jos on myyntitilaus ja ei haluttu tulostaa lähetettä, merkataan rivit kerätyksi 
+    // jos on myyntitilaus ja ei haluttu tulostaa lähetettä, merkataan rivit kerätyksi
     // ja toimitetuksi ja laitetaan alatila D
     if ($laskurow['eilahetetta'] != '' or $laskurow['sisainen'] != '') {
-      if ($laskurow['sisainen'] == '' and ($kateinen == 'X' or $itsetulostus == "X" 
+      if ($laskurow['sisainen'] == '' and ($kateinen == 'X' or $itsetulostus == "X"
         or $laskurow["vienti"] != '')) {
         // Jos kyseessä on käteismyyntiä tai maksuehdolla on itsetulostustäppä tai vientiä,
-        // merkataan tilaukset kerätyksi mutta ei toimitetuksi ja alatila C/B 
+        // merkataan tilaukset kerätyksi mutta ei toimitetuksi ja alatila C/B
         // tai toimitettu tilaus muutetaan maksuehdosta käteiseksi, tila pysyy D
         if ($laskurow["alatila"] == 'D') {
           $alat = "D";
@@ -805,12 +805,12 @@ else {
         }
       }
 
-      if ($laskurow["sisainen"] != '' 
-        or ($kateinen == 'X' and $kateisohitus == "" 
-          and ($kukarow["kassamyyja"] != '' or $kertakassa != "") 
-          and $laskurow["vienti"] == '' 
+      if ($laskurow["sisainen"] != ''
+        or ($kateinen == 'X' and $kateisohitus == ""
+          and ($kukarow["kassamyyja"] != '' or $kertakassa != "")
+          and $laskurow["vienti"] == ''
           and $laskurow["alatila"] == 'D')
-        or $korkolasku == 'kylla') {
+      ) {
         //laskutetaan koko tilaus heti jos se on sisainen lasku
         // tai maksuehto vaihdettu käteismyynniksi
         $laskutettavat  = $laskurow["tunnus"];

--- a/tilauskasittely/tilaus-valmis.inc
+++ b/tilauskasittely/tilaus-valmis.inc
@@ -805,8 +805,12 @@ else {
         }
       }
 
-      if ($laskurow["sisainen"] != '' or ($kukarow["kassamyyja"] != '' 
-        and $laskurow["alatila"] == 'D')) {
+      if ($laskurow["sisainen"] != '' 
+        or ($kateinen == 'X' and $kateisohitus == "" 
+          and ($kukarow["kassamyyja"] != '' or $kertakassa != "") 
+          and $laskurow["vienti"] == '' 
+          and $laskurow["alatila"] == 'D')
+        or $korkolasku == 'kylla') {
         //laskutetaan koko tilaus heti jos se on sisainen lasku
         // tai maksuehto vaihdettu käteismyynniksi
         $laskutettavat  = $laskurow["tunnus"];

--- a/tilauskasittely/tilaus-valmis.inc
+++ b/tilauskasittely/tilaus-valmis.inc
@@ -750,11 +750,18 @@ else {
       pupesoft_tulosta_lahete($params);
     }
 
-    // jos on myyntitilaus ja ei haluttu tulostaa lähetettä, merkataan rivit kerätyksi ja toimitetuksi ja laitetaan alatila D
+    // jos on myyntitilaus ja ei haluttu tulostaa lähetettä, merkataan rivit kerätyksi 
+    // ja toimitetuksi ja laitetaan alatila D
     if ($laskurow['eilahetetta'] != '' or $laskurow['sisainen'] != '') {
-      if ($laskurow['sisainen'] == '' and ($kateinen == 'X' or $itsetulostus == "X" or $laskurow["vienti"] != '')) {
-        // Jos kyseessä on käteismyyntiä tai maksuehtolla on itsetulostustäppä tai vientiä, merkataan tilaukset kerätyksi mutta ei toimitetuksi ja alatila C/B
-        if ($laskurow["vienti"] != '') {
+      if ($laskurow['sisainen'] == '' and ($kateinen == 'X' or $itsetulostus == "X" 
+        or $laskurow["vienti"] != '')) {
+        // Jos kyseessä on käteismyyntiä tai maksuehdolla on itsetulostustäppä tai vientiä,
+        // merkataan tilaukset kerätyksi mutta ei toimitetuksi ja alatila C/B 
+        // tai toimitettu tilaus muutetaan maksuehdosta käteiseksi, tila pysyy D
+        if ($kukarow["kassamyyja"] != '' and $laskurow["alatila"] == 'D') {
+          $alat = "D";
+        }
+        elseif ($laskurow["vienti"] != '') {
           $alat = "B";
         }
         else {
@@ -798,8 +805,10 @@ else {
         }
       }
 
-      if ($laskurow["sisainen"] != '') {
+      if ($laskurow["sisainen"] != '' or ($kukarow["kassamyyja"] != '' 
+        and $laskurow["alatila"] == 'D')) {
         //laskutetaan koko tilaus heti jos se on sisainen lasku
+        // tai maksuehto vaihdettu käteismyynniksi
         $laskutettavat  = $laskurow["tunnus"];
         $tee       = "TARKISTA";
         $laskutakaikki   = "KYLLA";

--- a/tilauskasittely/tilaus-valmis.inc
+++ b/tilauskasittely/tilaus-valmis.inc
@@ -758,7 +758,7 @@ else {
         // Jos kyseessä on käteismyyntiä tai maksuehdolla on itsetulostustäppä tai vientiä,
         // merkataan tilaukset kerätyksi mutta ei toimitetuksi ja alatila C/B 
         // tai toimitettu tilaus muutetaan maksuehdosta käteiseksi, tila pysyy D
-        if ($kukarow["kassamyyja"] != '' and $laskurow["alatila"] == 'D') {
+        if ($laskurow["alatila"] == 'D') {
           $alat = "D";
         }
         elseif ($laskurow["vienti"] != '') {


### PR DESCRIPTION
Kassamyyjä laittaa myyntitilauksen valmiiksi (ja tilauksen otsikolla on "suoraan laskutukseen" ruksi), jolloin se menee toimitetuksi silloin kun kyse ei ole käteismyynnistä.

Jos tässä vaiheessa halutaan muuttaa myynti käteismyynniksi, menee tilaus kerätty tilaan, eikä anneta tehdä laskua, vaikka valitaan tilauksen otsikolle käteinen/pankkikortti.

Korjattu niin, että ei muuteta toimitetusta kerätyksi. Tällä tavalla saadaan tehtyä käteiskuitti ja saadaan tilaus laskutetuksi.