### PR TITLE
Reklamaatio koontipurkulista

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -841,6 +841,10 @@ if ((int) $kukarow["kesken"] > 0) {
     $yhtiorow = hae_yhtion_parametrit($kukarow['yhtio']);
   }
 
+  if ($toim == "REKLAMAATIO" and $laskurow['eilahetetta'] != '' and $yhtiorow['reklamaation_kasittely'] == 'X' and $laskurow['tilaustyyppi'] != 'U') {
+    $yhtiorow['reklamaation_kasittely'] = '';
+  }
+
   if ($laskurow["valkoodi"] != '' and trim(strtoupper($laskurow["valkoodi"])) != trim(strtoupper($yhtiorow["valkoodi"])) and $laskurow["vienti_kurssi"] != 0 and $yhtiorow["suoratoim_ulkomaan_alarajasumma"] > 0) {
     $yhtiorow["suoratoim_ulkomaan_alarajasumma"] = round(laskuval($yhtiorow["suoratoim_ulkomaan_alarajasumma"], $laskurow["vienti_kurssi"]), 0);
   }
@@ -9973,7 +9977,7 @@ if ($tee == '') {
               echo "<input type='hidden' name='tee' value='ODOTTAA'>";
               echo "<input type='submit' value='* ".t("{$napin_teksti} Odottaa Tuotteita saapuvaksi")." *'>";
             }
-          }
+                    }
           echo "</form></td>";
         }
       }

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -841,6 +841,10 @@ if ((int) $kukarow["kesken"] > 0) {
     $yhtiorow = hae_yhtion_parametrit($kukarow['yhtio']);
   }
 
+  # Jos käytössä "semi laaja"-reklamaatiokäsittely (X)
+  # Ja tilaustyyppi ei ole takuu
+  # Ja ohitetaan varastoprosessi eli "suoraan laskutukseen" (eilahetetta != '')
+  # Halutaan tällöin simuloida lyhyttä reklamaatioprosessia
   if ($toim == "REKLAMAATIO" and $laskurow['eilahetetta'] != '' and $yhtiorow['reklamaation_kasittely'] == 'X' and $laskurow['tilaustyyppi'] != 'U') {
     $yhtiorow['reklamaation_kasittely'] = '';
   }

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -1996,6 +1996,21 @@ if ($kukarow["extranet"] == "" and $toim == 'REKLAMAATIO'
   // Joka tarkoittaa että "Reklamaatio on vastaanotettu
   // tämän jälkeen kun seuraavassa vaiheessa tullaan niin "Tulostetaan Purkulista"
 
+  $_tilaustyyppi = ($laskurow['tilaustyyppi'] != 'U');
+  $_tilaustyyppi = ($_tilaustyyppi and $yhtiorow['reklamaation_kasittely'] == 'X');
+  $sahkoinen_lahete_check = !empty($sahkoinen_lahete);
+  $sahkoinen_lahete_check = ($sahkoinen_lahete_check and isset($generoi_sahkoinen_lahete));
+  $sahkoinen_lahete_check = ($sahkoinen_lahete_check and trim($generoi_sahkoinen_lahete) != "");
+  $sahkoinen_lahete_check = ($sahkoinen_lahete_check and !empty($sahkoinen_lahete_toim));
+  $sahkoinen_lahete_check = ($sahkoinen_lahete_check and in_array($toim, $sahkoinen_lahete_toim));
+
+  if ($_tilaustyyppi and  $sahkoinen_lahete_check and $kukarow["extranet"] == "") {
+
+    require_once "inc/sahkoinen_lahete.class.inc";
+
+    sahkoinen_lahete($laskurow);
+  }
+
   if ($tee == 'VALMIS' or $yhtiorow['reklamaation_kasittely'] == 'X') {
     $alatila_lisa = "AND alatila = ''";              // semilaaja reklamaatio & takuu
   }

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -9977,7 +9977,7 @@ if ($tee == '') {
               echo "<input type='hidden' name='tee' value='ODOTTAA'>";
               echo "<input type='submit' value='* ".t("{$napin_teksti} Odottaa Tuotteita saapuvaksi")." *'>";
             }
-                    }
+          }
           echo "</form></td>";
         }
       }


### PR DESCRIPTION
Laajassa reklamaatiokäsitteyssä (reklamaatio suoraan purkulistan tulostusjonoon, ei vastaanottojonoon) tuki sähköiselle lähetteelle. Tulisi sillon kun reklamaatio laitetaan valmiiksi ja se siirtyy purkulistan tulostusjonoon.

Lisäksi tuki "suoraan laskutukseen" reklamaatioilla laajassa reklamaatiokäsittelyssä (reklamaatio suoraan purkulistan tulostusjonoon, ei vastaanottojonoon), että ohitetaan varasto ja merkitään reklamaatio suoraan valmiiksi laskutettavaksi.

Runkojen purkulistaan vaihtoehto että "ei tulosteta". Tämä käyttöliittymä jos "suoraan laskutukseen" ruksattu otsikolta.