### PR TITLE
* Päivitä oletuspaikka: kohdepaikan päivitys

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -21993,11 +21993,23 @@ if (!function_exists('paivita_oletuspaikka')) {
       $wherelisa = $yhtiorow['paivita_oletuspaikka'] == 'S' ? "" : "AND t.uusiotunnus = '0'";
       $joinlisa = "";
 
-      if ($tultiin_mobiilista) $joinlisa = "JOIN lasku ON (lasku.yhtio = t.yhtio AND lasku.tunnus = t.otunnus AND lasku.tila IN ('N','O') and lasku.alatila != 'X')";
+      if ($yhtiorow['paivita_oletuspaikka'] == 'S') {
+        $wherelisa = "";
+        $joinlisa = "JOIN lasku ON (lasku.yhtio = t.yhtio AND lasku.tunnus = t.otunnus AND lasku.tila IN ('N','O') and lasku.alatila != 'X')";
+        $tyyppilisa = "AND t.tyyppi = 'O'";
+      }
+      elseif ($yhtiorow['paivita_oletuspaikka'] == 'M') {
+        $wherelisa = "";
+        $joinlisa = "JOIN lasku ON (lasku.yhtio = t.yhtio AND lasku.tunnus = t.otunnus AND lasku.tila IN ('N','O') and lasku.alatila != 'X')";
+        $tyyppilisa = "AND t.tyyppi IN ('O','L','G')";
+      }
+      else {
+        $wherelisa = "AND t.uusiotunnus = '0'";
+        $joinlisa = "JOIN lasku ON (lasku.yhtio = t.yhtio AND lasku.tunnus = t.otunnus AND lasku.tila IN ('N','O') and lasku.alatila != 'X')";
+        $tyyppilisa = "AND t.tyyppi = 'O'";
+      }
 
-      $tyyppilisa = $tultiin_mobiilista ? "AND t.tyyppi IN ('O','L','G')" : "AND t.tyyppi = 'O'";
-
-      // P‰ivitet‰‰n uusi oletuspaikka myˆs avoimille keskener‰isille ostotilauksille (jos uusi paikka on samassa varastossa kun vanha)
+      // P‰ivitet‰‰n uusi oletuspaikka (jos uusi paikka on samassa varastossa kun vanha)
       $query = "UPDATE tilausrivi AS t
                 {$joinlisa}
                 SET t.hyllyalue  = '{$hylly['hyllyalue']}',
@@ -22017,6 +22029,28 @@ if (!function_exists('paivita_oletuspaikka')) {
       $result = pupe_query($query);
 
       $return["paivitetyt_ostorivit"] = mysql_affected_rows();
+
+      // P‰ivitet‰‰n siirtorivien kohdepaikka
+      $query = "UPDATE tilausrivin_lisatiedot AS tt
+                JOIN tilausrivi AS t ON (t.yhtio = tt.yhtio AND
+                  t.tunnus = tt.tilausrivitunnus AND
+                  t.tuoteno = '{$tuoteno}' AND
+                  t.kpl = '0' AND
+                  t.varattu != '0' AND
+                  t.tyyppi = 'G')
+                SET tt.kohde_hyllyalue  = '{$hylly['hyllyalue']}',
+                tt.kohde_hyllynro       = '{$hylly['hyllynro']}',
+                tt.kohde_hyllyvali      = '{$hylly['hyllyvali']}',
+                tt.kohde_hyllytaso      = '{$hylly['hyllytaso']}'
+                WHERE tt.yhtio    = '{$kukarow['yhtio']}'
+                AND tt.kohde_hyllyalue  = '{$oletusrow['hyllyalue']}'
+                AND tt.kohde_hyllynro   = '{$oletusrow['hyllynro']}'
+                AND tt.kohde_hyllytaso  = '{$oletusrow['hyllytaso']}'
+                AND tt.kohde_hyllyvali  = '{$oletusrow['hyllyvali']}'
+                {$wherelisa}";
+      $result = pupe_query($query);
+
+      $return["paivitetyt_ostorivit"] += mysql_affected_rows();
     }
 
     return $return;

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -22049,8 +22049,6 @@ if (!function_exists('paivita_oletuspaikka')) {
                 AND tt.kohde_hyllyvali  = '{$oletusrow['hyllyvali']}'
                 {$wherelisa}";
       $result = pupe_query($query);
-
-      $return["paivitetyt_ostorivit"] += mysql_affected_rows();
     }
 
     return $return;

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -22027,24 +22027,26 @@ if (!function_exists('paivita_oletuspaikka')) {
 
       $return["paivitetyt_ostorivit"] = mysql_affected_rows();
 
-      // P‰ivitet‰‰n siirtorivien kohdepaikka
-      $query = "UPDATE tilausrivin_lisatiedot AS tt
-                JOIN tilausrivi AS t ON (t.yhtio = tt.yhtio AND
-                  t.tunnus = tt.tilausrivitunnus AND
-                  t.tuoteno = '{$tuoteno}' AND
-                  t.kpl = '0' AND
-                  t.varattu != '0' AND
-                  t.tyyppi = 'G')
-                SET tt.kohde_hyllyalue  = '{$hylly['hyllyalue']}',
-                tt.kohde_hyllynro       = '{$hylly['hyllynro']}',
-                tt.kohde_hyllyvali      = '{$hylly['hyllyvali']}',
-                tt.kohde_hyllytaso      = '{$hylly['hyllytaso']}'
-                WHERE tt.yhtio    = '{$kukarow['yhtio']}'
-                AND tt.kohde_hyllyalue  = '{$oletusrow['hyllyalue']}'
-                AND tt.kohde_hyllynro   = '{$oletusrow['hyllynro']}'
-                AND tt.kohde_hyllytaso  = '{$oletusrow['hyllytaso']}'
-                AND tt.kohde_hyllyvali  = '{$oletusrow['hyllyvali']}'";
-      $result = pupe_query($query);
+      if ($yhtiorow['paivita_oletuspaikka'] == 'M') {
+        // P‰ivitet‰‰n siirtorivien kohdepaikka
+        $query = "UPDATE tilausrivin_lisatiedot AS tt
+                  JOIN tilausrivi AS t ON (t.yhtio = tt.yhtio AND
+                    t.tunnus = tt.tilausrivitunnus AND
+                    t.tuoteno = '{$tuoteno}' AND
+                    t.kpl = '0' AND
+                    t.varattu != '0' AND
+                    t.tyyppi = 'G')
+                  SET tt.kohde_hyllyalue  = '{$hylly['hyllyalue']}',
+                  tt.kohde_hyllynro       = '{$hylly['hyllynro']}',
+                  tt.kohde_hyllyvali      = '{$hylly['hyllyvali']}',
+                  tt.kohde_hyllytaso      = '{$hylly['hyllytaso']}'
+                  WHERE tt.yhtio    = '{$kukarow['yhtio']}'
+                  AND tt.kohde_hyllyalue  = '{$oletusrow['hyllyalue']}'
+                  AND tt.kohde_hyllynro   = '{$oletusrow['hyllynro']}'
+                  AND tt.kohde_hyllytaso  = '{$oletusrow['hyllytaso']}'
+                  AND tt.kohde_hyllyvali  = '{$oletusrow['hyllyvali']}'";
+        $result = pupe_query($query);
+      }
     }
 
     return $return;

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -21990,12 +21990,9 @@ if (!function_exists('paivita_oletuspaikka')) {
     }
     elseif (mysql_num_rows($upresult) == 1 and kuuluukovarastoon($oletusrow['hyllyalue'], $oletusrow['hyllynro']) == kuuluukovarastoon($hylly['hyllyalue'], $hylly['hyllynro'])) {
 
-      $wherelisa = $yhtiorow['paivita_oletuspaikka'] == 'S' ? "" : "AND t.uusiotunnus = '0'";
-      $joinlisa = "";
-
       if ($yhtiorow['paivita_oletuspaikka'] == 'S') {
         $wherelisa = "";
-        $joinlisa = "JOIN lasku ON (lasku.yhtio = t.yhtio AND lasku.tunnus = t.otunnus AND lasku.tila IN ('N','O') and lasku.alatila != 'X')";
+        $joinlisa = "JOIN lasku ON (lasku.yhtio = t.yhtio AND lasku.tunnus = t.otunnus AND lasku.tila = 'O' and lasku.alatila != 'X')";
         $tyyppilisa = "AND t.tyyppi = 'O'";
       }
       elseif ($yhtiorow['paivita_oletuspaikka'] == 'M') {
@@ -22005,7 +22002,7 @@ if (!function_exists('paivita_oletuspaikka')) {
       }
       else {
         $wherelisa = "AND t.uusiotunnus = '0'";
-        $joinlisa = "JOIN lasku ON (lasku.yhtio = t.yhtio AND lasku.tunnus = t.otunnus AND lasku.tila IN ('N','O') and lasku.alatila != 'X')";
+        $joinlisa = "JOIN lasku ON (lasku.yhtio = t.yhtio AND lasku.tunnus = t.otunnus AND lasku.tila = 'O' and lasku.alatila != 'X')";
         $tyyppilisa = "AND t.tyyppi = 'O'";
       }
 
@@ -22046,8 +22043,7 @@ if (!function_exists('paivita_oletuspaikka')) {
                 AND tt.kohde_hyllyalue  = '{$oletusrow['hyllyalue']}'
                 AND tt.kohde_hyllynro   = '{$oletusrow['hyllynro']}'
                 AND tt.kohde_hyllytaso  = '{$oletusrow['hyllytaso']}'
-                AND tt.kohde_hyllyvali  = '{$oletusrow['hyllyvali']}'
-                {$wherelisa}";
+                AND tt.kohde_hyllyvali  = '{$oletusrow['hyllyvali']}'";
       $result = pupe_query($query);
     }
 

--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -4339,10 +4339,11 @@ if ($fieldname == 'vastaavat_tuotteet_esitysmuoto') {
 if ($fieldname == 'paivita_oletuspaikka') {
   $ulos = "<td><select name='{$nimi}' ".js_alasvetoMaxWidth($nimi, 400).">";
 
-  $sel = $trow[$i] == 'S' ? 'selected' : '';
+  $sel = array($trow[$i] => 'selected') + array('' => '', 'S' => '', 'M' => '');
 
   $ulos .= "<option value = ''>".t("P‰ivitet‰‰n uusi oletuspaikka avoimille ostoriveille")."</option>";
-  $ulos .= "<option value = 'S' {$sel}>".t("P‰ivitet‰‰n uusi oletuspaikka avoimille ja saapumisiin liitetyille ostoriveille.")."</option>";
+  $ulos .= "<option value = 'S' {$sel['S']}>".t("P‰ivitet‰‰n uusi oletuspaikka avoimille ja saapumisiin liitetyille ostoriveille.")."</option>";
+  $ulos .= "<option value = 'M' {$sel['M']}>".t("P‰ivitet‰‰n uusi oletuspaikka avoimille ja saapumisiin liitetyille ostoriveille, myyntiriveille ja siirtoriveille.")."</option>";
   $ulos .= "</select></td>";
 
   $jatko = 0;

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -18,6 +18,7 @@ if ($tee != '') {
              tilausrivi WRITE,
              tilausrivi as t WRITE,
              tilausrivi as tilausrivi_osto READ,
+             tilausrivin_lisatiedot AS tt WRITE,
              sarjanumeroseuranta WRITE,
              sarjanumeroseuranta_arvomuutos READ,
              lasku WRITE,


### PR DESCRIPTION
Osataan päivittää myös siirtorivien kohdepaikkatiedot, jos oletuspaikkaa muutetaan.

Siirrettiin pelkästään mobiilipuolen toiminnallisuus "Päivitä oletuspaikka"-yhtiöparametrin uudeksi valinnaksi.

```SQL
CREATE INDEX kohde_hyllypaikka ON tilausrivin_lisatiedot (yhtio, kohde_hyllyalue, kohde_hyllynro, kohde_hyllyvali, kohde_hyllytaso);