### PR TITLE
Verkkokaupassa maksetut verkkokauppatilaukset

### DIFF
--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -3862,6 +3862,11 @@ if (isset($jatka)) {
   if ($laskutuskielto != '') {
     $chn = '999';
   }
+  // Verkkokaupasta tulleilla tilauksilla, joilla on jo laskunumero tarkoittaa, ett‰ se on jo maksettu
+  // t‰m‰n takia tulee olla chn == 999, jotta osataan ker‰yksen j‰lkeen p‰ivitt‰‰ tilaus laskutettu-tilaan (LX)
+  elseif ($otsikon_laskurow["laatija"] == "Magento" and $otsikon_laskurow["laskunro"] != 0) {
+    $chn = '999';
+  }
   elseif ($liitostunnus != "") {
     $chn = $asiarow['chn'];
 

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -163,17 +163,17 @@ if (($nimi != '' and !isset($jatka) and $asiakasid == 0 and !isset($vaihdatoim_a
   $kutsuja     = "otsik.inc";
 
   if (isset($vaihdatoim_asiakas) and $tnimi != "") {
-    $ytunnus     = $tnimi;
+    $ytunnus    = $tnimi;
     $osoite     = $tosoite;
-    $postitp     = $tpostitp;
+    $postitp    = $tpostitp;
     $postino    = $tpostino;
     $tila       = "vaihdatoim_asiakas";
     $muutparametrit = $asiakasid;
-    $kutsuja     = "";
+    $kutsuja    = "";
   }
 
-  $asiakasid  = "";
-  $ahlopetus   = "tilauskasittely/tilaus_myynti.php////toim=$toim//tee=$tee//tilausnumero=$tilausnumero//mista=$mista//tila=$tila//from=ASIAKASYLLAPITO";
+  $asiakasid = "";
+  $ahlopetus = "tilauskasittely/tilaus_myynti.php////toim=$toim//tee=$tee//tilausnumero=$tilausnumero//mista=$mista//tila=$tila//from=ASIAKASYLLAPITO";
   $lause     = "<font class='head'>".t("Valitse asiakas").":</font><hr><br>";
 
   require "inc/asiakashaku.inc";
@@ -236,14 +236,14 @@ if ($kukarow['kesken'] > 0 and isset($laskurow) and (($laskurow['tila'] == 'N' a
   if (empty($_kateis) and empty($_jv)) {
 
     // Parametrejä saatanat.php:lle
-    $sytunnus       = $laskurow['ytunnus'];
+    $sytunnus        = $laskurow['ytunnus'];
     $sliitostunnus   = $laskurow['liitostunnus'];
-    $eiliittymaa    = "ON";
+    $eiliittymaa     = "ON";
     $luottorajavirhe = "";
-    $jvvirhe      = "";
-    $ylivito      = 0;
-    $trattavirhe    = "";
-    $laji        = "MA";
+    $jvvirhe         = "";
+    $ylivito         = 0;
+    $trattavirhe     = "";
+    $laji            = "MA";
     $grouppaus       = ($yhtiorow["myyntitilaus_saatavat"] == "Y") ? "ytunnus" : "";
 
     ob_start();
@@ -431,35 +431,32 @@ if ($erpcmvv != "" or $erpcmkk != "" or $erpcmpp != "" or $meapurow["erapvmkasin
   $erpcmkk = (int) $erpcmkk;
   $erpcmpp = (int) $erpcmpp;
 
-
-  if ($erpcmvv != "" or $erpcmkk != "" or $erpcmpp != "") {
-    if ($kukarow['extranet'] == '') {
-      if ($erpcmvv < date("Y")) {
-        echo "<font class='error'>".t("VIRHE: Syötetty eräpäivä on virheellinen")."!</font><br>";
-        $tee  = "OTSIK";
-        unset($jatka);
-        $erpcm_virhe = "X"; // apumuuttuja
-        if ($kukarow['kesken'] != 0) {
-          $tiedot_laskulta = "ok";
-        }
+  if ($kukarow['extranet'] == '' and empty($olderpcm) and ($erpcmvv != "" or $erpcmkk != "" or $erpcmpp != "")) {
+    if ($erpcmvv < date("Y")) {
+      echo "<font class='error'>".t("VIRHE: Syötetty eräpäivä on virheellinen")."!</font><br>";
+      $tee  = "OTSIK";
+      unset($jatka);
+      $erpcm_virhe = "X"; // apumuuttuja
+      if ($kukarow['kesken'] != 0) {
+        $tiedot_laskulta = "ok";
       }
-      elseif ($erpcmvv == date("Y") and ($erpcmkk < date("n") or $erpcmkk < date("m"))) {
-        echo "<font class='error'>".t("VIRHE: Syötetty eräpäivä on virheellinen")."!</font><br>";
-        $tee  = "OTSIK";
-        unset($jatka);
-        $erpcm_virhe = "X"; // apumuuttuja
-        if ($kukarow['kesken'] != 0) {
-          $tiedot_laskulta = "ok";
-        }
+    }
+    elseif ($erpcmvv == date("Y") and ($erpcmkk < date("n") or $erpcmkk < date("m"))) {
+      echo "<font class='error'>".t("VIRHE: Syötetty eräpäivä on virheellinen")."!</font><br>";
+      $tee  = "OTSIK";
+      unset($jatka);
+      $erpcm_virhe = "X"; // apumuuttuja
+      if ($kukarow['kesken'] != 0) {
+        $tiedot_laskulta = "ok";
       }
-      elseif ($erpcmvv == date("Y") and ($erpcmkk == date("n") or $erpcmkk == date("m")) and ($erpcmpp < date("j") or $erpcmpp < date("d"))) {
-        echo "<font class='error'>".t("VIRHE: Syötetty eräpäivä on virheellinen")."!</font><br>";
-        $tee  = "OTSIK";
-        unset($jatka);
-        $erpcm_virhe = "X"; // apumuuttuja
-        if ($kukarow['kesken'] != 0) {
-          $tiedot_laskulta = "ok";
-        }
+    }
+    elseif ($erpcmvv == date("Y") and ($erpcmkk == date("n") or $erpcmkk == date("m")) and ($erpcmpp < date("j") or $erpcmpp < date("d"))) {
+      echo "<font class='error'>".t("VIRHE: Syötetty eräpäivä on virheellinen")."!</font><br>";
+      $tee  = "OTSIK";
+      unset($jatka);
+      $erpcm_virhe = "X"; // apumuuttuja
+      if ($kukarow['kesken'] != 0) {
+        $tiedot_laskulta = "ok";
       }
     }
   }
@@ -1548,9 +1545,20 @@ if ($tila == "" and !isset($jatka)) {
       $vasen_sarake[$vasen] .= t("Ei käytössä");
     }
     else {
-      $vasen_sarake[$vasen] .= "<input type='text' name='erpcmpp' value='$erpcmpp' size='3'>
-          <input type='text' name='erpcmkk' value='$erpcmkk' size='3'>
-          <input type='text' name='erpcmvv' value='$erpcmvv' size='6'>";
+      $edis = "";
+
+      if ($srow["mapvm"] != '0000-00-00' and $srow["chn"] == '999') {
+        $edis = "disabled";
+
+        echo "<input type='hidden' name='olderpcm' value='OK'>";
+        echo "<input type='hidden' name='erpcmpp' value='$erpcmpp'>";
+        echo "<input type='hidden' name='erpcmkk' value='$erpcmkk'>";
+        echo "<input type='hidden' name='erpcmvv' value='$erpcmvv'>";
+      }
+
+      $vasen_sarake[$vasen] .= "<input type='text' name='erpcmpp' value='$erpcmpp' size='3' $edis>
+          <input type='text' name='erpcmkk' value='$erpcmkk' size='3' $edis>
+          <input type='text' name='erpcmvv' value='$erpcmvv' size='6' $edis>";
     }
     $vasen_sarake[$vasen] .= "</td>";
     $vasen++;
@@ -2496,9 +2504,13 @@ if ($tila == "" and !isset($jatka)) {
     $vasen_sarake[$vasen] .= "</select></td>";
     $vasen++;
 
-    if ($yhtiorow['laskutuskielto'] != 0 and $toim != "MYYNTITILI") {
+    if (!empty($yhtiorow['laskutuskielto']) and $toim != "MYYNTITILI") {
       $oikea_sarake[$oikea] = "<td>".t("Laskutuskieltoon").":</td><td><input type='checkbox' name='laskutuskielto' $laskkielto></td>";
       $oikea++;
+    }
+    elseif ($toim != "MYYNTITILI" and $srow['chn'] == '999') {
+      // Laskutuskielto on muilla tavoin asetettu (esim. verkkokauppatilausket) ja jätetään se päälle
+      echo "<input type='hidden' name='laskutuskielto' value='ON'>";
     }
 
     if ($toim == "RIVISYOTTO" or $toim == "PIKATILAUS") {
@@ -3860,11 +3872,6 @@ if (isset($jatka)) {
 
   //jos ollaan haluttu laskutuskielto laitetaan chn kenttään 999
   if ($laskutuskielto != '') {
-    $chn = '999';
-  }
-  // Verkkokaupasta tulleilla tilauksilla, joilla on jo laskunumero tarkoittaa, että se on jo maksettu
-  // tämän takia tulee olla chn == 999, jotta osataan keräyksen jälkeen päivittää tilaus laskutettu-tilaan (LX)
-  elseif ($otsikon_laskurow["laatija"] == "Magento" and $otsikon_laskurow["laskunro"] != 0) {
     $chn = '999';
   }
   elseif ($liitostunnus != "") {


### PR DESCRIPTION
Verkkokaupassa maksettuja tilauksia, jos kävi Pupen puolella muokkaamassa päivittyi laskun kanavointitieto vääräksi. Tämän takia tilausta ei osattu oikein päivittää laskutettu tilaan sen jälkeen, kun tilaus kerätyksi merkitään vaan tilaus jäi toimitettu tilaan siitä huolimatta, että se oli jo todellisuudessa myös laskutettu. Nyt tämä ongelma on korjattu ja verkkokaupasta tulleiden maksettujen tilausten laskun kanavointitietoa osataan käsitellä kuten kuuluu.