### PR TITLE
* Kuljetusliikkeelle SSCC

### DIFF
--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -221,6 +221,7 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "TOIMTAPALP")     $ulos .= "<option value='TOIMTAPALP' {$avain_sel['TOIMTAPALP']}>      ".t("Toimitustavan lajittelupiste")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "TERMINAALIALUE")   $ulos .= "<option value='TERMINAALIALUE' $avain_sel[TERMINAALIALUE]>    ".t("Varaston terminaalialue")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "SSCC")         $ulos .= "<option value='SSCC' $avain_sel[SSCC]>              ".t("SSCC-koodi")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "CARRIER_SSCC") $ulos .= "<option value='CARRIER_SSCC' {$avain_sel['CARRIER_SSCC']}>".t("Kuljetusliikkeen SSCC")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "SIIRTO_VASTNRO")   $ulos .= "<option value='SIIRTO_VASTNRO' {$avain_sel['SIIRTO_VASTNRO']}>  ".t("Siirtolistan vastaanottonumero")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "PAKKAUSKV")     $ulos .= "<option value='PAKKAUSKV' $avain_sel[PAKKAUSKV]>          ".t("Pakkaustiedon kieliversio")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "INVASTEPAIKKA")    $ulos .= "<option value='INVASTEPAIKKA' {$avain_sel['INVASTEPAIKKA']}>    ".t("Inventointiaste-raportin hylk‰‰m‰t tuotepaikat")."</option>";
@@ -447,6 +448,22 @@ if ($avain_sel['KOPIOITUOTE'] == 'SELECTED') {
     $ulos .= "</td>";
     $jatko = 0;
   }
+}
+
+if ($_selite and $avain_sel['CARRIER_SSCC'] == 'SELECTED') {
+  $toimitustavat = hae_kaikki_toimitustavat();
+
+  $ulos .= "<td>";
+  $ulos .= "<select name='{$nimi}'>";
+
+  foreach ($toimitustavat as $toimitustapa) {
+    $sel = $trow[$i] == $toimitustapa['selite'] ? "selected" : "";
+    $ulos .= "<option value='{$toimitustapa['selite']}'>{$toimitustapa['selite']}</optino>";
+  }
+
+  $ulos .= "</select>";
+  $ulos .= "</td>";
+  $jatko = 0;
 }
 
 $_toimmyynti = ($avain_sel['TOIMMYYNTI'] == 'SELECTED' and $_selite);

--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -221,7 +221,7 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "TOIMTAPALP")     $ulos .= "<option value='TOIMTAPALP' {$avain_sel['TOIMTAPALP']}>      ".t("Toimitustavan lajittelupiste")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "TERMINAALIALUE")   $ulos .= "<option value='TERMINAALIALUE' $avain_sel[TERMINAALIALUE]>    ".t("Varaston terminaalialue")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "SSCC")         $ulos .= "<option value='SSCC' $avain_sel[SSCC]>              ".t("SSCC-koodi")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "CARRIER_SSCC") $ulos .= "<option value='CARRIER_SSCC' {$avain_sel['CARRIER_SSCC']}>".t("Kuljetusliikkeen SSCC")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "GS1_SSCC") $ulos .= "<option value='GS1_SSCC' {$avain_sel['GS1_SSCC']}>".t("GS1 SSCC")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "SIIRTO_VASTNRO")   $ulos .= "<option value='SIIRTO_VASTNRO' {$avain_sel['SIIRTO_VASTNRO']}>  ".t("Siirtolistan vastaanottonumero")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "PAKKAUSKV")     $ulos .= "<option value='PAKKAUSKV' $avain_sel[PAKKAUSKV]>          ".t("Pakkaustiedon kieliversio")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "INVASTEPAIKKA")    $ulos .= "<option value='INVASTEPAIKKA' {$avain_sel['INVASTEPAIKKA']}>    ".t("Inventointiaste-raportin hylk‰‰m‰t tuotepaikat")."</option>";
@@ -450,13 +450,15 @@ if ($avain_sel['KOPIOITUOTE'] == 'SELECTED') {
   }
 }
 
