### PR TITLE
Ostotilauksen rivien luku excelistä

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -30797,3 +30797,31 @@ if (!function_exists("paata_kvartaali")) {
     return $nykyinen_kvartaali;
   }
 }
+
+function choose_correct_date($date) {
+  global $kukarow, $yhtiorow;
+
+  if (trim($date) == "") {
+    return '';
+  }
+
+  // Päivämäärä oli ymmärrettävässä muodossa
+  if (strtotime($date) !== false) {
+    // Palautetaan Y-m-d
+    return date('Y-m-d', strtotime($date));
+  }
+
+  // Excelissä date voi tulla integerinä
+  if (is_numeric($date)) {
+    /*  the date fields have integers that are the amount of days from 1900-00-00 */
+    return date('Y-m-d', mktime(0, 0, 0, 1, $date - 1, 1900));
+  }
+
+  // Ei osattu valita sopivaa päivää
+  echo "<font class='error'>";
+  echo t("Virheellinen päivämäärä");
+  echo " \"{$date}\"";
+  echo "</font><br>";
+
+  return '';
+}

--- a/tilauskasittely/mikrotilaus.inc
+++ b/tilauskasittely/mikrotilaus.inc
@@ -38,34 +38,6 @@ Toivottu ker‰ysajankohta
 Toivottu valmistusajankohta
 */
 
-function choose_correct_date($date) {
-  global $kukarow, $yhtiorow;
-
-  if (trim($date) == "") {
-    return '';
-  }
-
-  // P‰iv‰m‰‰r‰ oli ymm‰rrett‰v‰ss‰ muodossa
-  if (strtotime($date) !== false) {
-    // Palautetaan Y-m-d
-    return date('Y-m-d', strtotime($date));
-  }
-
-  // Exceliss‰ date voi tulla integerin‰
-  if (is_numeric($date)) {
-    /*  the date fields have integers that are the amount of days from 1900-00-00 */
-    return date('Y-m-d', mktime(0, 0, 0, 1, $date - 1, 1900));
-  }
-
-  // Ei osattu valita sopivaa p‰iv‰‰
-  echo "<font class='error'>";
-  echo t("Virheellinen p‰iv‰m‰‰r‰");
-  echo " \"{$date}\"";
-  echo "</font><br>";
-
-  return '';
-}
-
 if ($tee == "file") {
   if (is_uploaded_file($_FILES['userfile']['tmp_name']) === TRUE) {
     $timeparts = explode(" ", microtime());

--- a/tilauskasittely/mikrotilaus_ostotilaus.inc
+++ b/tilauskasittely/mikrotilaus_ostotilaus.inc
@@ -29,6 +29,7 @@ if ($tee == "file") {
       $kpl      = (float) str_replace(",", ".", $rivi[1]);
 
       $toimaika   = pupesoft_cleanstring($rivi[2]);
+      $toimaika = choose_correct_date($toimaika);
 
       if (trim($toimaika) == "") {
         $toimaika = $laskurow["toimaika"];


### PR DESCRIPTION
Ostotilausten tilausrivien excelissä luvussa pävimääräkentät eivät menneet aina oikein, koska excelin päivämäärätallennusmuodon käsittely ei onnistunut. Tällöin päivämääräksi tuli aina kuluva päivämäärä. Nyt osataan käsitellä myös excelin päivämäärien tallennusmuotoa jolloin päivämäärät saadan luettua oikein sisään.