### PR TITLE
Palkkatosite: SQL-errorin korjaus

### DIFF
--- a/palkkatosite.php
+++ b/palkkatosite.php
@@ -140,7 +140,8 @@ if (is_uploaded_file($_FILES['userfile']['tmp_name']) === TRUE) {
 
       //  Trimmataan kaikki
       foreach ($kentat as &$k) {
-        $k = trim($k);
+        $k = pupesoft_cleanstring(trim($k));
+        $k = pupesoft_csvstring($k);
       }
 
       // Tili


### PR DESCRIPTION
Palkkatosite ohjelmasta tuli SQL-errori, jos sille syötetyssä tiedostossa tuli erikoismerkkejä. Siivotaan erikoismerkit nyt pois jotta SQL-virheeltä vältyttäisiin.