### PR TITLE
Myynninseurantaraportti: laskutuspvm

### DIFF
--- a/raportit/myyntiseuranta.php
+++ b/raportit/myyntiseuranta.php
@@ -1478,7 +1478,9 @@ else {
             $lisa .= " and lasku.tunnus IN ({$rajaus[$i]}) ";
           }
 
-          if ($laskutuspaiva != "") $select .= "lasku.tapvm laskutuspvm, ";
+          if ($laskutuspaiva != "" and strpos($select, "lasku.tapvm laskutuspvm, ") === FALSE) {
+            $select .= "lasku.tapvm laskutuspvm, ";
+          }
         }
         //**  Tilauksittain loppu **//
 


### PR DESCRIPTION
Laskutuspäivämäärän kanssa haettaessa tuloksesta tuli joskus tyhjä, kun valittiin myös "Piilota Nollarivit" vaikka tulos ei tyhjä suinkaan todellisuudessa olisi ollut. Tämä on nyt korjattu ja nyt myös näillä hakuehdoilla saa tuloksen ruudulle.