### PR TITLE
Sarjanumeroseuranta T: tuloutuskorjaus

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -26179,7 +26179,7 @@ if (!function_exists("tsekit")) {
                   and tuoteno = '$toimrow[tuoteno]'
                   and $tunken = '$toimrow[tunnus]'";
       }
-      elseif ($rivirow["sarjanumeroseuranta"] == "E" or $rivirow["sarjanumeroseuranta"] == "F" or $rivirow["sarjanumeroseuranta"] == "G") {
+      elseif ($toimrow["sarjanumeroseuranta"] == "E" or $toimrow["sarjanumeroseuranta"] == "F" or $toimrow["sarjanumeroseuranta"] == "G") {
         $query = "SELECT sum(sarjanumeroseuranta.era_kpl*if(tilausrivi.tunnus is not null, if(tilausrivi.kpl+tilausrivi.varattu+tilausrivi.jt > 0 or tilausrivi.tyyppi = 'O', 1, -1), 1)) kpl, min(sarjanumeroseuranta.sarjanumero) sarjanumero
                   FROM sarjanumeroseuranta
                   LEFT JOIN tilausrivi ON (tilausrivi.yhtio = sarjanumeroseuranta.yhtio and tilausrivi.tunnus = sarjanumeroseuranta.myyntirivitunnus)

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -26155,7 +26155,7 @@ if (!function_exists("tsekit")) {
     // katotaan onko kaikki sarjanumerot ok
     $query = "SELECT tilausrivi.tunnus, tilausrivi.tuoteno, tilausrivi.varattu+tilausrivi.kpl kpl, tuote.sarjanumeroseuranta, tilausrivi.uusiotunnus
               FROM tilausrivi use index (uusiotunnus_index)
-              JOIN tuote on tuote.yhtio=tilausrivi.yhtio and tuote.tuoteno=tilausrivi.tuoteno and tuote.sarjanumeroseuranta != '' and tuote.sarjanumeroseuranta != 'T'
+              JOIN tuote on tuote.yhtio=tilausrivi.yhtio and tuote.tuoteno=tilausrivi.tuoteno and tuote.sarjanumeroseuranta NOT IN ('', 'T')
               WHERE tilausrivi.yhtio='$kukarow[yhtio]' and
               tilausrivi.uusiotunnus='$row[tunnus]' and
               tilausrivi.tyyppi='O'";
@@ -26179,7 +26179,7 @@ if (!function_exists("tsekit")) {
                   and tuoteno = '$toimrow[tuoteno]'
                   and $tunken = '$toimrow[tunnus]'";
       }
-      elseif ($toimrow["sarjanumeroseuranta"] == "E" or $toimrow["sarjanumeroseuranta"] == "F" or $toimrow["sarjanumeroseuranta"] == "G") {
+      else {
         $query = "SELECT sum(sarjanumeroseuranta.era_kpl*if(tilausrivi.tunnus is not null, if(tilausrivi.kpl+tilausrivi.varattu+tilausrivi.jt > 0 or tilausrivi.tyyppi = 'O', 1, -1), 1)) kpl, min(sarjanumeroseuranta.sarjanumero) sarjanumero
                   FROM sarjanumeroseuranta
                   LEFT JOIN tilausrivi ON (tilausrivi.yhtio = sarjanumeroseuranta.yhtio and tilausrivi.tunnus = sarjanumeroseuranta.myyntirivitunnus)

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -26155,7 +26155,7 @@ if (!function_exists("tsekit")) {
     // katotaan onko kaikki sarjanumerot ok
     $query = "SELECT tilausrivi.tunnus, tilausrivi.tuoteno, tilausrivi.varattu+tilausrivi.kpl kpl, tuote.sarjanumeroseuranta, tilausrivi.uusiotunnus
               FROM tilausrivi use index (uusiotunnus_index)
-              JOIN tuote on tuote.yhtio=tilausrivi.yhtio and tuote.tuoteno=tilausrivi.tuoteno and tuote.sarjanumeroseuranta!=''
+              JOIN tuote on tuote.yhtio=tilausrivi.yhtio and tuote.tuoteno=tilausrivi.tuoteno and tuote.sarjanumeroseuranta != '' and tuote.sarjanumeroseuranta != 'T'
               WHERE tilausrivi.yhtio='$kukarow[yhtio]' and
               tilausrivi.uusiotunnus='$row[tunnus]' and
               tilausrivi.tyyppi='O'";
@@ -26179,7 +26179,7 @@ if (!function_exists("tsekit")) {
                   and tuoteno = '$toimrow[tuoteno]'
                   and $tunken = '$toimrow[tunnus]'";
       }
-      else {
+      elseif ($rivirow["sarjanumeroseuranta"] == "E" or $rivirow["sarjanumeroseuranta"] == "F" or $rivirow["sarjanumeroseuranta"] == "G") {
         $query = "SELECT sum(sarjanumeroseuranta.era_kpl*if(tilausrivi.tunnus is not null, if(tilausrivi.kpl+tilausrivi.varattu+tilausrivi.jt > 0 or tilausrivi.tyyppi = 'O', 1, -1), 1)) kpl, min(sarjanumeroseuranta.sarjanumero) sarjanumero
                   FROM sarjanumeroseuranta
                   LEFT JOIN tilausrivi ON (tilausrivi.yhtio = sarjanumeroseuranta.yhtio and tilausrivi.tunnus = sarjanumeroseuranta.myyntirivitunnus)

--- a/tilauskasittely/ostotilausten_rivien_kohdistus.inc
+++ b/tilauskasittely/ostotilausten_rivien_kohdistus.inc
@@ -1988,7 +1988,7 @@ if ($tila == '') {
         $snro_ok = t("S:nro ok");
         $snro   = t("S:nro");
       }
-      else {
+      elseif ($rivirow["sarjanumeroseuranta"] == "E" or $rivirow["sarjanumeroseuranta"] == "F" or $rivirow["sarjanumeroseuranta"] == "G") {
         $query = "SELECT sum(sarjanumeroseuranta.era_kpl*if(tilausrivi.tunnus is not null, if(tilausrivi.kpl+tilausrivi.varattu+tilausrivi.jt > 0 or tilausrivi.tyyppi = 'O', 1, -1), 1)) kpl, min(sarjanumeroseuranta.sarjanumero) sarjanumero
                   FROM sarjanumeroseuranta
                   LEFT JOIN tilausrivi ON (tilausrivi.yhtio = sarjanumeroseuranta.yhtio and tilausrivi.tunnus = sarjanumeroseuranta.myyntirivitunnus)

--- a/tilauskasittely/ostotilausten_rivien_kohdistus.inc
+++ b/tilauskasittely/ostotilausten_rivien_kohdistus.inc
@@ -1968,7 +1968,7 @@ if ($tila == '') {
     echo "<input type='hidden' id='{$id}_varasto' value='{$rivirow['varasto']}' />";
     echo "<span class='saldo_{$id}' style='display:none;'></span>";
 
-    if ($rivirow["sarjanumeroseuranta"] != "") {
+    if ($rivirow["sarjanumeroseuranta"] != "" and $rivirow["sarjanumeroseuranta"] != "T") {
       if ($rivirow["siskpl"] < 0) {
         $tunken = "sarjanumeroseuranta.myyntirivitunnus";
         $tunind = "yhtio_myyntirivi";
@@ -1988,7 +1988,7 @@ if ($tila == '') {
         $snro_ok = t("S:nro ok");
         $snro   = t("S:nro");
       }
-      elseif ($rivirow["sarjanumeroseuranta"] == "E" or $rivirow["sarjanumeroseuranta"] == "F" or $rivirow["sarjanumeroseuranta"] == "G") {
+      else {
         $query = "SELECT sum(sarjanumeroseuranta.era_kpl*if(tilausrivi.tunnus is not null, if(tilausrivi.kpl+tilausrivi.varattu+tilausrivi.jt > 0 or tilausrivi.tyyppi = 'O', 1, -1), 1)) kpl, min(sarjanumeroseuranta.sarjanumero) sarjanumero
                   FROM sarjanumeroseuranta
                   LEFT JOIN tilausrivi ON (tilausrivi.yhtio = sarjanumeroseuranta.yhtio and tilausrivi.tunnus = sarjanumeroseuranta.myyntirivitunnus)


### PR DESCRIPTION
Tuotteen sarjanumeroseurantatyypin ollessa T ei näitä tuotteita voinut tulouttaa laisinkaan varastoon. Tämä korjattu nyt niin, että tälle sarjanumeroseurantatyypile ei välttämättä tarvitse vielä tuloutuksen yhteydessä sarjanumeroa syöttää - mutta ostotilauksen kautta se on edelleen mahdollista.