### PR TITLE
Tuotannonsuunnittelu: siirrä parkkiin ominaisuus

### DIFF
--- a/tuotannonsuunnittelu.php
+++ b/tuotannonsuunnittelu.php
@@ -336,7 +336,7 @@ if ($tee == '') {
       <input type='hidden' name='tee' value='paivita'>
       <select name='tila' onchange='submit()'>
       <option value=''>Valitse</option>
-      <option value='OV'>Siirä parkkiin</option>
+      <option value='OV'>Siirrä parkkiin</option>
       <option value='VA'>Aloita valmistus</option>
       <option value='TK'>Keskeytä valmistus</option>
       <option value='VT'>Valmis tarkistukseen</option>

--- a/valmistus.class.php
+++ b/valmistus.class.php
@@ -293,6 +293,22 @@ class Valmistus {
           if (! pupe_query($query)) {
             throw new Exception("Kalenteri merkintää ei poistettu");
           }
+
+          $query = "UPDATE lasku
+                    SET
+                      toimaika  = '2099-01-01',
+                      kerayspvm = '2099-01-01 00:00:00'
+                    WHERE yhtio = '{$kukarow['yhtio']}'
+                      AND tunnus = {$this->tunnus}";
+          pupe_query($query);
+
+          $query = "UPDATE tilausrivi
+                    SET
+                      toimaika  = '2099-01-01',
+                      kerayspvm = '2099-01-01'
+                    WHERE yhtio = '{$kukarow['yhtio']}'
+                      AND otunnus = {$this->tunnus}";
+          pupe_query($query);
         }
         // Jos työ on keskeytetty ja siirretään takaisin parkkiin
         // nollataan kalenterista valmistuslinja (kalenteri.henkilo)


### PR DESCRIPTION
Palautettaessa tuotannonsuunnittelussa valmistus takaisin parkkiin "Siirrä parkkiin" toiminnolla niin päivitetään samalla myös kerayspvm ja toimaika tiedot laskulle ja tilausriveille 2099-01-01, jotta valmistus ei näkyisi hassusti tuotehallinnassa.

Lisäksi korjattiin samalla yksi typo; "Siirä parkkiin" -> "Siirrä parkkiin".
