### PR TITLE
Korjauksia pankkiyhteyssertifikaatin hakuun Nordeasta

### DIFF
--- a/inc/pankkiyhteys_functions.inc
+++ b/inc/pankkiyhteys_functions.inc
@@ -976,6 +976,7 @@ function generoi_private_key_ja_csr($params = array()) {
   $company_name = empty($params['company_name']) ? $yhtiorow['nimi'] : $params['company_name'];
   $customer_id  = empty($params['customer_id']) ? '' : $params['customer_id'];
   $key_bits     = empty($params['key_bits']) ? 2048 : $params['key_bits'];
+  $email        = empty($params['email']) ? "" : $params['email'];
 
   $key_config = array(
     "digest_alg"       => "sha1",
@@ -987,9 +988,12 @@ function generoi_private_key_ja_csr($params = array()) {
     "countryName"      => $yhtiorow["maa"],
     "localityName"     => $yhtiorow["kotipaikka"],
     "organizationName" => $company_name,
-    "commonName"       => $company_name,
-    "emailAddress"     => $yhtiorow["email"]
+    "commonName"       => $company_name
   );
+
+  if (!empty($email)) {
+    $csr_info["emailAddress"] = $email;
+  }
 
   if (!empty($customer_id)) {
     $csr_info["serialNumber"] = $customer_id;

--- a/inc/pankkiyhteys_functions.inc
+++ b/inc/pankkiyhteys_functions.inc
@@ -974,11 +974,12 @@ function generoi_private_key_ja_csr($params = array()) {
   global $kukarow, $yhtiorow;
 
   $company_name = empty($params['company_name']) ? $yhtiorow['nimi'] : $params['company_name'];
-  $customer_id = empty($params['customer_id']) ? '' : $params['customer_id'];
+  $customer_id  = empty($params['customer_id']) ? '' : $params['customer_id'];
+  $key_bits     = empty($params['key_bits']) ? 2048 : $params['key_bits'];
 
   $key_config = array(
     "digest_alg"       => "sha1",
-    "private_key_bits" => 2048,
+    "private_key_bits" => $key_bits,
     "private_key_type" => OPENSSL_KEYTYPE_RSA
   );
 

--- a/pankkiyhteysadmin.php
+++ b/pankkiyhteysadmin.php
@@ -272,14 +272,17 @@ if ($tee == "luo" and $pin != '') {
   switch ($bank) {
   case "nordea":
     $key_bits = 1024;
+    $email    = "";
     break;
   default:
+    $email    = $yhtiorow["email"];
     $key_bits = 2048;
   }
 
   $csr_params = array(
     "company_name" => $company_name,
     "customer_id"  => $customer_id,
+    "email"        => $email,
     "key_bits"     => $key_bits
   );
 

--- a/pankkiyhteysadmin.php
+++ b/pankkiyhteysadmin.php
@@ -269,9 +269,18 @@ if ($tee == "luo") {
 
 // Haetaan sertifikaatti jos PIN on annettu
 if ($tee == "luo" and $pin != '') {
+  switch ($bank) {
+  case "nordea":
+    $key_bits = 1024;
+    break;
+  default:
+    $key_bits = 2048;
+  }
+
   $csr_params = array(
     "company_name" => $company_name,
-    "customer_id" => $customer_id
+    "customer_id"  => $customer_id,
+    "key_bits"     => $key_bits
   );
 
   // Generoidaan allekirjoitusta ja salausta varten private key ja certificate-signing-request


### PR DESCRIPTION
* Käytetään 1024-bittistä salausta Nordean avaimessa, koska Nordea vaatii niin
* Ei laiteta sähköpostiosoitetta Nordean certificate requestiin, sillä se luultavasti sekoittaa tunnistuksen