### PR TITLE
Laskun näyttäminen ruudulla

### DIFF
--- a/raportit/asiakkaantilaukset.php
+++ b/raportit/asiakkaantilaukset.php
@@ -144,7 +144,18 @@ if ($tee != 'NAYTATILAUS' and $ytunnus == '' and $otunnus == '' and $laskunro ==
 }
 
 if ($tee == 'NAYTATILAUS') {
-  echo "<font class='head'>".t("Tilaus")." $tunnus:</font><hr>";
+  $query = "SELECT tila
+            FROM lasku
+            WHERE tunnus = $tunnus
+            AND $logistiikka_yhtiolisa";
+  $_tila = mysql_fetch_assoc(pupe_query($query));
+
+  if ($_tila["tila"] != "U") {
+    echo "<font class='head'>".t("Tilaus")." $tunnus:</font><hr>";
+  }
+  else {
+    echo "<font class='head'>".t("Lasku").":</font><hr>";
+  }
 
   require "naytatilaus.inc";
 

--- a/tilauskasittely/tulostakopio.php
+++ b/tilauskasittely/tulostakopio.php
@@ -73,8 +73,11 @@ if ($tee == 'NAYTAHTML') {
   if ($logistiikka_yhtio != '' and $konsernivarasto_yhtiot != '') {
     echo "<font class='head'>", t("Yhtiön"), " $yhtiorow[nimi] ", t("tilaus"), " $tunnus:</font><hr>";
   }
-  else {
+  elseif ($toim != "LASKU") {
     echo "<font class='head'>".t("Tilaus")." $tunnus:</font><hr>";
+  }
+  else {
+    echo "<font class='head'>".t("Lasku").":</font><hr>";
   }
 
   require "raportit/naytatilaus.inc";


### PR DESCRIPTION
Näytettäessä lasku ruudulla tuli laskun tietojen yläpuolelle teksti "Tilaus *numero*:". Tämä *numero* ei ollut suinkaan laskun tilauksen numero vaan laskun tunnistenumero. Nyt tämä hämäävä teksti on korvattu tekstillä "Lasku:".

Tämä koskee ohjelmia asiakkaan tilaukset ja lasku kopio (toiminto näytä ruudulla).