### PR TITLE
* Varastosiirrot: Näytä kohdepaikka tulosteessa

### DIFF
--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -430,6 +430,17 @@ if ($fieldname == "varastosiirto_tilausvahvistus") {
   $jatko = 0;
 }
 
+if ($fieldname == "varastosiirto_kohdepaikka") {
+  $sel = $trow[$i] == "K" ? "selected" : "";
+
+  $ulos  = "<td><select name='{$nimi}' ".js_alasvetoMaxWidth($nimi, 400).">";
+  $ulos .= "<option value = ''>".t("N‰ytet‰‰n varaston sis‰isiss‰ siirroissa kohdepaikka")."</option>";
+  $ulos .= "<option value = 'K' {$sel}>".t("N‰ytet‰‰n kaikissa siirroissa kohdepaikka")."</option>";
+  $ulos .= "</select></td>";
+
+  $jatko = 0;
+}
+
 if ($fieldname == "ostotilaustyyppi") {
 
   $ulos = "<td><select name='{$nimi}' ".js_alasvetoMaxWidth($nimi, 400).">";

--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -905,7 +905,7 @@ if (!function_exists('rivi_kerayslista')) {
         $kohderow   = mysql_fetch_assoc($kohderesult);
         $varastopaikkakohde = '';
 
-        if ($laskurow['varasto'] == $laskurow['clearing'] and $kohderow['kohde_hyllyalue'] != '' and $kohderow['kohde_hyllynro'] != '' and $kohderow['kohde_hyllyvali'] != '' and $kohderow['kohde_hyllytaso'] != '') {
+        if (($laskurow['varasto'] == $laskurow['clearing'] or $yhtiorow['varastosiirto_kohdepaikka'] == "K") and $kohderow['kohde_hyllyalue'] != '' and $kohderow['kohde_hyllynro'] != '' and $kohderow['kohde_hyllyvali'] != '' and $kohderow['kohde_hyllytaso'] != '') {
           $varastopaikkakohde = $kohderow["kohde_hyllyalue"] . " " . $kohderow["kohde_hyllynro"] . " " . $kohderow["kohde_hyllyvali"] . " " . $kohderow["kohde_hyllytaso"];
           $row['kommentti'] .= "\n".t("Vie paikalle", $kieli)." ".$varastopaikkakohde;
         }


### PR DESCRIPTION
Uusi yhtiön parametri lisätty jolla voidaan ohjata näytetäänkö varastosiirtojen kohdepaikkatieto PDF:llä aina, vai ainoastaan varastonsisäisissä siirroissa.