### PR TITLE
Mobiili: vie tuote suuntalavalle

### DIFF
--- a/mobiili/suuntalavalle.php
+++ b/mobiili/suuntalavalle.php
@@ -70,6 +70,24 @@ $suuntalavat_res = pupe_query($query);
 if (isset($submit) and $tullaan != 'pre_vahvista_kerayspaikka') {
   if (empty($suuntalava)) $errors[] = t("Valitse suuntalava");
 
+  if (!empty($sscc) and $submit == "hae") {
+    $_sscc = mysql_escape_string($sscc);
+
+    $query = " SELECT *
+               FROM suuntalavat
+               WHERE suuntalavat.yhtio = '{$kukarow['yhtio']}'
+               AND suuntalavat.tila IN ('', 'S', 'P')
+               AND suuntalavat.sscc = '{$_sscc}'";
+    $_chk_res = pupe_query($query);
+
+    if (mysql_num_rows($_chk_res) == 1) {
+      $_chk_row = mysql_fetch_assoc($_chk_res);
+      $suuntalava = $_chk_row['tunnus'];
+      $submit = "ok";
+      $errors = array();
+    }
+  }
+
   // Rivi suuntalavalle
   if (($submit == 'ok' or $submit == 'siirtovalmis' or $submit == 'suoraan_hyllyyn') and count($errors) == 0) {
 

--- a/mobiili/suuntalavalle.php
+++ b/mobiili/suuntalavalle.php
@@ -36,52 +36,41 @@ if (!empty($tilausrivi['uusiotunnus'])) {
 
 if (empty($tullaan)) $tullaan = '';
 
+$sscchaku = !empty($sscc) ? "and suuntalavat.sscc = '".mysql_escape_string($sscc)."'" : "";
+
 // Etsit‰‰n sopivat suuntalavat
 $query = "(SELECT DISTINCT suuntalavat.tunnus, suuntalavat.sscc, suuntalavat.tila, suuntalavat.kaytettavyys, suuntalavat.keraysvyohyke, suuntalavat.tyyppi
            FROM suuntalavat
            JOIN suuntalavat_saapuminen ON (suuntalavat_saapuminen.yhtio = suuntalavat.yhtio AND suuntalavat_saapuminen.suuntalava = suuntalavat.tunnus AND suuntalavat_saapuminen.saapuminen = '{$saapuminen}')
            WHERE suuntalavat.yhtio            = '{$kukarow['yhtio']}'
            AND (suuntalavat.keraysvyohyke = '{$tilausrivi['keraysvyohyke']}' OR suuntalavat.usea_keraysvyohyke = 'K')
-           AND suuntalavat.tila               IN ('', 'S', 'P'))
-           UNION
-           (SELECT DISTINCT suuntalavat.tunnus, suuntalavat.sscc, suuntalavat.tila, suuntalavat.kaytettavyys, suuntalavat.keraysvyohyke, suuntalavat.tyyppi
-           FROM suuntalavat
-           WHERE suuntalavat.yhtio            = '{$kukarow['yhtio']}'
-           AND suuntalavat.tila               IN ('', 'S', 'P')
-           AND suuntalavat.tunnus             = '{$tilausrivi['suuntalava']}')
+           AND suuntalavat.tila               = ''
+           {$sscchaku})
            UNION
            (SELECT DISTINCT suuntalavat.tunnus, suuntalavat.sscc, suuntalavat.tila, suuntalavat.kaytettavyys, suuntalavat.keraysvyohyke, suuntalavat.tyyppi
            FROM suuntalavat
            WHERE suuntalavat.yhtio            = '{$kukarow['yhtio']}'
            AND suuntalavat.keraysvyohyke      = '{$tilausrivi['keraysvyohyke']}'
            AND suuntalavat.tila               = ''
-           AND suuntalavat.kaytettavyys       = 'L')
+           AND suuntalavat.kaytettavyys       = 'L'
+           {$sscchaku})
            UNION
            (SELECT DISTINCT suuntalavat.tunnus, suuntalavat.sscc, suuntalavat.tila, suuntalavat.kaytettavyys, suuntalavat.keraysvyohyke, suuntalavat.tyyppi
            FROM suuntalavat
            WHERE suuntalavat.yhtio            = '{$kukarow['yhtio']}'
            AND suuntalavat.usea_keraysvyohyke = 'K'
-           AND suuntalavat.tila               IN ('', 'S', 'P')
-           AND suuntalavat.kaytettavyys       = 'L')
+           AND suuntalavat.tila               = ''
+           AND suuntalavat.kaytettavyys       = 'L'
+           {$sscchaku})
            ORDER BY sscc, tunnus";
