### PR TITLE
Myyntitilauksen jakaminen varastoittain

### DIFF
--- a/tilauskasittely/tilaus-valmis.inc
+++ b/tilauskasittely/tilaus-valmis.inc
@@ -1838,7 +1838,7 @@ else {
                       AND tilausrivi.tunnus  != '{$row['perheid']}'";
             $ohnoes_res = pupe_query($query);
 
-            if (mysql_num_rows($ohnoes_res) > 0 or $row['omalle_tilaukselle'] != '') {
+            if (mysql_num_rows($ohnoes_res) > 0 or $row['omalle_tilaukselle'] > 0) {
               $query = "UPDATE tilausrivi
                         SET otunnus = '{$laskurow['tunnus']}'
                         WHERE yhtio  = '{$kukarow['yhtio']}'


### PR DESCRIPTION
Tuoteperheiden tapauksessa eri varastosta menossa olevat lapsituotteet päivittyivät erheellisesti samalle tilaukselle isätuotteensa kanssa vaikka isätuote olisi ollut menossa eri varastosta. Tämä korjattu ja jatkossa isätuotteen kanssa eri varastosta menossa olevat lapsituotteet pystyvät menemään oman varastonsa tilaukselle eikä niitä siirretä ns. väärästä varastosta menossa olevalle tilaukselle.