### PR TITLE
Relex products

### DIFF
--- a/rajapinnat/relex/relex_products.php
+++ b/rajapinnat/relex/relex_products.php
@@ -564,6 +564,8 @@ while ($row = mysql_fetch_assoc($res)) {
       'toimitusaika_ema'                => '')
   );
 
+  $parastoimittaja = array();
+
   if (mysql_num_rows($ttres) > 0) {
 
     // Nollataan defaultit pois

--- a/rajapinnat/relex/relex_products.php
+++ b/rajapinnat/relex/relex_products.php
@@ -664,7 +664,7 @@ while ($row = mysql_fetch_assoc($res)) {
       $ostohinta_netto = $ostohinta;
 
       // lis‰t‰‰n kuluprosentti hintaan jos sit‰ k‰ytet‰‰n saapumisellakin
-      if (in_array($yhtiorow['jalkilaskenta_kuluperuste'], array('KP', 'VS'))) {
+      if (in_array($yhtiorow['jalkilaskenta_kuluperuste'], array('KP', 'VS', 'PX'))) {
         $ostohinta_netto = $ostohinta_netto * (1 + ($ttrow['oletus_kulupros'] / 100));
       }
 


### PR DESCRIPTION
Bugikorjaus, alustetaan parastoimittaja-taulukko, jotta ei vahingossa käytetä edellisen loopin arvoja, mikäli tuotteelta ei löytyisi yhtään toimittajaa.

Lisäksi huomioidaan netto-ostohinnan laskennassa jalkilaskennan_kuluperuste parametrin optio "Virallisen varastonarvon laskentaan käytetään kululaskujen summaa, mikäli kululaskut on syötetty, muuten kulusummaa/kuluprosenttia".