-
 $suuntalavat_res = pupe_query($query);
 
 if (isset($submit) and $tullaan != 'pre_vahvista_kerayspaikka') {
   if (empty($suuntalava)) $errors[] = t("Valitse suuntalava");
 
   if (!empty($sscc) and $submit == "hae") {
-    $_sscc = mysql_escape_string($sscc);
-
-    $query = " SELECT *
-               FROM suuntalavat
-               WHERE suuntalavat.yhtio = '{$kukarow['yhtio']}'
-               AND suuntalavat.tila IN ('', 'S', 'P')
-               AND suuntalavat.sscc = '{$_sscc}'";
-    $_chk_res = pupe_query($query);
-
-    if (mysql_num_rows($_chk_res) == 1) {
-      $_chk_row = mysql_fetch_assoc($_chk_res);
+    if (mysql_num_rows($suuntalavat_res) == 1) {
+      $_chk_row = mysql_fetch_assoc($suuntalavat_res);
       $suuntalava = $_chk_row['tunnus'];
       $submit = "ok";
       $errors = array();
@@ -194,7 +183,7 @@ echo "<div class='main'>
             <input type='text' id='sscc' name='sscc' value='$hae'/>
         </td>
         <td>
-            <button name='submit' class='button' value='hae' onclick='submit();'>", t("Etsi"), "</button>
+            <button name='submit' id='hakunappi' class='button' value='hae' onclick='submit();'>", t("Etsi"), "</button>
         </td>
     </tr>
 </table>
@@ -256,3 +245,33 @@ foreach ($errors as $error) {
   echo $error."</br>";
 }
 echo "</div>";
+
+// Autofocus opera mobileen
+echo "<input type='button' id='myHiddenButton' visible='false' onclick='javascript:doFocus();' width='1px' style='display:none'>";
+echo "<script type='text/javascript'>
+
+  $(document).ready(function() {
+    $('#sscc').on('keyup', function() {
+      // Autosubmit vain jos on syˆtetty tarpeeksi pitk‰ viivakoodi
+      if ($('#sscc').val().length > 6) {
+        document.getElementById('hakunappi').click();
+      }
+    });
+  });
+
+  function doFocus() {
+          var focusElementId = 'alusta';
+          var textBox = document.getElementById(focusElementId);
+          textBox.focus();
+      }
+
+  function clickButton() {
+     document.getElementById('myHiddenButton').click();
+  }
+
+  if(!document.getElementById('saapumiset')) {
+       setTimeout('clickButton()', 500);
+  }
+
+</script>
+";


### PR DESCRIPTION
Jos ollaan lisäämässä tuottetta suuntalavalle mobiili-tuloutuksessa ja syötetään suuntalavan sscc (viivakoodi), niin tehdään automaaginen "haku" sscc:llä listan suuntalavoihin, ilman että tarvii erikseen painaa "hae". Jos listalta löytyy yksi osuma, valitaan kyseinen suuntalava automaagisesti ja lisätään tuote sille (toimii kuin olisi painettu ok:ta).

Ominaisuus nopeuttaa mobiili-tuloutuksessa tuotteen lisäämistä suuntalavalle.