### PR TITLE
IBM-spesifinen NAMEFMT 0 -komento pois

### DIFF
--- a/maksuaineisto_get.php
+++ b/maksuaineisto_get.php
@@ -63,8 +63,6 @@ if ($login_result === FALSE) {
   exit;
 }
 
-$quote = ftp_site($conn_id, "NAMEFMT 0");
-
 ftp_pasv($conn_id, true);
 
 $local_file = $pankkiaineiston_haku["local_dir"]."tiliote-".date("YmdHis").".dat";


### PR DESCRIPTION
* Ei tehdä IBM-spesifistä komentoa "NAMEFMT 0" ftp-palvelimelle turhaan