### PR TITLE
* Siirtorivien yhdistäminen JT-toimituksessa

### DIFF
--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -2634,6 +2634,19 @@ if ($fieldname == "jt_asiakkaan_tilausnumero") {
   $jatko = 0;
 }
 
+if ($fieldname == "jt_siirtolistojen_yhdistaminen") {
+
+  $ulos = "<td><select name='{$nimi}' ".js_alasvetoMaxWidth($nimi, 400).">";
+
+  $sel = $trow[$i] == 'K' ? " selected" : "";
+
+  $ulos .= "<option value = ''>".t("Siirtolistat yhdistet‰‰n JT-rivien vapautuksessa, jos t‰m‰ on mahdollista")."</option>";
+  $ulos .= "<option value = 'K'{$sel}>".t("Siirtolistoja ei ikin‰ yhdistet‰ JT-rivien vapautuksessa")."</option>";
+  $ulos .= "</select></td>";
+
+  $jatko = 0;
+}
+
 if ($fieldname == "tilausvahvistus_tallenna") {
 
   $ulos = "<td><select name='$nimi' ".js_alasvetoMaxWidth($nimi, 400).">";

--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -244,11 +244,11 @@ if (!function_exists("tee_jt_tilaus")) {
           // vai saako siirtolistoja yhdist‰‰ jos voi
           // Kuitenkin niin, ett‰ mahdollisuuksien mukaan ei eroteta samalla siirtolistalla olleita rivej‰
           // - t‰m‰ tehd‰‰n vanhan siirtolistanumeron mukaan
-          $lisatjoin = "JOIN tilausrivi 
+          $lisatjoin = "JOIN tilausrivi
           		            ON (tilausrivi.yhtio = lasku.yhtio AND tilausrivi.otunnus = lasku.tunnus)
-          	            JOIN tilausrivin_lisatiedot 
+          	            JOIN tilausrivin_lisatiedot
           		            ON (tilausrivin_lisatiedot.yhtio = lasku.yhtio AND tilausrivin_lisatiedot.tilausrivitunnus = tilausrivi.tunnus)";
-          
+
           $lisatehdot = "AND tilausrivin_lisatiedot.vanha_otunnus = {$otsikkorivi["tunnus"]}";
         }
 
@@ -293,8 +293,7 @@ if (!function_exists("tee_jt_tilaus")) {
                   $yhdlisa";
         $stresult = pupe_query($query);
       }
-$riveja = mysql_num_rows($stresult);
-echo "283 <pre> $query </pre> <br> lisaehdot $lisatehdot <br> $riveja <br><br>";
+
       if (mysql_num_rows($stresult) != 0) {
         $otsikkorivi = mysql_fetch_assoc($stresult);
         $id = $otsikkorivi['tunnus'];

--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -238,6 +238,19 @@ if (!function_exists("tee_jt_tilaus")) {
                          AND laskun_lisatiedot.laskutus_postitp  = '$lisatiedot_row[laskutus_postitp]'
                          AND laskun_lisatiedot.laskutus_maa      = '$lisatiedot_row[laskutus_maa]'";
         }
+        elseif ($otsikkorivi["tila"] == 'G' and $yhtiorow["jt_siirtolistojen_yhdistaminen"] == 'K') {
+          // Ollaan vapauttamassa siirtolistaa,
+          // katsotaan halutaanko v‰ltt‰m‰tt‰ uusi otsikko aina
+          // vai saako siirtolistoja yhdist‰‰ jos voi
+          // Kuitenkin niin, ett‰ mahdollisuuksien mukaan ei eroteta samalla siirtolistalla olleita rivej‰
+          // - t‰m‰ tehd‰‰n vanhan siirtolistanumeron mukaan
+          $lisatjoin = "JOIN tilausrivi 
+          		            ON (tilausrivi.yhtio = lasku.yhtio AND tilausrivi.otunnus = lasku.tunnus)
+          	            JOIN tilausrivin_lisatiedot 
+          		            ON (tilausrivin_lisatiedot.yhtio = lasku.yhtio AND tilausrivin_lisatiedot.tilausrivitunnus = tilausrivi.tunnus)";
+          
+          $lisatehdot = "AND tilausrivin_lisatiedot.vanha_otunnus = {$otsikkorivi["tunnus"]}";
+        }
 
         // Tarvitsemmeko uuden otsikon?
         $query = "SELECT lasku.*
@@ -280,17 +293,9 @@ if (!function_exists("tee_jt_tilaus")) {
                   $yhdlisa";
         $stresult = pupe_query($query);
       }
-
-      $saa_yhdistaa = TRUE;
-
-       // Ollaan vapauttamassa siirtolistaa,
-       // katsotaan halutaanko v‰ltt‰m‰tt‰ uusi otsikko aina
-       // vai saako siirtolistoja yhdist‰‰ jos voi
-       if ($otsikkorivi["tila"] == 'G' and $yhtiorow["jt_siirtolistojen_yhdistaminen"] == 'K') {
-         $saa_yhdistaa = FALSE;
-       }
-
-      if (mysql_num_rows($stresult) != 0 and $saa_yhdistaa) {
+$riveja = mysql_num_rows($stresult);
+echo "283 <pre> $query </pre> <br> lisaehdot $lisatehdot <br> $riveja <br><br>";
+      if (mysql_num_rows($stresult) != 0) {
         $otsikkorivi = mysql_fetch_assoc($stresult);
         $id = $otsikkorivi['tunnus'];
         if ($debug == 1) echo t("Lis‰‰n laskun olemassaolevaan")." $otsikkorivi[nimi] $id<br>";

--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -242,8 +242,7 @@ if (!function_exists("tee_jt_tilaus")) {
         // Tarvitsemmeko uuden otsikon?
         $query = "SELECT lasku.*
                   FROM lasku
-                  #$lisatjoin
-                  JOIN laskun_lisatiedot ON laskun_lisatiedot.yhtio = lasku.yhtio and laskun_lisatiedot.otunnus = lasku.tunnus
+                  $lisatjoin
                   WHERE lasku.yhtio          = '$kukarow[yhtio]'
                   AND lasku.laatija          = '$kukarow[kuka]'
                   AND lasku.alatila          = '$alatila'

--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -242,7 +242,8 @@ if (!function_exists("tee_jt_tilaus")) {
         // Tarvitsemmeko uuden otsikon?
         $query = "SELECT lasku.*
                   FROM lasku
-                  $lisatjoin
+                  #$lisatjoin
+                  JOIN laskun_lisatiedot ON laskun_lisatiedot.yhtio = lasku.yhtio and laskun_lisatiedot.otunnus = lasku.tunnus
                   WHERE lasku.yhtio          = '$kukarow[yhtio]'
                   AND lasku.laatija          = '$kukarow[kuka]'
                   AND lasku.alatila          = '$alatila'
@@ -281,7 +282,16 @@ if (!function_exists("tee_jt_tilaus")) {
         $stresult = pupe_query($query);
       }
 
-      if (mysql_num_rows($stresult) != 0) {
+      $saa_yhdistaa = TRUE;
+
+       // Ollaan vapauttamassa siirtolistaa,
+       // katsotaan halutaanko v‰ltt‰m‰tt‰ uusi otsikko aina
+       // vai saako siirtolistoja yhdist‰‰ jos voi
+       if ($otsikkorivi["tila"] == 'G' and $yhtiorow["jt_siirtolistojen_yhdistaminen"] == 'K') {
+         $saa_yhdistaa = FALSE;
+       }
+
+      if (mysql_num_rows($stresult) != 0 and $saa_yhdistaa) {
         $otsikkorivi = mysql_fetch_assoc($stresult);
         $id = $otsikkorivi['tunnus'];
         if ($debug == 1) echo t("Lis‰‰n laskun olemassaolevaan")." $otsikkorivi[nimi] $id<br>";


### PR DESCRIPTION
Siirtolistojen JT-rivien vapautuksessa oli teknisestä bugista johtunut ominaisuus jonka takia tilausrivejä ei JT-rivien vapautuksessa yhdistetty samalle siirtolistalle.

Bugi korjattiin ja "ominaisuus" lähti pois, mutta nyt tämä ominaisuus palautetaan takaisin yhtiön parametrin muodossa. Jos siis uusi yhtiön parametri on päällä tilausrivejä jotka alunperin ovat olleet eri siirtolistoilta ei yhdistetä samalle siirtolistalle JT-rivien vapautuksessa.