### PR TITLE
Varastosiirron muokkaaminen - keräyserät käytössä

### DIFF
--- a/tilauskasittely/tilaus-valmis-siirtolista.inc
+++ b/tilauskasittely/tilaus-valmis-siirtolista.inc
@@ -504,6 +504,29 @@ else {
         }
       }
       else {
+        // Jos yhtiön parametreissä on keräyserät A tarkistetaan asiakkaan takaa
+        if ($yhtiorow['kerayserat'] == 'A') {
+          // Haetaan kerayseratieto asiakkaan takaa
+          $query = "SELECT kerayserat
+                    FROM asiakas
+                    WHERE yhtio = '{$kukarow['yhtio']}'
+                    AND tunnus  = '{$laskurow['liitostunnus']}'";
+          $asrow = mysql_fetch_assoc(pupe_query($query));
+        }
+
+        // Poistetaan vanhat keräyserät kun palautetaan tilaus takaisin tulostusjonoon,
+        // jottei keräyseriä luotaisi joka kerta vaan lisää ja lisää,
+        // kun palautetaan tilaus takaisin tulostusjonoon
+        if ($yhtiorow['kerayserat'] == 'K'
+          or $yhtiorow['kerayserat'] == 'P'
+          or ($yhtiorow['kerayserat'] == 'A' and $asrow['kerayserat'] == 'A')) {
+
+          $query = "DELETE FROM kerayserat
+                    WHERE yhtio = '{$kukarow['yhtio']}'
+                    AND otunnus = '{$laskurow['tunnus']}'";
+          pupe_query($query);
+        }
+
         //Laitetaan lista tulostusjonoon
         $query = "UPDATE lasku
                   SET alatila = 'J'


### PR DESCRIPTION
Varastosiirrosta, jos ollaan jo keräyslista tulostettu ja jos tässä vaiheessa käydään muokkaamassa varastosiirtoa palautetaan varastosiirto takaisin tulostusjonoon. Kun keräyserät ovat käytössä tulisi tässä vaiheessa, kun varastosiirto tulostusjonoon palautetaan niin samalla myös nollata keräyserät. Näin ei aiemmin siis käynyt vaan varastosiirto joutui tilaan jossa sillä oli keräyserät olemassa, mutta se oli tulostusjonossa. Tämä ongelma on nyt siis korjattu ja varastosiirron muokkaus, joka palauttaa sen tulostusjonoon samalla myös mitätöi aiemmat keräyserät.