### PR TITLE
Varastopaikkojen siivous

### DIFF
--- a/varastopaikkojen_siivous.php
+++ b/varastopaikkojen_siivous.php
@@ -450,7 +450,10 @@ if ($tee == 'LISTAATUNTEMATTOMAT' and !$_cli) {
             varastopaikat.tunnus
             FROM tuotepaikat USE INDEX (tuote_index)
             LEFT OUTER JOIN varastopaikat ON (varastopaikat.yhtio = tuotepaikat.yhtio
-              AND varastopaikat.tunnus = tuotepaikat.varasto)
+              AND concat(rpad(upper(varastopaikat.alkuhyllyalue), 5, '0'), lpad(upper(varastopaikat.alkuhyllynro), 5, '0'))
+                <= concat(rpad(upper(tuotepaikat.hyllyalue), 5, '0'), lpad(upper(tuotepaikat.hyllynro), 5, '0'))
+              AND concat(rpad(upper(varastopaikat.loppuhyllyalue), 5, '0'), lpad(upper(varastopaikat.loppuhyllynro), 5, '0'))
+                >= concat(rpad(upper(tuotepaikat.hyllyalue), 5, '0'), lpad(upper(tuotepaikat.hyllynro), 5, '0')))
             WHERE tuotepaikat.yhtio    = '{$kukarow["yhtio"]}'
             AND varastopaikat.tunnus is null";
   $result = pupe_query($query);

--- a/varastopaikkojen_siivous.php
+++ b/varastopaikkojen_siivous.php
@@ -729,7 +729,10 @@ if ($tee == "LISTAAVIRHEELLISETRIVIT" and !$_cli) {
               and tuote.tuoteno        = tilausrivi.tuoteno
               and tuote.ei_saldoa      = '')
             LEFT OUTER JOIN varastopaikat ON (varastopaikat.yhtio = tilausrivi.yhtio
-              AND varastopaikat.tunnus = tilausrivi.varasto)
+              AND concat(rpad(upper(varastopaikat.alkuhyllyalue),  5, '0'), lpad(upper(varastopaikat.alkuhyllynro),  5, '0'))
+                <= concat(rpad(upper(tilausrivi.hyllyalue), 5, '0'), lpad(upper(tilausrivi.hyllynro), 5, '0'))
+              AND concat(rpad(upper(varastopaikat.loppuhyllyalue), 5, '0'), lpad(upper(varastopaikat.loppuhyllynro), 5, '0'))
+                >= concat(rpad(upper(tilausrivi.hyllyalue), 5, '0'), lpad(upper(tilausrivi.hyllynro), 5, '0')))
             WHERE tilausrivi.yhtio     = '$kukarow[yhtio]'
             AND tilausrivi.tyyppi      in ('L','G','V')
             AND tilausrivi.jt + tilausrivi.varattu != 0

--- a/varastopaikkojen_siivous.php
+++ b/varastopaikkojen_siivous.php
@@ -799,7 +799,10 @@ if ($tee == "LISTAATAPAHTUMATILMANPAIKKAA" and !$_cli) {
               AND tuote.tuoteno        = tapahtuma.tuoteno
               AND tuote.ei_saldoa      = '')
             LEFT OUTER JOIN varastopaikat ON (varastopaikat.yhtio = tapahtuma.yhtio
-              AND varastopaikat.tunnus = tuotepaikat.varasto)
+              AND concat(rpad(upper(varastopaikat.alkuhyllyalue),  5, '0'), lpad(upper(varastopaikat.alkuhyllynro),  5, '0'))
+                <= concat(rpad(upper(tapahtuma.hyllyalue), 5, '0'), lpad(upper(tapahtuma.hyllynro), 5, '0'))
+              AND concat(rpad(upper(varastopaikat.loppuhyllyalue), 5, '0'), lpad(upper(varastopaikat.loppuhyllynro), 5, '0'))
+                >= concat(rpad(upper(tapahtuma.hyllyalue), 5, '0'), lpad(upper(tapahtuma.hyllynro), 5, '0')))
             WHERE tapahtuma.yhtio      = '{$kukarow["yhtio"]}'
             AND tapahtuma.laji         not in ('epäkurantti')
             AND varastopaikat.tunnus IS NULL


### PR DESCRIPTION
Varastopaikkojen siivous ohjelmalla ei saa nyt kiinni niitä varastopaikkoja, jotka ei kuulu enää minkään varaston alueeseen - vaikkakin se varasto johon niiden tuotepaikat.varasto on viel olemassa niin sen varaston hyllyaluetta on muutettu niin et ne paikat ei enää kuulu siihen. Nyt varastopaikkojen siivous ohjelmalla saadaan kiinni myös ne varastopaikat jotka eivät kuulu enää minkään varaston alueeseen eli ne eivät kuulu enää mihinkään varastoon.