### PR TITLE
Rahtikirjanroon vain postin seurantakoodi

### DIFF
--- a/tilauskasittely/rahtikirja_postitarra_pdf.inc
+++ b/tilauskasittely/rahtikirja_postitarra_pdf.inc
@@ -63,6 +63,10 @@ $sivu = 1;
 
 $tulostakolli = $tulostuskpl;
 
+if (is_numeric($rahtikirjanro) and $tulostakolli > 0) {
+  $rahtikirjanro = "";
+}
+
 // tulostetaan niin monta lappua kun on kollejakin
 for ($tulostuskpl=1; $tulostuskpl<=$tulostakolli; $tulostuskpl++) {
 


### PR DESCRIPTION
Jos rahtikirjanumeroon jätetään postin seurantakoodin eteen tilausnumero, menee se Magentoon sellaisenaan, eikä lähetksen seuranta Magenton kautta onnistu