### PR TITLE
Rahtikirja: korjaus rahtikirjanumeroon

### DIFF
--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -619,7 +619,6 @@ if ($tee == 'tulosta') {
       $_paktiedot = ($_paktiedot and trim($pakkaustieto_rahtikirjanro) != '');
 
       if ($_tulostustapa and $_paktiedot) {
-
         $query = "SELECT group_concat(tunnus) pakkaustieto_tunnukset
                   FROM rahtikirjat
                   WHERE yhtio                 = '$kukarow[yhtio]'

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -620,7 +620,6 @@ if ($tee == 'tulosta') {
 
       if ($_tulostustapa and $_paktiedot) {
 
-
         $query = "SELECT group_concat(tunnus) pakkaustieto_tunnukset
                   FROM rahtikirjat
                   WHERE yhtio                 = '$kukarow[yhtio]'

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -600,7 +600,7 @@ if ($tee == 'tulosta') {
       else {
         $groupby_lisa = "";
       }
-echo "603 rahtikirjanro $rahtikirjanro <br><br>"; var_dump($toitarow); echo "<br><br>";
+
       if ($toitarow["rahtikirja"] != "rahtikirja_postitarra_pdf.inc") {
         $query = "SELECT min(rahtikirjanro) rahtikirjanro
                   FROM rahtikirjat
@@ -610,7 +610,7 @@ echo "603 rahtikirjanro $rahtikirjanro <br><br>"; var_dump($toitarow); echo "<br
         $rahtikirjanrorow = mysql_fetch_assoc($rahtikirjanrores);
         $rahtikirjanro = $rahtikirjanrorow['rahtikirjanro'];
       }
-echo "611 rahtikirjanro $rahtikirjanro <br><br>";
+
       $pakkaustieto_tunnukset = '';
 
       $_tulostustapa = ($toitarow['tulostustapa'] == 'L');
@@ -619,7 +619,7 @@ echo "611 rahtikirjanro $rahtikirjanro <br><br>";
       $_paktiedot = ($_paktiedot and trim($pakkaustieto_rahtikirjanro) != '');
 
       if ($_tulostustapa and $_paktiedot) {
-        
+
 
         $query = "SELECT group_concat(tunnus) pakkaustieto_tunnukset
                   FROM rahtikirjat

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -600,13 +600,8 @@ if ($tee == 'tulosta') {
       else {
         $groupby_lisa = "";
       }
-echo "603 rahtikirjanro $rahtikirjanro <br><br>";
-      $_tulostustapa = ($toitarow['tulostustapa'] == 'L');
-      $_paktiedot = ($toitarow['uudet_pakkaustiedot'] == 'K');
-      $_paktiedot = ($_paktiedot and $tultiin == 'koonti_eratulostus_pakkaustiedot');
-      $_paktiedot = ($_paktiedot and trim($pakkaustieto_rahtikirjanro) != '');
-
-      if ($_tulostustapa and $_paktiedot) {
+echo "603 rahtikirjanro $rahtikirjanro <br><br>"; var_dump($toitarow); echo "<br><br>";
+      if ($toitarow["rahtikirja"] != "rahtikirja_postitarra_pdf.inc") {
         $query = "SELECT min(rahtikirjanro) rahtikirjanro
                   FROM rahtikirjat
                   WHERE yhtio = '{$kukarow['yhtio']}'
@@ -614,9 +609,16 @@ echo "603 rahtikirjanro $rahtikirjanro <br><br>";
         $rahtikirjanrores = pupe_query($query);
         $rahtikirjanrorow = mysql_fetch_assoc($rahtikirjanrores);
         $rahtikirjanro = $rahtikirjanrorow['rahtikirjanro'];
-echo "611 rahtikirjanro $rahtikirjanro <br><br>"; exit;
+      }
+echo "611 rahtikirjanro $rahtikirjanro <br><br>";
+      $_tulostustapa = ($toitarow['tulostustapa'] == 'L');
+      $_paktiedot = ($toitarow['uudet_pakkaustiedot'] == 'K');
+      $_paktiedot = ($_paktiedot and $tultiin == 'koonti_eratulostus_pakkaustiedot');
+      $_paktiedot = ($_paktiedot and trim($pakkaustieto_rahtikirjanro) != '');
+
+      if ($_tulostustapa and $_paktiedot) {
         $pakkaustieto_tunnukset = '';
-        
+
         $query = "SELECT group_concat(tunnus) pakkaustieto_tunnukset
                   FROM rahtikirjat
                   WHERE yhtio                 = '$kukarow[yhtio]'

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -601,7 +601,7 @@ if ($tee == 'tulosta') {
         $groupby_lisa = "";
       }
 
-      if ($toitarow["rahtikirja"] != "rahtikirja_postitarra_pdf.inc") {
+      if (strpos($toitarow["rahtikirja"], "unifaun") !== FALSE) {
         $query = "SELECT min(rahtikirjanro) rahtikirjanro
                   FROM rahtikirjat
                   WHERE yhtio = '{$kukarow['yhtio']}'

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -611,13 +611,15 @@ echo "603 rahtikirjanro $rahtikirjanro <br><br>"; var_dump($toitarow); echo "<br
         $rahtikirjanro = $rahtikirjanrorow['rahtikirjanro'];
       }
 echo "611 rahtikirjanro $rahtikirjanro <br><br>";
+      $pakkaustieto_tunnukset = '';
+
       $_tulostustapa = ($toitarow['tulostustapa'] == 'L');
       $_paktiedot = ($toitarow['uudet_pakkaustiedot'] == 'K');
       $_paktiedot = ($_paktiedot and $tultiin == 'koonti_eratulostus_pakkaustiedot');
       $_paktiedot = ($_paktiedot and trim($pakkaustieto_rahtikirjanro) != '');
 
       if ($_tulostustapa and $_paktiedot) {
-        $pakkaustieto_tunnukset = '';
+        
 
         $query = "SELECT group_concat(tunnus) pakkaustieto_tunnukset
                   FROM rahtikirjat

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -600,23 +600,23 @@ if ($tee == 'tulosta') {
       else {
         $groupby_lisa = "";
       }
-
-      $query = "SELECT min(rahtikirjanro) rahtikirjanro
-                FROM rahtikirjat
-                WHERE yhtio = '{$kukarow['yhtio']}'
-                AND tunnus IN ({$tunnukset})";
-      $rahtikirjanrores = pupe_query($query);
-      $rahtikirjanrorow = mysql_fetch_assoc($rahtikirjanrores);
-      $rahtikirjanro = $rahtikirjanrorow['rahtikirjanro'];
-
-      $pakkaustieto_tunnukset = '';
-
+echo "603 rahtikirjanro $rahtikirjanro <br><br>";
       $_tulostustapa = ($toitarow['tulostustapa'] == 'L');
       $_paktiedot = ($toitarow['uudet_pakkaustiedot'] == 'K');
       $_paktiedot = ($_paktiedot and $tultiin == 'koonti_eratulostus_pakkaustiedot');
       $_paktiedot = ($_paktiedot and trim($pakkaustieto_rahtikirjanro) != '');
 
       if ($_tulostustapa and $_paktiedot) {
+        $query = "SELECT min(rahtikirjanro) rahtikirjanro
+                  FROM rahtikirjat
+                  WHERE yhtio = '{$kukarow['yhtio']}'
+                  AND tunnus IN ({$tunnukset})";
+        $rahtikirjanrores = pupe_query($query);
+        $rahtikirjanrorow = mysql_fetch_assoc($rahtikirjanrores);
+        $rahtikirjanro = $rahtikirjanrorow['rahtikirjanro'];
+echo "611 rahtikirjanro $rahtikirjanro <br><br>"; exit;
+        $pakkaustieto_tunnukset = '';
+        
         $query = "SELECT group_concat(tunnus) pakkaustieto_tunnukset
                   FROM rahtikirjat
                   WHERE yhtio                 = '$kukarow[yhtio]'


### PR DESCRIPTION
Postitarroille meni rahtikirjannumeroon posti JJFI koodin eteen erheellisesti tilausnumero. Tämä on nyt korjattu niin, että JJFI koodin eteen ei tilausnumeroa mene.