### PR TITLE
Saapumisen jälkilaskenta

### DIFF
--- a/tilauskasittely/jalkilaskenta.inc
+++ b/tilauskasittely/jalkilaskenta.inc
@@ -561,7 +561,7 @@ if (!function_exists('korjaatapahtuma')) {
 
 if (!function_exists("hae_varastotilit")) {
   function hae_varastotilit($tuote_row) {
-    global $yhtiorow;
+    global $yhtiorow, $varastonmuutostili, $varastotili;
 
     $varastotili = $yhtiorow["varasto"];
     $varastonmuutostili = $yhtiorow["varastonmuutos"];


### PR DESCRIPTION
Jos jälkilaskenta korjasi myyntilaskun varastonmuutosstiliöintejä, korjattujen tiliöintirivien tilinumero jäi virheellisesti nollaksi