### PR TITLE
Tuloutus suuntalavoja käyttäen

### DIFF
--- a/tilauskasittely/varastoon.inc
+++ b/tilauskasittely/varastoon.inc
@@ -346,7 +346,7 @@ elseif ($toiminto == "kalkyyli" and $tee == "varastoon") {
 
   // tavallinen laskenta.. VARATTU PITÄÄ OLLA != 0 ja varastoon-kenttä 1!
   // jos varastoon-kentässä on 0 niin tätä riviä ei haluttu vielä viedä varastoon
-  $query = "SELECT tilausrivi.*, {$ale_query_select_lisa} alennuksetyht, tilausrivin_lisatiedot.poikkeava_tulliprosentti, tuote.tullinimike1, tuote.tullinimike2
+  $query = "SELECT tilausrivi.*, {$ale_query_select_lisa} alennuksetyht, tilausrivin_lisatiedot.poikkeava_tulliprosentti, tuote.tullinimike1, tuote.tullinimike2, lasku.nimi, lasku.nimitark
             FROM tilausrivi
             JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio and lasku.tunnus = tilausrivi.uusiotunnus)
             LEFT JOIN tuotteen_toimittajat ON (tilausrivi.yhtio = tuotteen_toimittajat.yhtio and tilausrivi.tuoteno = tuotteen_toimittajat.tuoteno and tuotteen_toimittajat.liitostunnus = lasku.liitostunnus)
@@ -382,7 +382,7 @@ elseif ($toiminto == "kalkyyli" and $tee == "") {
   }
 
   // Näytetään ruudulla
-  $query = "SELECT tilausrivi.*, {$ale_query_select_lisa} alennuksetyht, tilausrivin_lisatiedot.poikkeava_tulliprosentti, tuote.tullinimike1, tuote.tullinimike2
+  $query = "SELECT tilausrivi.*, {$ale_query_select_lisa} alennuksetyht, tilausrivin_lisatiedot.poikkeava_tulliprosentti, tuote.tullinimike1, tuote.tullinimike2, lasku.nimi, lasku.nimitark
             FROM tilausrivi
             JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio and lasku.tunnus = tilausrivi.uusiotunnus)
             LEFT JOIN tuotteen_toimittajat ON (tilausrivi.yhtio = tuotteen_toimittajat.yhtio and tilausrivi.tuoteno = tuotteen_toimittajat.tuoteno and tuotteen_toimittajat.liitostunnus = lasku.liitostunnus)
@@ -828,7 +828,7 @@ while ($tilrivirow = mysql_fetch_assoc($presult)) {
               hyllynro   = '$tilrivirow[hyllynro]',
               hyllytaso  = '$tilrivirow[hyllytaso]',
               hyllyvali  = '$tilrivirow[hyllyvali]',
-              selite     = '$laskurow[nimi] $laskurow[nimitark], ".t("Tilaus").": $tilrivirow[otunnus], ".t("Ostohinta").": $ohinta $lisavartlisa',
+              selite     = '$tilrivirow[nimi] $tilrivirow[nimitark], ".t("Tilaus").": $tilrivirow[otunnus], ".t("Ostohinta").": $ohinta $lisavartlisa',
               laatija    = '$kukarow[kuka]',
               rivitunnus = '$tilrivirow[tunnus]',
               laadittu   = '$varastoonvientipva'";


### PR DESCRIPTION
Jos samalle suuntalavalle vietiin tuloutuksessa eri toimittajien tuotteita, varastoonvientivaiheessa tuotteen tulotapahtuman selitteeseen meni yhden toimittajan tiedot kaikille tuotteille riippumatta siitä, miltä toimittajalta tuote oikeasti oli tullut.

Tuloutusrivit olivat kuitenkin oikean toimittajan saapumisella.