### PR TITLE
Myynninseurantaraportti: laskun maksupäivämäärä

### DIFF
--- a/raportit/myyntiseuranta.php
+++ b/raportit/myyntiseuranta.php
@@ -1512,8 +1512,19 @@ else {
       }
 
       if ($naytamaksupvm != "") {
-        $group .= ",lasku.mapvm";
-        $select .= "lasku.mapvm maksupvm, ";
+        $maksupvm_join = "";
+        // Maksup‰iv‰m‰‰r‰ on varmasti tallennettu vain itse laskulle
+        // tilauksia haettaessa t‰ytyy siis k‰yd‰ katsomassa maksupvm laskulta
+        if ($ajotapa != "lasku") {
+          $maksupvm_join = "LEFT JOIN lasku AS UX ON (UX.yhtio = lasku.yhtio AND UX.laskunro = lasku.laskunro AND UX.tila = 'U')";
+          $group .= ",UX.mapvm";
+          $select .= "UX.mapvm maksupvm, ";
+        }
+        else {
+          $group .= ",lasku.mapvm";
+          $select .= "lasku.mapvm maksupvm, ";
+        }
+
         $gluku++;
         $muutgroups++;
       }
@@ -2300,6 +2311,7 @@ else {
               {$maksuehto_join}
               {$toimtuoteno_join}
               {$lisa_parametri}
+              {$maksupvm_join}
               WHERE lasku.yhtio in ({$yhtio})
               and lasku.tila in ({$tila})";
 

--- a/raportit/myyntiseuranta.php
+++ b/raportit/myyntiseuranta.php
@@ -1511,8 +1511,8 @@ else {
         $lisa .= " and tilausrivi.var != 'P' ";
       }
 
+      $maksupvm_join = "";
       if ($naytamaksupvm != "") {
-        $maksupvm_join = "";
         // Maksup‰iv‰m‰‰r‰ on varmasti tallennettu vain itse laskulle
         // tilauksia haettaessa t‰ytyy siis k‰yd‰ katsomassa maksupvm laskulta
         if ($ajotapa != "lasku") {

--- a/raportit/myyntiseuranta.php
+++ b/raportit/myyntiseuranta.php
@@ -976,15 +976,16 @@ else {
       $query_ale_lisa = generoi_alekentta('M');
 
       // HUOM: ", " (pilkku-space) stringi‰ k‰ytet‰‰n vain sarakkeiden v‰lill‰, eli ole tarkkana concatissa ja muissa funkkareissa $select-muuttujassa
-      $select       = "";
-      $query        = "";
-      $group        = "";
-      $order        = "";
-      $gluku        = 0;
-      $varasto_join     = "";
-      $kantaasiakas_join   = "";
-      $maksuehto_join   = "";
+      $select            = "";
+      $query             = "";
+      $group             = "";
+      $order             = "";
+      $gluku             = 0;
+      $varasto_join      = "";
+      $kantaasiakas_join = "";
+      $maksuehto_join    = "";
       $toimtuoteno_join  = "";
+      $maksupvm_join     = "";
 
       // n‰it‰ k‰ytet‰‰n queryss‰
       $sel_osasto = "";
@@ -1511,7 +1512,6 @@ else {
         $lisa .= " and tilausrivi.var != 'P' ";
       }
 
-      $maksupvm_join = "";
       if ($naytamaksupvm != "") {
         // Maksup‰iv‰m‰‰r‰ on varmasti tallennettu vain itse laskulle
         // tilauksia haettaessa t‰ytyy siis k‰yd‰ katsomassa maksupvm laskulta


### PR DESCRIPTION
Näytetään laskun maksupäivämäärä oikein myös muilla ajotavoilla kuin "Laskuista (Laskutus)". Aiemmin näillä muilla ajotavoilla maksupäivämääräksi tuli siis 0000-00-00 vaikka lasku olisikin jo maksettu.