### PR TITLE
Ylläpitosopimuksen monistus

### DIFF
--- a/monistalasku.php
+++ b/monistalasku.php
@@ -1717,7 +1717,12 @@ if ($tee == 'MONISTA') {
             break;
           case 'kerayspvm':
           case 'laadittu':
-            $rvalues .= ", now()";
+            if ($toim == 'SOPIMUS') {
+              $rvalues .= ", '".$rivirow[$fieldname]."'";
+            }
+            else {
+              $rvalues .= ", now()";
+            }
             break;
           case 'tunnus':
           case 'laskutettu':


### PR DESCRIPTION
Ylläpitosopimuksen monistuksessa sopimusriveille laitetiin virheellisesti monistuspäivän leima, jolloin saattoi käydä niin että rivit eivät olleet synkassa sopimuksen voimassaoloaikojen kanssa. Nyt riveillä säilytetään monistaessa alkuperäisen ylläpitosopimuksen arvot.