### PR TITLE
Unifaun: sähköpostiosoitteet

### DIFF
--- a/inc/unifaun_send.inc
+++ b/inc/unifaun_send.inc
@@ -83,6 +83,13 @@ class Unifaun {
       $this->asiakasrow = mysql_fetch_assoc($asres);
     }
   }
+  
+  public function sanitizeEmails ($emails) {
+    $emails = str_replace(" ", "", $emails);
+    $emails = str_replace(",", ";", $emails);
+    
+    return $emails;
+  }
 
   public function setPostiRow($postirow) {
     $this->postirow = $postirow;
@@ -275,7 +282,7 @@ class Unifaun {
     $uni_snd_val = $uni_sender->addChild('val', utf8_encode(str_replace("0037", "FI", $this->postirow["yhtio_ovttunnus"]))); // VAT number
     $uni_snd_val->addAttribute('n', "vatno");
 
-    $uni_snd_val = $uni_sender->addChild('val', utf8_encode($this->yhtiorow["email"])); // E-mail
+    $uni_snd_val = $uni_sender->addChild('val', utf8_encode($this->sanitizeEmails($this->yhtiorow["email"]))); // E-mail
     $uni_snd_val->addAttribute('n', "email");
 
     //$uni_snd_val = $uni_sender->addChild('val', ""); # Mobile phone number. In Sweden the number must begin with 07 and contain 10 digits.
@@ -477,7 +484,7 @@ class Unifaun {
     $uni_rcv_val->addAttribute('n', "vatno");
 
     if ($this->asiakasrow["email"] != "") {
-      $uni_rcv_val = $uni_receiver->addChild('val', utf8_encode($this->asiakasrow["email"])); // E-mail
+      $uni_rcv_val = $uni_receiver->addChild('val', utf8_encode($this->sanitizeEmails($this->asiakasrow["email"]))); // E-mail
       $uni_rcv_val->addAttribute('n', "email");
     }
 
@@ -736,7 +743,7 @@ class Unifaun {
         $uni_add_val->addAttribute('n', "text3"); 
       }
       if ($this->asiakasrow["email"] != '') {
-        $uni_add_val = $uni_addon->addChild('val', utf8_encode($this->asiakasrow["email"])); // Used to define notification mode for add-on NOT.
+        $uni_add_val = $uni_addon->addChild('val', utf8_encode($this->sanitizeEmails($this->asiakasrow["email"]))); // Used to define notification mode for add-on NOT.
         $uni_add_val->addAttribute('n', "text4");
       }
     }


### PR DESCRIPTION
Unifauniin lähettettäessä sähköpostit tulee erotella ";" merkillä. Korjattun niin, että sähköpostit erotellaan aina ";" merkillä, jos esimerkiksi asiakkaan tiedoissa on useita sähköpostiosoitteita.