### PR TITLE
Liitetiedostolinkkeihin enemmän infoa

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -6553,7 +6553,7 @@ if (!function_exists('ebid')) {
     }
     else {
 
-      $query = "SELECT tunnus
+      $query = "SELECT tunnus, filename, selite
                 from liitetiedostot
                 where liitostunnus = '$laskurow[tunnus]'
                 and liitos         = 'lasku'
@@ -6572,7 +6572,14 @@ if (!function_exists('ebid')) {
           $out[] = $palvelin2."view.php?id=$row[tunnus]";
         }
         else {
-          $out .= "<a href='".$palvelin2."view.php?id=$row[tunnus]' target='Attachment'>". t('Näytä lasku') ."</a> ";
+          if ($laskurow['tila'] == 'X') {
+            $out .= "<div id='div_$row[tunnus]' class='popup'>$row[filename]<br>$row[selite]</div>
+                     <a class='tooltip' id='$row[tunnus]' href='".$palvelin2."view.php?id=$row[tunnus]' target='Attachment'>". t('Liite') .": $row[filename]</a>&nbsp;&nbsp;";
+          }
+          else {
+            $out .= "<div id='div_$row[tunnus]' class='popup'>$row[filename]<br>$row[selite]</div>
+                     <a class='tooltip' id='$row[tunnus]' href='".$palvelin2."view.php?id=$row[tunnus]' target='Attachment'>". t('Näytä lasku') ."</a>&nbsp;&nbsp;";
+          }
         }
       }
 

--- a/muutosite.php
+++ b/muutosite.php
@@ -64,6 +64,8 @@ if (isset($livesearch_tee) and $livesearch_tee == "TOIMITTAJAHAKU") {
 // ekotetaan javascriptiä jotta saadaan pdf:ät uuteen ikkunaan
 js_openFormInNewWindow();
 
+js_popup();
+
 echo "  <script language='javascript'>
 
       $(function() {

--- a/raportit.php
+++ b/raportit.php
@@ -57,7 +57,9 @@ if (substr($toim, -4) == '_OKP') {
 // Livesearch jutut
 enable_ajax();
 
-if (!isset($excel))      $excel = "";
+js_popup();
+
+if (!isset($excel)) $excel = "";
 if (!isset($livesearch_tee)) $livesearch_tee = "";
 
 if ($livesearch_tee == "TILIHAKU") {


### PR DESCRIPTION
Muistiotositteilla näytetään suoraan liitetiedostojen filenimet entinsen "Näytä lasku"-linkkitekstin sijaan. Laskuilla näytetään liitteen filenimi ja selite kun hiirulainen viedään "Näytä lasku"-linkin päälle.