### PR TITLE
Unifaun: koontitulostus

### DIFF
--- a/inc/toimitustapatarkista.inc
+++ b/inc/toimitustapatarkista.inc
@@ -6,26 +6,27 @@ if (!function_exists("toimitustapatarkista")) {
 
     static $aputulostustapa, $apuvakkielto, $apurahtikirja;
 
-    if ((mysql_field_name($result, $i)=="rahtikirja") and ($t[$i]!='')) {
+    if (mysql_field_name($result, $i) == "rahtikirja" and $t[$i] != '') {
 
       // otetaan arvo talteen
       $apurahtikirja = $t[$i];
       if (!file_exists("tilauskasittely/".$t[$i])) {
         $virhe[$i] = t("Tiedosto tilauskasittely")."/$t[$i] ".t("ei löydy")."!";
       }
-      
+
       $apurahtikirja = $t[$i];
     }
 
-    if ((mysql_field_name($result, $i)=="tulostustapa") and ($t[$i]!='')) {
+    if (mysql_field_name($result, $i) == "tulostustapa" and $t[$i] != '') {
       // otetaan arvo talteen
       $aputulostustapa = $t[$i];
-      if ($t[$i]!='H' and $t[$i]!='E' and $t[$i]!='K' and $t[$i]!='L' and $t[$i]!='X') {
+
+      if ($t[$i] != 'H' and $t[$i] != 'E' and $t[$i] != 'K' and $t[$i] != 'L' and $t[$i] != 'X') {
         $virhe[$i] = t("Virheellinen tulostustapa")."!";
       }
     }
-    
-    if ((mysql_field_name($result, $i)=="uudet_pakkaustiedot")) {
+
+    if (mysql_field_name($result, $i) == "uudet_pakkaustiedot") {
 
       if ($aputulostustapa == 'L' and strpos($apurahtikirja, 'rahtikirja_unifaun') !== FALSE and $t[$i] != 'K') {
         $virhe[$i] = t("Virhe")."! ". t("Koontierätulostus ei toimi Unifaun Online rahtikirjan kanssa ilman koontirahtikirjan pakkaustietoja").".";
@@ -33,7 +34,7 @@ if (!function_exists("toimitustapatarkista")) {
     }
 
     // jos toimitustavan nimeä ollaan muuttamassa...
-    if ((mysql_field_name($result, $i)=="selite") and ($t[$i]!=$trow[$i])) {
+    if (mysql_field_name($result, $i) == "selite" and $t[$i] != $trow[$i]) {
       $toita = trim($t[$i]);
       $toita = str_replace("'", "", $toita);
       $toita = str_replace("\"", "", $toita);
@@ -41,7 +42,7 @@ if (!function_exists("toimitustapatarkista")) {
       $query = "SELECT tunnus from toimitustapa where selite='$toita' and yhtio='$kukarow[yhtio]' and tunnus != '$tunnus'";
       $updre = pupe_query($query);
 
-      if (mysql_num_rows($updre)!=0) {
+      if (mysql_num_rows($updre) > 0) {
         $virhe[$i] = t("Et voi muuttaa toimitustaavan nimeä, koska")." '$toita' ".t("on jo olemassa")."!";
       }
       else {
@@ -176,7 +177,7 @@ if (!function_exists("toimitustapatarkista")) {
       }
     }
 
-    if ($trow and (mysql_field_name($result, $i) == "vak_kielto") and ($t[$i] != "")) {
+    if ($trow and mysql_field_name($result, $i) == "vak_kielto" and $t[$i] != "") {
       $query = "SELECT count(*) AS count
                 FROM toimitustapa
                 WHERE yhtio                         = '{$kukarow["yhtio"]}'

--- a/inc/toimitustapatarkista.inc
+++ b/inc/toimitustapatarkista.inc
@@ -4,16 +4,17 @@ if (!function_exists("toimitustapatarkista")) {
   function toimitustapatarkista(&$t, $i, $result, $tunnus, &$virhe, $trow) {
     global $kukarow, $yhtiorow, $alias_set;
 
-    static $aputulostustapa, $apuvakkielto;
+    static $aputulostustapa, $apuvakkielto, $apurahtikirja;
 
     if ((mysql_field_name($result, $i)=="rahtikirja") and ($t[$i]!='')) {
+
+      // otetaan arvo talteen
+      $apurahtikirja = $t[$i];
       if (!file_exists("tilauskasittely/".$t[$i])) {
         $virhe[$i] = t("Tiedosto tilauskasittely")."/$t[$i] ".t("ei löydy")."!";
       }
       
-      if ($aputulostustapa == 'L' and strpos($t['rahtikirja'], 'rahtikirja_unifaun') !== FALSE) {
-        $virhe[$i] = t("Virheellinen tulostustapa")."! ". t("Koontierätulostus ei toimi Unifaun Online rahtikirjan kanssa").".";
-      }
+      $apurahtikirja = $t[$i];
     }
 
     if ((mysql_field_name($result, $i)=="tulostustapa") and ($t[$i]!='')) {
@@ -21,6 +22,13 @@ if (!function_exists("toimitustapatarkista")) {
       $aputulostustapa = $t[$i];
       if ($t[$i]!='H' and $t[$i]!='E' and $t[$i]!='K' and $t[$i]!='L' and $t[$i]!='X') {
         $virhe[$i] = t("Virheellinen tulostustapa")."!";
+      }
+    }
+    
+    if ((mysql_field_name($result, $i)=="uudet_pakkaustiedot")) {
+
+      if ($aputulostustapa == 'L' and strpos($apurahtikirja, 'rahtikirja_unifaun') !== FALSE and $t[$i] != 'K') {
+        $virhe[$i] = t("Virhe")."! ". t("Koontierätulostus ei toimi Unifaun Online rahtikirjan kanssa ilman koontirahtikirjan pakkaustietoja").".";
       }
     }
 

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -887,11 +887,6 @@ if ($tee == 'tulosta') {
       if (!isset($nayta_pdf)) echo "$rahinta $jvtext<br>";
 
       // unifaunille tässä kohtaa normaali rahtikirja, jos koontierätulostus!
-      $_tulostustapa = ($toitarow['tulostustapa'] == 'L');
-      $_paktiedot = ($toitarow['uudet_pakkaustiedot'] == 'K');
-      $_paktiedot = ($_paktiedot and $tultiin == 'koonti_eratulostus_pakkaustiedot');
-      $_paktiedot = ($_paktiedot and trim($pakkaustieto_rahtikirjanro) != '');
-
       if ($_onko_unifaun and $_tulostustapa and $_paktiedot) {
         $toitarow["rahtikirja"] = "rahtikirja_pdf.inc";
       }

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -670,7 +670,7 @@ if ($tee == 'tulosta') {
                     AND tulostettu = '0000-00-00 00:00:00'";
           $ures  = pupe_query($query);
 
-          if ($_onko_unifaun and $tultiin == 'koonti_eratulostus_pakkaustiedot') {
+          if ($_onko_unifaun) {
             require_once "inc/unifaun_send.inc";
 
             $query = "SELECT unifaun_nimi

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -689,6 +689,7 @@ if ($tee == 'tulosta') {
             $mergeidres = pupe_query($query);
             $mergeidrow = mysql_fetch_assoc($mergeidres);
             $mergeid = $mergeidrow['rahtikirjanro'];
+            $rahtikirjanro = $pakkaustieto_rahtikirjanro;
 
             if (!empty($kirow['unifaun_nimi']) and !empty($mergeid)) {
 

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -1148,7 +1148,10 @@ if ($tee == 'tulosta') {
       $tee = "SKIPPAA";
     }
     elseif (strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-kopio.php") === FALSE) {
-      if ($toitarow['tulostustapa'] == 'H' or $toitarow['tulostustapa'] == 'K' or $toitarow["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc' or $toitarow["rahtikirja"] == 'rahtikirja_unifaun_uo_siirto.inc') {
+      if ($_onko_unifaun and $_tulostustapa and $_paktiedot) {
+        $tee = '';
+      }
+      elseif ($toitarow['tulostustapa'] == 'H' or $toitarow['tulostustapa'] == 'K' or $toitarow["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc' or $toitarow["rahtikirja"] == 'rahtikirja_unifaun_uo_siirto.inc') {
         $tee = 'XXX';
       }
       else {

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -62,7 +62,7 @@ $_onko_unifaun = ($_onko_unifaun or $toitarow["rahtikirja"] == 'rahtikirja_unifa
 // Tulostetaan rahtikirja tai kutsutaan unifaunin _closeWithPrinter-metodia
 if ($tee == 'tulosta' or $tee == 'close_with_printer') {
 
-  if ($toitarow['tulostustapa'] == 'L' and $toitarow['uudet_pakkaustiedot'] == 'K' and $tultiin != 'koonti_eratulostus_pakkaustiedot' and strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-kopio.php") === FALSE) {
+  if ($toitarow['tulostustapa'] == 'L' and $toitarow['uudet_pakkaustiedot'] == 'K' and $tultiin != 'koonti_eratulostus_pakkaustiedot' and strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-kopio.php") === FALSE and isset($tulosta_rahtikirjat_nappulatsukka)) {
 
     $linkkilisa = '';
 
@@ -670,7 +670,7 @@ if ($tee == 'tulosta') {
                     AND tulostettu = '0000-00-00 00:00:00'";
           $ures  = pupe_query($query);
 
-          if ($_onko_unifaun) {
+          if ($_onko_unifaun and isset($tulosta_rahtikirjat_nappulatsukka)) {
             require_once "inc/unifaun_send.inc";
 
             $query = "SELECT unifaun_nimi

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -324,6 +324,10 @@ if ($tee == 'close_with_printer') {
     $res   = pupe_query($query);
   }
 
+  if ($toitarow['erittely'] == 'k' and $toitarow['rahtikirja'] != 'rahtikirja_hrx_siirto.inc') {
+    require "tilauskasittely/rahtikirja_erittely_pdf.inc";
+  }
+
   require_once "inc/unifaun_send.inc";
 
   $query = "SELECT unifaun_nimi
@@ -907,11 +911,11 @@ if ($tee == 'tulosta') {
           // Otetaan talteen tässä $rahtikirjanro talteen
           $rahtikirjanro_alkuperainen = $rahtikirjanro;
 
-          if ($tulosta_vak_yleisrahtikirja != '') {
+          if (!$unifaun_era_vainkollitarra and $tulosta_vak_yleisrahtikirja != '') {
             require "tilauskasittely/rahtikirja_pdf.inc";
           }
 
-          if ($toitarow['erittely'] == 'k' and $toitarow['rahtikirja'] != 'rahtikirja_hrx_siirto.inc') {
+          if (!$unifaun_era_vainkollitarra and $toitarow['erittely'] == 'k' and $toitarow['rahtikirja'] != 'rahtikirja_hrx_siirto.inc') {
             require "tilauskasittely/rahtikirja_erittely_pdf.inc";
           }
 

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -689,7 +689,14 @@ if ($tee == 'tulosta') {
             $mergeidres = pupe_query($query);
             $mergeidrow = mysql_fetch_assoc($mergeidres);
             $mergeid = $mergeidrow['rahtikirjanro'];
-            $rahtikirjanro = $pakkaustieto_rahtikirjanro;
+
+            $query = "SELECT min(rahtikirjanro) rahtikirjanro
+                      FROM rahtikirjat
+                      WHERE yhtio = '{$kukarow['yhtio']}'
+                      AND tunnus IN ({$tunnukset})";
+            $rahtikirjanrores = pupe_query($query);
+            $rahtikirjanrorow = mysql_fetch_assoc($rahtikirjanrores);
+            $rahtikirjanro = $rahtikirjanrorow['rahtikirjanro'];
 
             if (!empty($kirow['unifaun_nimi']) and !empty($mergeid)) {
 

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -911,7 +911,7 @@ if ($tee == 'tulosta') {
           // Otetaan talteen tässä $rahtikirjanro talteen
           $rahtikirjanro_alkuperainen = $rahtikirjanro;
 
-          if (!$unifaun_era_vainkollitarra and $tulosta_vak_yleisrahtikirja != '') {
+          if ($tulosta_vak_yleisrahtikirja != '') {
             require "tilauskasittely/rahtikirja_pdf.inc";
           }
 

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -599,7 +599,12 @@ if ($tee == 'tulosta') {
 
       $pakkaustieto_tunnukset = '';
 
-      if ($toitarow['tulostustapa'] == 'L' and $toitarow['uudet_pakkaustiedot'] == 'K' and $tultiin == 'koonti_eratulostus_pakkaustiedot' and trim($pakkaustieto_rahtikirjanro) != '') {
+      $_tulostustapa = ($toitarow['tulostustapa'] == 'L');
+      $_paktiedot = ($toitarow['uudet_pakkaustiedot'] == 'K');
+      $_paktiedot = ($_paktiedot and $tultiin == 'koonti_eratulostus_pakkaustiedot');
+      $_paktiedot = ($_paktiedot and trim($pakkaustieto_rahtikirjanro) != '');
+
+      if ($_tulostustapa and $_paktiedot) {
         $query = "SELECT group_concat(tunnus) pakkaustieto_tunnukset
                   FROM rahtikirjat
                   WHERE yhtio                 = '$kukarow[yhtio]'
@@ -654,11 +659,6 @@ if ($tee == 'tulosta') {
       $kuljetusohjeet = $pak["viesti"];
 
       $tulostuskpl = $kollityht;
-
-      $_tulostustapa = ($toitarow['tulostustapa'] == 'L');
-      $_paktiedot = ($toitarow['uudet_pakkaustiedot'] == 'K');
-      $_paktiedot = ($_paktiedot and $tultiin == 'koonti_eratulostus_pakkaustiedot');
-      $_paktiedot = ($_paktiedot and trim($pakkaustieto_rahtikirjanro) != '');
 
       if ($_tulostustapa and $_paktiedot) {
         // merkataan rahtikirjat tulostetuksi..

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -661,6 +661,9 @@ if ($tee == 'tulosta') {
                     AND yhtio      = '$kukarow[yhtio]'
                     AND tulostettu = '0000-00-00 00:00:00'";
           $ures  = pupe_query($query);
+          
+          // unifaunille täs kohtaa rahtikirja myös!
+          
         }
 
         // käytetään tästä alaspäin vanhoja tunnuksia
@@ -843,6 +846,8 @@ if ($tee == 'tulosta') {
       $kaikki_lotsikot = substr($kaikki_lotsikot, 0, -2);
 
       if (!isset($nayta_pdf)) echo "$rahinta $jvtext<br>";
+
+       // unifaunille täs kohtaa ei mitään, jos koontierätulostus! alla olevan iffin sisään sillon myöskin!
 
       // Kopsutulostus toistaiseksi vain A4-paperille unifaun keississä
       if (strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-kopio.php") !== FALSE and ($toitarow["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc' or $toitarow["rahtikirja"] == 'rahtikirja_unifaun_uo_siirto.inc')) {

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -597,6 +597,14 @@ if ($tee == 'tulosta') {
         $groupby_lisa = "";
       }
 
+      $query = "SELECT min(rahtikirjanro) rahtikirjanro
+                FROM rahtikirjat
+                WHERE yhtio = '{$kukarow['yhtio']}'
+                AND tunnus IN ({$tunnukset})";
+      $rahtikirjanrores = pupe_query($query);
+      $rahtikirjanrorow = mysql_fetch_assoc($rahtikirjanrores);
+      $rahtikirjanro = $rahtikirjanrorow['rahtikirjanro'];
+
       $pakkaustieto_tunnukset = '';
 
       $_tulostustapa = ($toitarow['tulostustapa'] == 'L');
@@ -690,16 +698,8 @@ if ($tee == 'tulosta') {
             $mergeidrow = mysql_fetch_assoc($mergeidres);
             $mergeid = $mergeidrow['rahtikirjanro'];
 
-            $query = "SELECT min(rahtikirjanro) rahtikirjanro
-                      FROM rahtikirjat
-                      WHERE yhtio = '{$kukarow['yhtio']}'
-                      AND tunnus IN ({$tunnukset})";
-            $rahtikirjanrores = pupe_query($query);
-            $rahtikirjanrorow = mysql_fetch_assoc($rahtikirjanrores);
-            $rahtikirjanro = $rahtikirjanrorow['rahtikirjanro'];
-
             @include "tilauskasittely/$toitarow[rahtikirja]";
-           
+
             if ($toitarow["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc' and $unifaun_ps_host != "" and $unifaun_ps_user != "" and $unifaun_ps_pass != "" and $unifaun_ps_path != "") {
               $unifaun = new Unifaun($unifaun_ps_host, $unifaun_ps_user, $unifaun_ps_pass, $unifaun_ps_path, $unifaun_ps_port, $unifaun_ps_fail, $unifaun_ps_succ);
             }

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -692,6 +692,8 @@ if ($tee == 'tulosta') {
 
             if (!empty($kirow['unifaun_nimi']) and !empty($mergeid)) {
 
+              @include "tilauskasittely/$toitarow[rahtikirja]";
+
               if ($toitarow["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc' and $unifaun_ps_host != "" and $unifaun_ps_user != "" and $unifaun_ps_pass != "" and $unifaun_ps_path != "") {
                 $unifaun = new Unifaun($unifaun_ps_host, $unifaun_ps_user, $unifaun_ps_pass, $unifaun_ps_path, $unifaun_ps_port, $unifaun_ps_fail, $unifaun_ps_succ);
               }

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -670,7 +670,7 @@ if ($tee == 'tulosta') {
                     AND tulostettu = '0000-00-00 00:00:00'";
           $ures  = pupe_query($query);
 
-          if ($_onko_unifaun and isset($tulosta_rahtikirjat_nappulatsukka)) {
+          if ($_onko_unifaun and $tultiin == 'koonti_eratulostus_pakkaustiedot') {
             require_once "inc/unifaun_send.inc";
 
             $query = "SELECT unifaun_nimi

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -684,35 +684,7 @@ if ($tee == 'tulosta') {
 
           if ($_onko_unifaun) {
             require_once "inc/unifaun_send.inc";
-
-            $query = "SELECT unifaun_nimi
-                      FROM kirjoittimet
-                      WHERE yhtio = '{$kukarow['yhtio']}'
-                      AND tunnus  = '{$kirjoitin_tunnus}'";
-            $kires = pupe_query($query);
-            $kirow = mysql_fetch_assoc($kires);
-
-            $query = "SELECT *
-                      FROM rahtikirjat
-                      WHERE yhtio = '{$kukarow['yhtio']}'
-                      AND otsikkonro = 0
-                      AND tunnus IN ({$tunnukset})
-                      AND pakkaustieto_tunnukset != ''";
-            $mergeidres = pupe_query($query);
-            $mergeidrow = mysql_fetch_assoc($mergeidres);
-            $mergeid = $mergeidrow['rahtikirjanro'];
-
             @include "tilauskasittely/$toitarow[rahtikirja]";
-
-            if ($toitarow["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc' and $unifaun_ps_host != "" and $unifaun_ps_user != "" and $unifaun_ps_pass != "" and $unifaun_ps_path != "") {
-              $unifaun = new Unifaun($unifaun_ps_host, $unifaun_ps_user, $unifaun_ps_pass, $unifaun_ps_path, $unifaun_ps_port, $unifaun_ps_fail, $unifaun_ps_succ);
-            }
-            elseif ($toitarow["rahtikirja"] == 'rahtikirja_unifaun_uo_siirto.inc' and $unifaun_uo_host != "" and $unifaun_uo_user != "" and $unifaun_uo_pass != "" and $unifaun_uo_path != "") {
-              $unifaun = new Unifaun($unifaun_uo_host, $unifaun_uo_user, $unifaun_uo_pass, $unifaun_uo_path, $unifaun_uo_port, $unifaun_uo_fail, $unifaun_uo_succ);
-            }
-
-            $unifaun->_closeWithPrinter($mergeid, $kirow['unifaun_nimi']);
-            $unifaun->ftpSend();
           }
         }
 

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -888,11 +888,6 @@ if ($tee == 'tulosta') {
 
       if (!isset($nayta_pdf)) echo "$rahinta $jvtext<br>";
 
-      // unifaunille t‰ss‰ kohtaa normaali rahtikirja, jos koontier‰tulostus!
-      if ($_onko_unifaun and $_tulostustapa and $_paktiedot) {
-        $toitarow["rahtikirja"] = "rahtikirja_pdf.inc";
-      }
-
       // Kopsutulostus toistaiseksi vain A4-paperille unifaun keississ‰
       if (strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-kopio.php") !== FALSE and ($toitarow["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc' or $toitarow["rahtikirja"] == 'rahtikirja_unifaun_uo_siirto.inc')) {
         $toitarow["rahtikirja"] = "rahtikirja_pdf.inc";
@@ -902,7 +897,7 @@ if ($tee == 'tulosta') {
       if (!isset($tee_varsinainen_tulostus) or (isset($tee_varsinainen_tulostus) and $tee_varsinainen_tulostus)) {
 
         // tulostetaan toimitustavan m‰‰rittelem‰ rahtikirja
-        if (@include "tilauskasittely/$toitarow[rahtikirja]") {
+        if (($_onko_unifaun and $_tulostustapa and $_paktiedot) or @include "tilauskasittely/$toitarow[rahtikirja]") {
 
           // Otetaan talteen t‰ss‰ $rahtikirjanro talteen
           $rahtikirjanro_alkuperainen = $rahtikirjanro;

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -670,36 +670,38 @@ if ($tee == 'tulosta') {
                     AND tulostettu = '0000-00-00 00:00:00'";
           $ures  = pupe_query($query);
 
-          require_once "inc/unifaun_send.inc";
+          if ($_onko_unifaun) {
+            require_once "inc/unifaun_send.inc";
 
-          $query = "SELECT unifaun_nimi
-                    FROM kirjoittimet
-                    WHERE yhtio = '{$kukarow['yhtio']}'
-                    AND tunnus  = '{$kirjoitin_tunnus}'";
-          $kires = pupe_query($query);
-          $kirow = mysql_fetch_assoc($kires);
+            $query = "SELECT unifaun_nimi
+                      FROM kirjoittimet
+                      WHERE yhtio = '{$kukarow['yhtio']}'
+                      AND tunnus  = '{$kirjoitin_tunnus}'";
+            $kires = pupe_query($query);
+            $kirow = mysql_fetch_assoc($kires);
 
-          $query = "SELECT *
-                    FROM rahtikirjat
-                    WHERE yhtio = '{$kukarow['yhtio']}'
-                    AND otsikkonro = 0
-                    AND tunnus IN ({$tunnukset})
-                    AND pakkaustieto_tunnukset != ''";
-          $mergeidres = pupe_query($query);
-          $mergeidrow = mysql_fetch_assoc($mergeidres);
-          $mergeid = $mergeidrow['rahtikirjanro'];
+            $query = "SELECT *
+                      FROM rahtikirjat
+                      WHERE yhtio = '{$kukarow['yhtio']}'
+                      AND otsikkonro = 0
+                      AND tunnus IN ({$tunnukset})
+                      AND pakkaustieto_tunnukset != ''";
+            $mergeidres = pupe_query($query);
+            $mergeidrow = mysql_fetch_assoc($mergeidres);
+            $mergeid = $mergeidrow['rahtikirjanro'];
 
-          if (!empty($kirow['unifaun_nimi']) and !empty($mergeid)) {
+            if (!empty($kirow['unifaun_nimi']) and !empty($mergeid)) {
 
-            if ($toitarow["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc' and $unifaun_ps_host != "" and $unifaun_ps_user != "" and $unifaun_ps_pass != "" and $unifaun_ps_path != "") {
-              $unifaun = new Unifaun($unifaun_ps_host, $unifaun_ps_user, $unifaun_ps_pass, $unifaun_ps_path, $unifaun_ps_port, $unifaun_ps_fail, $unifaun_ps_succ);
+              if ($toitarow["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc' and $unifaun_ps_host != "" and $unifaun_ps_user != "" and $unifaun_ps_pass != "" and $unifaun_ps_path != "") {
+                $unifaun = new Unifaun($unifaun_ps_host, $unifaun_ps_user, $unifaun_ps_pass, $unifaun_ps_path, $unifaun_ps_port, $unifaun_ps_fail, $unifaun_ps_succ);
+              }
+              elseif ($toitarow["rahtikirja"] == 'rahtikirja_unifaun_uo_siirto.inc' and $unifaun_uo_host != "" and $unifaun_uo_user != "" and $unifaun_uo_pass != "" and $unifaun_uo_path != "") {
+                $unifaun = new Unifaun($unifaun_uo_host, $unifaun_uo_user, $unifaun_uo_pass, $unifaun_uo_path, $unifaun_uo_port, $unifaun_uo_fail, $unifaun_uo_succ);
+              }
+
+              $unifaun->_closeWithPrinter($mergeid, $kirow['unifaun_nimi']);
+              $unifaun->ftpSend();
             }
-            elseif ($toitarow["rahtikirja"] == 'rahtikirja_unifaun_uo_siirto.inc' and $unifaun_uo_host != "" and $unifaun_uo_user != "" and $unifaun_uo_pass != "" and $unifaun_uo_path != "") {
-              $unifaun = new Unifaun($unifaun_uo_host, $unifaun_uo_user, $unifaun_uo_pass, $unifaun_uo_path, $unifaun_uo_port, $unifaun_uo_fail, $unifaun_uo_succ);
-            }
-
-            $unifaun->_closeWithPrinter($mergeid, $kirow['unifaun_nimi']);
-            $unifaun->ftpSend();
           }
         }
 

--- a/rahtikirja.php
+++ b/rahtikirja.php
@@ -810,7 +810,8 @@ if ($tee == 'add') {
       }
 
       // t‰m‰ toimitustapa pit‰isi tulostaa nyt..
-      if ($row['nouto'] == '' and ($row['tulostustapa'] == 'H' or $row['tulostustapa'] == 'K' or $row["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc' or $row["rahtikirja"] == 'rahtikirja_unifaun_uo_siirto.inc')) {
+      if ($row['nouto'] == '' and ($row['tulostustapa'] == 'H' or $row['tulostustapa'] == 'K' or
+         ($row['tulostustapa'] != 'L' and ($row["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc' or $row["rahtikirja"] == 'rahtikirja_unifaun_uo_siirto.inc')))) {
         // rahtikirjojen tulostus vaatii seuraavat muuttujat:
 
         // $toimitustapa_varasto  toimitustavan selite!!!!varastopaikan tunnus
@@ -2714,7 +2715,7 @@ if (($id == 'dummy' and $mista == 'rahtikirja-tulostus.php') or $id != 0) {
             AND tunnus  = '{$otsik['liitostunnus']}'";
   $as_chk_res = pupe_query($query);
   $as_chk_row = mysql_fetch_assoc($as_chk_res);
-  
+
   if (!$toimitustapa_row) {
     $query = "SELECT *
               FROM toimitustapa
@@ -2723,7 +2724,7 @@ if (($id == 'dummy' and $mista == 'rahtikirja-tulostus.php') or $id != 0) {
     $toimitustapa_res = pupe_query($query);
     $toimitustapa_row = mysql_fetch_assoc($toimitustapa_res);
   }
-  
+
   // ei esit‰ytet‰ koonti-tulostustavoissa rahtikirjatietoja ker‰yserien ollessa p‰‰ll‰
   $_tulostustapa_chk = (!in_array($toimitustapa_row['tulostustapa'], array('K', 'L')));
 

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -2858,7 +2858,8 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
       $query = "SELECT
                 lasku.*,
                 toimitustapa.tulostustapa,
-                toimitustapa.nouto
+                toimitustapa.nouto,
+                toimitustapa.rahtikirja
                 FROM lasku
                 LEFT JOIN toimitustapa ON (lasku.yhtio = toimitustapa.yhtio and lasku.toimitustapa = toimitustapa.selite)
                 WHERE lasku.tunnus in ({$tilausnumeroita})
@@ -3777,6 +3778,17 @@ if (php_sapi_name() != 'cli' and strpos($_SERVER['SCRIPT_NAME'], "keraa.php") !=
 
         $oslappkpl_hidden = 0;
         $disabled = '';
+
+        // jos unifaun + hetitulostus tai erätulostus
+        // --> ei tulosteta osoitelappuja Pupessa
+        $_ei_koonti = ($otsik_row['tulostustapa'] == 'H' or $otsik_row['tulostustapa'] == 'E');
+        $_onko_unifaun = ($otsik_row["rahtikirja"] == 'rahtikirja_unifaun_ps_siirto.inc');
+        $_onko_unifaun = ($_onko_unifaun or $otsik_row["rahtikirja"] == 'rahtikirja_unifaun_uo_siirto.inc');
+
+        if (!empty($oslappkpl) and $_onko_unifaun and $_ei_koonti) {
+          $yhtiorow["oletus_oslappkpl"] = 0;
+          $oslappkpl = 0;
+        }
 
         if ($yhtiorow["oletus_oslappkpl"] != 0 and ($yhtiorow['kerayserat'] == 'P' or $yhtiorow['kerayserat'] == 'A')) {
 

--- a/unifaun_fetch.php
+++ b/unifaun_fetch.php
@@ -172,10 +172,24 @@ if ($handle = opendir($ftpget_dest[$operaattori])) {
           $eranumero_sscc = preg_replace("/[^0-9\,]/", "", str_replace("_", ",", $eranumero_sscc));
 
           if (!empty($eranumero_sscc)) {
+
+            // koontierätulostuksessa pikkuisen eri tavalla kuin muissa
+            if ($toimitrow["tulostustapa"] == 'L') {
+
+              $_rahtiwherelisa = "AND otsikkonro = 0 and rahtikirjanro = '$eranumero_sscc'";
+              $_otsikkonro = 0;
+              $_pakkaustieto_tunnukset = "pakkaustieto_tunnukset = '$eranumero_sscc', ";
+            }
+            else {
+              $_rahtiwherelisa = "AND otsikkonro = '{$eranumero_sscc}'";
+              $_otsikkonro = $eranumero_sscc;
+              $_pakkaustieto_tunnukset = "";
+            }
+            
             $query = "SELECT tunnus, rahtikirjanro, sscc_ulkoinen
                       FROM rahtikirjat
                       WHERE yhtio    = '{$kukarow['yhtio']}'
-                      AND otsikkonro = '{$eranumero_sscc}'
+                      $_rahtiwherelisa
                       ORDER BY tunnus
                       LIMIT 1";
             $rakir_res = pupe_query($query);
@@ -222,7 +236,8 @@ if ($handle = opendir($ftpget_dest[$operaattori])) {
                            pakkauskuvaus  = '',
                            rahtikirjanro  = '$rahtikirjanro',
                            sscc_ulkoinen  = '$sscc_ulkoinen',
-                           otsikkonro     = '{$lasku_row['tunnus']}',
+                           otsikkonro     = $_otsikkonro,
+                           $_pakkaustieto_tunnukset
                            tulostuspaikka = '{$lasku_row['varasto']}',
                            toimitustapa   = '{$lasku_row['toimitustapa']}',
                            tulostettu     = now(),

--- a/unifaun_fetch.php
+++ b/unifaun_fetch.php
@@ -173,9 +173,15 @@ if ($handle = opendir($ftpget_dest[$operaattori])) {
 
           if (!empty($eranumero_sscc)) {
 
-            // koontierätulostuksessa pikkuisen eri tavalla kuin muissa
-            if ($toimitrow["tulostustapa"] == 'L') {
+            $query = "SELECT *
+                      FROM toimitustapa
+                      WHERE yhtio = '$kukarow[yhtio]'
+                      AND selite  = '{$toimitrow['toimitustapa']}'";
+            $toimitustapa_res = pupe_query($query);
+            $toimitustapa_row = mysql_fetch_assoc($toimitustapa_res);
 
+            // koontierätulostuksessa pikkuisen eri tavalla kuin muissa
+            if ($toimitustapa_row["tulostustapa"] == 'L') {
               $_rahtiwherelisa = "AND otsikkonro = 0 and rahtikirjanro = '$eranumero_sscc'";
               $_otsikkonro = 0;
               $_pakkaustieto_tunnukset = "pakkaustieto_tunnukset = '$eranumero_sscc', ";


### PR DESCRIPTION
Unifauniin lisätty tuki myös Pupen koontierätulostukselle ja koontihetitulostukselle.

Koontihetitulostus toimii niin että rahtikirjan syöttö tehdään vasta kun halutaan aineistoa siirtää Unifaunille. Siinä kerrotaan koonnin alusta, esim lava. Yksittäisten kollien kollilaput tulostetaan keräysvaiheessa, ja niistä kolleista ei mene tietoa Unifauniin.

Koontierätulostus toimii niin että rahtikirjan syöttö tehdään normaalisti. Yksittäisten kollien kollilaput tulostetaan keräysvaiheessa, ja niistä kolleista ei mene tietoa Unifauniin. Rahtikirjan tulostuksessa annetaan vasta koonnin alusta, esim lava. Unifaunille lähetetään tässä vaiheessa aineisto lavasta.