-if ($avain_sel['CARRIER_SSCC'] == 'SELECTED') {
+if ($avain_sel['GS1_SSCC'] == 'SELECTED') {
 
   if ($_selite) {
     $toimitustavat = hae_kaikki_toimitustavat();
 
     $ulos .= "<td>";
     $ulos .= "<select name='{$nimi}'>";
+
+    $ulos .= "<option value='kaikki'>".t("Kaikki toimitustavat")."</optino>";
 
     foreach ($toimitustavat as $toimitustapa) {
       $sel = $trow[$i] == $toimitustapa['selite'] ? "selected" : "";

--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -450,21 +450,40 @@ if ($avain_sel['KOPIOITUOTE'] == 'SELECTED') {
   }
 }
 
-if ($_selite and $avain_sel['CARRIER_SSCC'] == 'SELECTED') {
-  $toimitustavat = hae_kaikki_toimitustavat();
+if ($avain_sel['CARRIER_SSCC'] == 'SELECTED') {
 
-  $ulos .= "<td>";
-  $ulos .= "<select name='{$nimi}'>";
+  if ($_selite) {
+    $toimitustavat = hae_kaikki_toimitustavat();
 
-  foreach ($toimitustavat as $toimitustapa) {
-    $sel = $trow[$i] == $toimitustapa['selite'] ? "selected" : "";
-    $ulos .= "<option value='{$toimitustapa['selite']}'>{$toimitustapa['selite']}</optino>";
+    $ulos .= "<td>";
+    $ulos .= "<select name='{$nimi}'>";
+
+    foreach ($toimitustavat as $toimitustapa) {
+      $sel = $trow[$i] == $toimitustapa['selite'] ? "selected" : "";
+      $ulos .= "<option value='{$toimitustapa['selite']}' {$sel}>{$toimitustapa['selite']}</optino>";
+    }
+
+    $ulos .= "</select>";
+    $ulos .= "</td>";
+    $jatko = 0;
   }
 
-  $ulos .= "</select>";
-  $ulos .= "</td>";
-  $jatko = 0;
+  if ($_selitetark) {
+    $ulos .= "<td>";
+    $ulos .= "<select name='{$nimi}'>";
+
+    foreach (range(0, 9) as $n) {
+      $sel = (int) $trow[$i] == $n ? "selected" : "";
+      $ulos .= "<option value='{$n}' {$sel}>{$n}</optino>";
+    }
+
+    $ulos .= "</select>";
+    $ulos .= "</td>";
+    $jatko = 0;
+  }
 }
+
+
 
 $_toimmyynti = ($avain_sel['TOIMMYYNTI'] == 'SELECTED' and $_selite);
 

--- a/inc/avainsanatarkista.inc
+++ b/inc/avainsanatarkista.inc
@@ -260,7 +260,7 @@ if (!function_exists("avainsanatarkista")) {
       }
     }
 
-    $_arr = array("RAJATOIMIPAIKAT", "MAARATOIMPAIKKA", "CARRIER_SSCC");
+    $_arr = array("RAJATOIMIPAIKAT", "MAARATOIMPAIKKA", "GS1_SSCC");
 
     if (in_array(strtoupper($tem_laji), $_arr)) {
       if (mysql_field_name($result, $i) == "selite") {

--- a/inc/avainsanatarkista.inc
+++ b/inc/avainsanatarkista.inc
@@ -260,7 +260,7 @@ if (!function_exists("avainsanatarkista")) {
       }
     }
 
-    $_arr = array("RAJATOIMIPAIKAT", "MAARATOIMPAIKKA", "GS1_SSCC");
+    $_arr = array("RAJATOIMIPAIKAT", "MAARATOIMPAIKKA");
 
     if (in_array(strtoupper($tem_laji), $_arr)) {
       if (mysql_field_name($result, $i) == "selite") {

--- a/inc/avainsanatarkista.inc
+++ b/inc/avainsanatarkista.inc
@@ -260,7 +260,9 @@ if (!function_exists("avainsanatarkista")) {
       }
     }
 
-    if (in_array(strtoupper($tem_laji), array("RAJATOIMIPAIKAT", "MAARATOIMPAIKKA"))) {
+    $_arr = array("RAJATOIMIPAIKAT", "MAARATOIMPAIKKA", "CARRIER_SSCC");
+
+    if (in_array(strtoupper($tem_laji), $_arr)) {
       if (mysql_field_name($result, $i) == "selite") {
         $selite = trim($tem_selite);
 

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -22316,11 +22316,11 @@ if (!function_exists('tee_keraysera_painon_perusteella')) {
             if (!empty($yhtiorow['gs1_company_id'])) {
               $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
-              if (empty($_selitetark)) {
+              if ($_selitetark == '') {
                 $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
               }
 
-              if (!empty($_selitetark)) {
+              if ($_selitetark != '') {
                 $expansioncode = $_selitetark;
 
                 $sscc_ulkoinen = gs1_sscc($expansioncode, $sscc, $pakkausnro);
@@ -22355,11 +22355,11 @@ if (!function_exists('tee_keraysera_painon_perusteella')) {
         if (!empty($yhtiorow['gs1_company_id'])) {
           $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
-          if (empty($_selitetark)) {
+          if ($_selitetark == '') {
             $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
           }
 
-          if (!empty($_selitetark)) {
+          if ($_selitetark != '') {
             $expansioncode = $_selitetark;
 
             $sscc_ulkoinen = gs1_sscc($expansioncode, $sscc, $pakkausnro);
@@ -22396,11 +22396,11 @@ if (!function_exists('tee_keraysera_painon_perusteella')) {
         if (!empty($yhtiorow['gs1_company_id'])) {
           $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
-          if (empty($_selitetark)) {
+          if ($_selitetark == '') {
             $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
           }
 
-          if (!empty($_selitetark)) {
+          if ($_selitetark != '') {
             $expansioncode = $_selitetark;
 
             $uusi_row['data']['sscc_ulkoinen'] = $sscc_ulkoinen = gs1_sscc($expansioncode, $sscc, $pakkausnro);

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -31419,6 +31419,24 @@ if (!function_exists("jaljella_oleva_maksupaatesumma")) {
   }
 }
 
+if (!function_exists("carrier_sscc")) {
+  function carrier_sscc($expansioncode, $id, $n) {
+    global $yhtiorow;
+
+    $sscc_prefix = '00';
+    $sscc_expansioncode = $expansioncode;
+    $sscc_gs1_company_id = $yhtiorow['gs1_company_id'];
+    $sscc_item_id = substr($id, -7);
+    $sscc_count = str_pad((int) $n, 2, 0, STR_PAD_LEFT);
+
+    $sscc = $sscc_prefix.$sscc_expansioncode.$sscc_gs1_company_id.$sscc_item_id.$sscc_count;
+    $sscc_checknum = tarkiste($sscc);
+    $sscc = $sscc.$sscc_checknum;
+
+    return $sscc;
+  }
+}
+
 if (!function_exists("hae_tuoteperhe")) {
   /**
    * Hakee tuoteperheen kaikkine lapsineen rekursiivisesti

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -31419,6 +31419,26 @@ if (!function_exists("jaljella_oleva_maksupaatesumma")) {
   }
 }
 
+if (!function_exists("carrier_sscc_checksum")) {
+  function carrier_sscc_checksum($sscc) {
+    $multiply = array(
+      3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3
+    );
+
+    $sscc = (string) $sscc;
+
+    $sum = 0;
+
+    $length = strlen($sscc);
+
+    for ($i = 0; $i < $length; $i++) {
+      $sum += (int) $sscc[$i] * $multiply[$i];
+    }
+
+    return (ceil($sum / 10) * 10) - $sum;
+  }
+}
+
 if (!function_exists("carrier_sscc")) {
   function carrier_sscc($expansioncode, $id, $n) {
     global $yhtiorow;
@@ -31430,7 +31450,7 @@ if (!function_exists("carrier_sscc")) {
     $sscc_count = str_pad((int) $n, 2, 0, STR_PAD_LEFT);
 
     $sscc = $sscc_prefix.$sscc_expansioncode.$sscc_gs1_company_id.$sscc_item_id.$sscc_count;
-    $sscc_checknum = tarkiste($sscc);
+    $sscc_checknum = carrier_sscc_checksum($sscc);
     $sscc = $sscc.$sscc_checknum;
 
     return $sscc;

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -22215,22 +22215,19 @@ if (!function_exists('uusi_sscc_nro')) {
   }
 }
 
-if (!function_exists('uusi_gs1_sscc_nro')) {
-  function uusi_gs1_sscc_nro($sscc_sisainen) {
-    global $kukarow, $yhtiorow;
+if (!function_exists("gs1_sscc")) {
+  function gs1_sscc($expansioncode, $id, $n) {
+    global $yhtiorow;
 
-    // Rakennetaan GS1 SSCC -numero
-    $sscc_sovellustunnus = "00";
-    $sscc_gs1_laajennustunnus = "0";
+    $sscc_prefix = '00';
+    $sscc_expansioncode = $expansioncode;
+    $sscc_gs1_company_id = str_pad($yhtiorow['gs1_company_id'], 7, 0, STR_PAD_LEFT);
+    $sscc_item_id = str_pad(substr($id, -7), 7, 0, STR_PAD_LEFT);
+    $sscc_count = str_pad((int) $n, 2, 0, STR_PAD_LEFT);
 
-    $sscc_gs1_yritystunnus = str_pad($yhtiorow['ean'], 7, 0, STR_PAD_LEFT);
-    $sscc_sisainen = str_pad($sscc_sisainen, 7, 0, STR_PAD_LEFT);
-
-    $sscc = $sscc_sovellustunnus.$sscc_gs1_laajennustunnus.$sscc_gs1_yritystunnus.$sscc_sisainen;
-
-    $sscc_tarkiste = tarkiste($sscc);
-
-    $sscc = $sscc.$sscc_tarkiste;
+    $sscc = $sscc_expansioncode.$sscc_gs1_company_id.$sscc_item_id.$sscc_count;
+    $sscc_checknum = tarkiste($sscc);
+    $sscc = $sscc_prefix.$sscc.$sscc_checknum;
 
     return $sscc;
   }
@@ -22315,7 +22312,26 @@ if (!function_exists('tee_keraysera_painon_perusteella')) {
             $pakkauksen_kaytetty_paino = ($kerayseran_rivit[$i]['data']['tuotemassa'] * $jaljella);
 
             $sscc          = uusi_sscc_nro();
-            $sscc_ulkoinen = uusi_gs1_sscc_nro($sscc);
+
+            if (!empty($yhtiorow['gs1_company_id'])) {
+              $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+
+              if (empty($_selitetark)) {
+                $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
+              }
+
+              if (!empty($_selitetark)) {
+                $expansioncode = $_selitetark;
+
+                $sscc_ulkoinen = gs1_sscc($expansioncode, $sscc, $pakkausnro);
+              }
+              else {
+                $sscc_ulkoinen = $sscc;
+              }
+            }
+            else {
+              $sscc_ulkoinen = $sscc;
+            }
           }
 
           break;
@@ -22335,7 +22351,26 @@ if (!function_exists('tee_keraysera_painon_perusteella')) {
         $pakkausnro++;
 
         $sscc          = uusi_sscc_nro();
-        $sscc_ulkoinen = uusi_gs1_sscc_nro($sscc);
+
+        if (!empty($yhtiorow['gs1_company_id'])) {
+          $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+
+          if (empty($_selitetark)) {
+            $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
+          }
+
+          if (!empty($_selitetark)) {
+            $expansioncode = $_selitetark;
+
+            $sscc_ulkoinen = gs1_sscc($expansioncode, $sscc, $pakkausnro);
+          }
+          else {
+            $sscc_ulkoinen = $sscc;
+          }
+        }
+        else {
+          $sscc_ulkoinen = $sscc;
+        }
       }
 
       $keraysera_kpl = $kerayseran_rivit[$i]['data']['varattu'] - $jaljella;
@@ -22357,7 +22392,26 @@ if (!function_exists('tee_keraysera_painon_perusteella')) {
         $uusi_row['data']['paino'] = $uusi_row['data']['tuotemassa'] * $jaljella;
         $uusi_row['data']['uusirivi'] = true;
         $uusi_row['data']['sscc'] = $sscc = uusi_sscc_nro();
-        $uusi_row['data']['sscc_ulkoinen'] = $sscc_ulkoinen = uusi_gs1_sscc_nro($sscc);
+
+        if (!empty($yhtiorow['gs1_company_id'])) {
+          $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+
+          if (empty($_selitetark)) {
+            $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
+          }
+
+          if (!empty($_selitetark)) {
+            $expansioncode = $_selitetark;
+
+            $uusi_row['data']['sscc_ulkoinen'] = $sscc_ulkoinen = gs1_sscc($expansioncode, $sscc, $pakkausnro);
+          }
+          else {
+            $uusi_row['data']['sscc_ulkoinen'] = $sscc_ulkoinen = $sscc;
+          }
+        }
+        else {
+          $uusi_row['data']['sscc_ulkoinen'] = $sscc_ulkoinen = $sscc;
+        }
 
         // splitataan array
         // halutaan lis‰t‰ uusi_row arrayn keskelle, joten joudutaan k‰ytt‰m‰‰n array_slicea.
@@ -31416,44 +31470,6 @@ if (!function_exists("jaljella_oleva_maksupaatesumma")) {
     }
 
     return $palautettava;
-  }
-}
-
-if (!function_exists("carrier_sscc_checksum")) {
-  function carrier_sscc_checksum($sscc) {
-    $multiply = array(
-      3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3, 1, 3
-    );
-
-    $sscc = (string) $sscc;
-
-    $sum = 0;
-
-    $length = strlen($sscc);
-
-    for ($i = 0; $i < $length; $i++) {
-      $sum += (int) $sscc[$i] * $multiply[$i];
-    }
-
-    return (ceil($sum / 10) * 10) - $sum;
-  }
-}
-
-if (!function_exists("carrier_sscc")) {
-  function carrier_sscc($expansioncode, $id, $n) {
-    global $yhtiorow;
-
-    $sscc_prefix = '00';
-    $sscc_expansioncode = $expansioncode;
-    $sscc_gs1_company_id = $yhtiorow['gs1_company_id'];
-    $sscc_item_id = substr($id, -7);
-    $sscc_count = str_pad((int) $n, 2, 0, STR_PAD_LEFT);
-
-    $sscc = $sscc_expansioncode.$sscc_gs1_company_id.$sscc_item_id.$sscc_count;
-    $sscc_checknum = carrier_sscc_checksum($sscc);
-    $sscc = $sscc_prefix.$sscc.$sscc_checknum;
-
-    return $sscc;
   }
 }
 

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -31449,9 +31449,9 @@ if (!function_exists("carrier_sscc")) {
     $sscc_item_id = substr($id, -7);
     $sscc_count = str_pad((int) $n, 2, 0, STR_PAD_LEFT);
 
-    $sscc = $sscc_prefix.$sscc_expansioncode.$sscc_gs1_company_id.$sscc_item_id.$sscc_count;
+    $sscc = $sscc_expansioncode.$sscc_gs1_company_id.$sscc_item_id.$sscc_count;
     $sscc_checknum = carrier_sscc_checksum($sscc);
-    $sscc = $sscc.$sscc_checknum;
+    $sscc = $sscc_prefix.$sscc.$sscc_checknum;
 
     return $sscc;
   }

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -22221,7 +22221,7 @@ if (!function_exists("gs1_sscc")) {
 
     $sscc_prefix = '00';
     $sscc_expansioncode = $expansioncode;
-    $sscc_gs1_company_id = str_pad($yhtiorow['gs1_company_id'], 7, 0, STR_PAD_LEFT);
+    $sscc_gs1_company_id = str_pad($yhtiorow['ean'], 7, 0, STR_PAD_LEFT);
     $sscc_item_id = str_pad(substr($id, -7), 7, 0, STR_PAD_LEFT);
     $sscc_count = str_pad((int) $n, 2, 0, STR_PAD_LEFT);
 
@@ -22313,7 +22313,7 @@ if (!function_exists('tee_keraysera_painon_perusteella')) {
 
             $sscc          = uusi_sscc_nro();
 
-            if (!empty($yhtiorow['gs1_company_id'])) {
+            if (!empty($yhtiorow['ean'])) {
               $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
               if ($_selitetark == '') {
@@ -22352,7 +22352,7 @@ if (!function_exists('tee_keraysera_painon_perusteella')) {
 
         $sscc          = uusi_sscc_nro();
 
-        if (!empty($yhtiorow['gs1_company_id'])) {
+        if (!empty($yhtiorow['ean'])) {
           $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
           if ($_selitetark == '') {
@@ -22393,7 +22393,7 @@ if (!function_exists('tee_keraysera_painon_perusteella')) {
         $uusi_row['data']['uusirivi'] = true;
         $uusi_row['data']['sscc'] = $sscc = uusi_sscc_nro();
 
-        if (!empty($yhtiorow['gs1_company_id'])) {
+        if (!empty($yhtiorow['ean'])) {
           $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
           if ($_selitetark == '') {

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -1219,7 +1219,7 @@ if ($tee == 'P') {
               if (!isset($pakkaukset[$monesko]['sscc'])) {
                 $pakkaukset[$monesko]['sscc'] = uusi_sscc_nro();
 
-                if (!empty($yhtiorow['gs1_company_id'])) {
+                if (!empty($yhtiorow['ean'])) {
                   $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$otsikkorivi['toimitustapa']}'", "", "", "selitetark");
 
                   if ($_selitetark == '') {

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -1218,7 +1218,26 @@ if ($tee == 'P') {
 
               if (!isset($pakkaukset[$monesko]['sscc'])) {
                 $pakkaukset[$monesko]['sscc'] = uusi_sscc_nro();
-                $pakkaukset[$monesko]['sscc_ulkoinen'] = uusi_gs1_sscc_nro($pakkaukset[$monesko]['sscc']);
+
+                if (!empty($yhtiorow['gs1_company_id'])) {
+                  $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$otsikkorivi['toimitustapa']}'", "", "", "selitetark");
+
+                  if (empty($_selitetark)) {
+                    $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
+                  }
+
+                  if (!empty($_selitetark)) {
+                    $expansioncode = $_selitetark;
+
+                    $pakkaukset[$monesko]['sscc_ulkoinen'] = gs1_sscc($expansioncode, $pakkaukset[$monesko]['sscc'], $monesko);
+                  }
+                  else {
+                    $pakkaukset[$monesko]['sscc_ulkoinen'] = $pakkaukset[$monesko]['sscc'];
+                  }
+                }
+                else {
+                  $pakkaukset[$monesko]['sscc_ulkoinen'] = $pakkaukset[$monesko]['sscc'];
+                }
               }
             }
 

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -1222,11 +1222,11 @@ if ($tee == 'P') {
                 if (!empty($yhtiorow['gs1_company_id'])) {
                   $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$otsikkorivi['toimitustapa']}'", "", "", "selitetark");
 
-                  if (empty($_selitetark)) {
+                  if ($_selitetark == '') {
                     $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
                   }
 
-                  if (!empty($_selitetark)) {
+                  if ($_selitetark != '') {
                     $expansioncode = $_selitetark;
 
                     $pakkaukset[$monesko]['sscc_ulkoinen'] = gs1_sscc($expansioncode, $pakkaukset[$monesko]['sscc'], $monesko);

--- a/tilauskasittely/osoitelappu_intrade_pdf.inc
+++ b/tilauskasittely/osoitelappu_intrade_pdf.inc
@@ -148,6 +148,18 @@ if ($yhtiorow['kerayserat'] == 'P' or $yhtiorow['kerayserat'] == 'A') {
   }
 }
 
+$kuljetusliike_sscc = false;
+$expansion_code = "";
+
+if (!empty($yhtiorow['gs1_company_id'])) {
+  $_selitetark = t_avainsana("CARRIER_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+
+  if (!empty($_selitetark)) {
+    $expansioncode = $_selitetark;
+    $kuljetusliike_sscc = true;
+  }
+}
+
 $kirjainlisa = '';
 
 for ($tulostuskpl = 1; $tulostuskpl <= $oslappkpl; $tulostuskpl++) {
@@ -162,6 +174,9 @@ for ($tulostuskpl = 1; $tulostuskpl <= $oslappkpl; $tulostuskpl++) {
 
   if (isset($uniq_pakkaukset_sscc[$tulostuskpl]) and $uniq_pakkaukset_sscc[$tulostuskpl] != "") {
     $sscc = $uniq_pakkaukset_sscc[$tulostuskpl];
+  }
+  elseif ($kuljetusliike_sscc) {
+    $sscc = carrier_sscc($expansioncode, $laskurow['tunnus'], $tulostuskpl);
   }
   else {
     // tehdään SSCC :

--- a/tilauskasittely/osoitelappu_intrade_pdf.inc
+++ b/tilauskasittely/osoitelappu_intrade_pdf.inc
@@ -154,11 +154,11 @@ $expansion_code = "";
 if (!empty($yhtiorow['gs1_company_id'])) {
   $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
-  if (empty($_selitetark)) {
+  if ($_selitetark == '') {
     $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
   }
 
-  if (!empty($_selitetark)) {
+  if ($_selitetark != '') {
     $expansioncode = $_selitetark;
     $kuljetusliike_sscc = true;
   }

--- a/tilauskasittely/osoitelappu_intrade_pdf.inc
+++ b/tilauskasittely/osoitelappu_intrade_pdf.inc
@@ -65,8 +65,8 @@ if (mysql_num_rows($pres) > 0) {
   $yhtiorow["puhelin"] = $print["puhelin"];
 }
 
-if (empty($yhtiorow['gs1_company_id'])) {
-  $yhtiorow['gs1_company_id'] = $yhtiorow["ytunnus"];
+if (empty($yhtiorow['ean'])) {
+  $yhtiorow['ean'] = $yhtiorow["ytunnus"];
 }
 
 //PDF:n luonti ja defaultit
@@ -151,7 +151,7 @@ if ($yhtiorow['kerayserat'] == 'P' or $yhtiorow['kerayserat'] == 'A') {
 $kuljetusliike_sscc = false;
 $expansion_code = "";
 
-if (!empty($yhtiorow['gs1_company_id'])) {
+if (!empty($yhtiorow['ean'])) {
   $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
   if ($_selitetark == '') {

--- a/tilauskasittely/osoitelappu_intrade_pdf.inc
+++ b/tilauskasittely/osoitelappu_intrade_pdf.inc
@@ -65,8 +65,8 @@ if (mysql_num_rows($pres) > 0) {
   $yhtiorow["puhelin"] = $print["puhelin"];
 }
 
-if ($yhtiorow['ean'] == '') {
-  $yhtiorow['ean'] = $yhtiorow["ytunnus"];
+if (empty($yhtiorow['gs1_company_id'])) {
+  $yhtiorow['gs1_company_id'] = $yhtiorow["ytunnus"];
 }
 
 //PDF:n luonti ja defaultit
@@ -152,7 +152,11 @@ $kuljetusliike_sscc = false;
 $expansion_code = "";
 
 if (!empty($yhtiorow['gs1_company_id'])) {
-  $_selitetark = t_avainsana("CARRIER_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+  $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+
+  if (empty($_selitetark)) {
+    $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
+  }
 
   if (!empty($_selitetark)) {
     $expansioncode = $_selitetark;
@@ -176,7 +180,7 @@ for ($tulostuskpl = 1; $tulostuskpl <= $oslappkpl; $tulostuskpl++) {
     $sscc = $uniq_pakkaukset_sscc[$tulostuskpl];
   }
   elseif ($kuljetusliike_sscc) {
-    $sscc = carrier_sscc($expansioncode, $laskurow['tunnus'], $tulostuskpl);
+    $sscc = gs1_sscc($expansioncode, $laskurow['tunnus'], $tulostuskpl);
   }
   else {
     // tehdään SSCC :

--- a/tilauskasittely/osoitelappu_pdf.inc
+++ b/tilauskasittely/osoitelappu_pdf.inc
@@ -184,11 +184,11 @@ $expansion_code = "";
 if (!empty($yhtiorow['gs1_company_id'])) {
   $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
-  if (empty($_selitetark)) {
+  if ($_selitetark == '') {
     $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
   }
 
-  if (!empty($_selitetark)) {
+  if ($_selitetark != '') {
     $expansioncode = $_selitetark;
     $kuljetusliike_sscc = true;
   }

--- a/tilauskasittely/osoitelappu_pdf.inc
+++ b/tilauskasittely/osoitelappu_pdf.inc
@@ -182,7 +182,11 @@ $kuljetusliike_sscc = false;
 $expansion_code = "";
 
 if (!empty($yhtiorow['gs1_company_id'])) {
-  $_selitetark = t_avainsana("CARRIER_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+  $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+
+  if (empty($_selitetark)) {
+    $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
+  }
 
   if (!empty($_selitetark)) {
     $expansioncode = $_selitetark;
@@ -206,7 +210,7 @@ for ($tulostuskpl = 1; $tulostuskpl <= $oslappkpl; $tulostuskpl++) {
     $sscc = $uniq_pakkaukset_sscc[$tulostuskpl];
   }
   elseif ($kuljetusliike_sscc) {
-    $sscc = carrier_sscc($expansioncode, $laskurow['tunnus'], $tulostuskpl);
+    $sscc = gs1_sscc($expansioncode, $laskurow['tunnus'], $tulostuskpl);
   }
   else {
     // tehdään SSCC :

--- a/tilauskasittely/osoitelappu_pdf.inc
+++ b/tilauskasittely/osoitelappu_pdf.inc
@@ -181,7 +181,7 @@ if ($yhtiorow['kerayserat'] == 'P' or $yhtiorow['kerayserat'] == 'A') {
 $kuljetusliike_sscc = false;
 $expansion_code = "";
 
-if (!empty($yhtiorow['gs1_company_id'])) {
+if (!empty($yhtiorow['ean'])) {
   $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
   if ($_selitetark == '') {

--- a/tilauskasittely/osoitelappu_pdf.inc
+++ b/tilauskasittely/osoitelappu_pdf.inc
@@ -178,6 +178,18 @@ if ($yhtiorow['kerayserat'] == 'P' or $yhtiorow['kerayserat'] == 'A') {
   }
 }
 
+$kuljetusliike_sscc = false;
+$expansion_code = "";
+
+if (!empty($yhtiorow['gs1_company_id'])) {
+  $_selitetark = t_avainsana("CARRIER_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+
+  if (!empty($_selitetark)) {
+    $expansioncode = $_selitetark;
+    $kuljetusliike_sscc = true;
+  }
+}
+
 $kirjainlisa = '';
 
 for ($tulostuskpl = 1; $tulostuskpl <= $oslappkpl; $tulostuskpl++) {
@@ -192,6 +204,9 @@ for ($tulostuskpl = 1; $tulostuskpl <= $oslappkpl; $tulostuskpl++) {
 
   if (isset($uniq_pakkaukset_sscc[$tulostuskpl]) and $uniq_pakkaukset_sscc[$tulostuskpl] != "") {
     $sscc = $uniq_pakkaukset_sscc[$tulostuskpl];
+  }
+  elseif ($kuljetusliike_sscc) {
+    $sscc = carrier_sscc($expansioncode, $laskurow['tunnus'], $tulostuskpl);
   }
   else {
     // tehdään SSCC :

--- a/tilauskasittely/rahtikirja_dpd.inc
+++ b/tilauskasittely/rahtikirja_dpd.inc
@@ -137,11 +137,11 @@ if ($kollityht > 0) {
   if (!empty($yhtiorow['gs1_company_id'])) {
     $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
-    if (empty($_selitetark)) {
+    if ($_selitetark == '') {
       $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
     }
 
-    if (!empty($_selitetark)) {
+    if ($_selitetark != '') {
       $expansioncode = $_selitetark;
       $kuljetusliike_sscc = true;
     }

--- a/tilauskasittely/rahtikirja_dpd.inc
+++ b/tilauskasittely/rahtikirja_dpd.inc
@@ -131,25 +131,42 @@ if ($kollityht > 0) {
 
   //$tulostakolli = 1; // tulostetaan aina yksi kappale???miks???
 
+  $kuljetusliike_sscc = false;
+  $expansion_code = "";
+
+  if (!empty($yhtiorow['gs1_company_id'])) {
+    $_selitetark = t_avainsana("CARRIER_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+
+    if (!empty($_selitetark)) {
+      $expansioncode = $_selitetark;
+      $kuljetusliike_sscc = true;
+    }
+  }
+
   $tulostakolli = $kollityht;
 
   for ($tulostuskpl=1; $tulostuskpl<=$tulostakolli; $tulostuskpl++) {
 
-    // tehdään SSCC :
-    // (00)
-    // 1
-    // ytunnus (8)
-    // lähetenro (6)
-    // kollityht (2)
-    // tarkiste (1)
+    if ($kuljetusliike_sscc) {
+      $sscc = carrier_sscc($expansioncode, $laskurow['tunnus'], $tulostuskpl);
+    }
+    else {
+      // tehdään SSCC :
+      // (00)
+      // 1
+      // ytunnus (8)
+      // lähetenro (6)
+      // kollityht (2)
+      // tarkiste (1)
 
-    //$prefix = "(00)"; // tää on turha
-    $sscc = 1;
-    $sscc .= sprintf("%08.8s", $yhtiorow["ytunnus"]);
-    $sscc .= sprintf('%06.6s', substr($laskurow["tunnus"], -6));
-    $sscc .= sprintf('%02.2s', $tulostuskpl);
-    $loppu = tarkiste($sscc);
-    $sscc = $sscc.$loppu;
+      //$prefix = "(00)"; // tää on turha
+      $sscc = 1;
+      $sscc .= sprintf("%08.8s", $yhtiorow["ytunnus"]);
+      $sscc .= sprintf('%06.6s', substr($laskurow["tunnus"], -6));
+      $sscc .= sprintf('%02.2s', $tulostuskpl);
+      $loppu = tarkiste($sscc);
+      $sscc = $sscc.$loppu;
+    }
 
     // tehdään pdf:n uusi sivu
     $firstpage = $pdf->new_page("a5");

--- a/tilauskasittely/rahtikirja_dpd.inc
+++ b/tilauskasittely/rahtikirja_dpd.inc
@@ -135,7 +135,11 @@ if ($kollityht > 0) {
   $expansion_code = "";
 
   if (!empty($yhtiorow['gs1_company_id'])) {
-    $_selitetark = t_avainsana("CARRIER_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+    $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
+
+    if (empty($_selitetark)) {
+      $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
+    }
 
     if (!empty($_selitetark)) {
       $expansioncode = $_selitetark;
@@ -148,7 +152,7 @@ if ($kollityht > 0) {
   for ($tulostuskpl=1; $tulostuskpl<=$tulostakolli; $tulostuskpl++) {
 
     if ($kuljetusliike_sscc) {
-      $sscc = carrier_sscc($expansioncode, $laskurow['tunnus'], $tulostuskpl);
+      $sscc = gs1_sscc($expansioncode, $laskurow['tunnus'], $tulostuskpl);
     }
     else {
       // tehdään SSCC :

--- a/tilauskasittely/rahtikirja_dpd.inc
+++ b/tilauskasittely/rahtikirja_dpd.inc
@@ -134,7 +134,7 @@ if ($kollityht > 0) {
   $kuljetusliike_sscc = false;
   $expansion_code = "";
 
-  if (!empty($yhtiorow['gs1_company_id'])) {
+  if (!empty($yhtiorow['ean'])) {
     $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$laskurow['toimitustapa']}'", "", "", "selitetark");
 
     if ($_selitetark == '') {

--- a/tilauskasittely/toimitusvahvistus_desadv.inc
+++ b/tilauskasittely/toimitusvahvistus_desadv.inc
@@ -391,11 +391,11 @@ if (!function_exists('desadv_row')) {
         if (!empty($yhtiorow['gs1_company_id'])) {
           $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$desadv_laskurow['toimitustapa']}'", "", "", "selitetark");
 
-          if (empty($_selitetark)) {
+          if ($_selitetark == '') {
             $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
           }
 
-          if (!empty($_selitetark)) {
+          if ($_selitetark != '') {
             $expansioncode = $_selitetark;
 
             $sscc_ulkoinen = gs1_sscc($expansioncode, $sscc, 1);

--- a/tilauskasittely/toimitusvahvistus_desadv.inc
+++ b/tilauskasittely/toimitusvahvistus_desadv.inc
@@ -387,7 +387,26 @@ if (!function_exists('desadv_row')) {
       // CPS - consignment packing sequence
       if ($desadv_version == "fi0089") {
         $sscc          = uusi_sscc_nro();
-        $sscc_ulkoinen = uusi_gs1_sscc_nro($sscc);
+
+        if (!empty($yhtiorow['gs1_company_id'])) {
+          $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$desadv_laskurow['toimitustapa']}'", "", "", "selitetark");
+
+          if (empty($_selitetark)) {
+            $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = 'kaikki'", "", "", "selitetark");
+          }
+
+          if (!empty($_selitetark)) {
+            $expansioncode = $_selitetark;
+
+            $sscc_ulkoinen = gs1_sscc($expansioncode, $sscc, 1);
+          }
+          else {
+            $sscc_ulkoinen = $pakkaukset[$monesko]['sscc'];
+          }
+        }
+        else {
+          $sscc_ulkoinen = $sscc;
+        }
 
         $desadv_message .= "CPS+{$sscc_ulkoinen}++1'";
         $x++;

--- a/tilauskasittely/toimitusvahvistus_desadv.inc
+++ b/tilauskasittely/toimitusvahvistus_desadv.inc
@@ -388,7 +388,7 @@ if (!function_exists('desadv_row')) {
       if ($desadv_version == "fi0089") {
         $sscc          = uusi_sscc_nro();
 
-        if (!empty($yhtiorow['gs1_company_id'])) {
+        if (!empty($yhtiorow['ean'])) {
           $_selitetark = t_avainsana("GS1_SSCC", "", "and avainsana.selite = '{$desadv_laskurow['toimitustapa']}'", "", "", "selitetark");
 
           if ($_selitetark == '') {


### PR DESCRIPTION
Avainsanoihin lisätty uusi laji "GS1_SSCC". Selitteeseen valitaan toimitustapa (tai kaikki) ja selitetarkiin "expansion code".

SSCC:tä käytetään normaalissa- ja intrade-osoitelapuissa, myös DPD-rahtikirjalla.