### PR TITLE
Pankkiyhteysfixejä

### DIFF
--- a/inc/pankkiyhteys_functions.inc
+++ b/inc/pankkiyhteys_functions.inc
@@ -964,13 +964,17 @@ function sepa_lataa_kaikki_uudet_tiedostot($params) {
 
 
 /**
- * Generoi private keyn ja certificate signing requestin. Tiedot signing requestiin haetaan
+ * Generoi private keyn ja certificate signing requestin. Osa signing requestin tiedoista haetaan
  * yhtiorowista. Palauttaa arrayn, jossa private_key ja csr.
  *
+ * @param array $params
  * @return array
  */
-function generoi_private_key_ja_csr() {
+function generoi_private_key_ja_csr($params = array()) {
   global $kukarow, $yhtiorow;
+
+  $company_name = empty($params['company_name']) ? $yhtiorow['nimi'] : $params['company_name'];
+  $customer_id = empty($params['customer_id']) ? '' : $params['customer_id'];
 
   $key_config = array(
     "digest_alg"       => "sha1",
@@ -981,10 +985,14 @@ function generoi_private_key_ja_csr() {
   $csr_info = array(
     "countryName"      => $yhtiorow["maa"],
     "localityName"     => $yhtiorow["kotipaikka"],
-    "organizationName" => $yhtiorow["nimi"],
-    "commonName"       => $yhtiorow["nimi"],
+    "organizationName" => $company_name,
+    "commonName"       => $company_name,
     "emailAddress"     => $yhtiorow["email"]
   );
+
+  if (!empty($customer_id)) {
+    $csr_info["serialNumber"] = $customer_id;
+  }
 
   $key = openssl_pkey_new($key_config);
   $csr = openssl_csr_new($csr_info, $key);

--- a/pankkiyhteysadmin.php
+++ b/pankkiyhteysadmin.php
@@ -10,6 +10,7 @@ echo "<hr>";
 sepa_pankkiyhteys_kunnossa();
 
 $tee = empty($tee) ? '' : $tee;
+$company_name = empty($company_name) ? '' : $company_name;
 $customer_id = empty($customer_id) ? '' : $customer_id;
 $pin = empty($pin) ? '' : $pin;
 $bank = "";
@@ -268,9 +269,14 @@ if ($tee == "luo") {
 
 // Haetaan sertifikaatti jos PIN on annettu
 if ($tee == "luo" and $pin != '') {
+  $csr_params = array(
+    "company_name" => $company_name,
+    "customer_id" => $customer_id
+  );
+
   // Generoidaan allekirjoitusta ja salausta varten private key ja certificate-signing-request
-  $generoidut_tunnukset1 = generoi_private_key_ja_csr();
-  $generoidut_tunnukset2 = generoi_private_key_ja_csr();
+  $generoidut_tunnukset1 = generoi_private_key_ja_csr($csr_params);
+  $generoidut_tunnukset2 = generoi_private_key_ja_csr($csr_params);
 
   $signing_private_key = $generoidut_tunnukset1["private_key"];
   $encryption_private_key = $generoidut_tunnukset2["private_key"];
@@ -378,6 +384,17 @@ if ($tee == "") {
     }
 
     echo "</select>";
+    echo "</td>";
+    echo "</tr>";
+
+    echo "<tr>";
+    echo "<th>";
+    echo "<label for='company_name'>";
+    echo t("Yrityksen nimi (Sama kuin sopimuksessa)");
+    echo "</label>";
+    echo "</th>";
+    echo "<td>";
+    echo "<input type='text' name='company_name' id='company_name' value='{$company_name}'>";
     echo "</td>";
     echo "</tr>";
 


### PR DESCRIPTION
* Annetaan syöttää yrityksen nimi, koska sen täytyy CSR:ssä ainakin Nordean tapauksessa olla täsmälleen sama kuin sopimuksessa
* Laitetaan CSR:n serial numberiksi customer_id, koska Nordea vaatii sen