### PR TITLE
Varastopaikkojen massamuutos: oletuspaikka

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -25364,25 +25364,10 @@ if (!function_exists('hyllysiirto')) {
       }
     }
 
-    # Jos kohdepaikasta tehd‰‰n oletuspaikka
-    # h‰lyrajat ja tilausm‰‰r‰t seuraavat mukana
-    if (!empty($kohdepaikasta_oletuspaikka)) {
-      $haly_tilausmaara_lisa  = "halytysraja = '{$mistarow['halytysraja']}',";
-      $haly_tilausmaara_lisa .= "tilausmaara = '{$mistarow['tilausmaara']}',";
-      $haly_tilausmaara_lisa .= "oletus = 'X',";
-
-      $mista_oletuspaikka_pois = "oletus = '',";
-    }
-    else {
-      $haly_tilausmaara_lisa = "";
-      $mista_oletuspaikka_pois = "";
-    }
-
     // Mist‰ varastosta otetaan?
     $query = "UPDATE tuotepaikat
               set saldo = saldo - {$kappaleet},
               {$lisavarlisa1}
-              {$mista_oletuspaikka_pois}
               saldoaika     = now(),
               muuttaja      = '{$kukarow['kuka']}',
               muutospvm     = now()
@@ -25395,7 +25380,6 @@ if (!function_exists('hyllysiirto')) {
     $query = "UPDATE tuotepaikat
               set saldo   = saldo + {$kappaleet},
               {$lisavarlisa2}
-              {$haly_tilausmaara_lisa}
               saldoaika     = now(),
               muuttaja      = '{$kukarow['kuka']}',
               muutospvm     = now()

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -25317,6 +25317,9 @@ if (!function_exists('hyllysiirto')) {
     if (!isset($params['poikkeavalaskutuspvm'])) $_poikkeavalaskutuspvm = '';
     else $_poikkeavalaskutuspvm = $params['poikkeavalaskutuspvm'];
 
+    if (!isset($params['kohdepaikasta_oletuspaikka'])) $kohdepaikasta_oletuspaikka = "";
+    else $kohdepaikasta_oletuspaikka = $params['kohdepaikasta_oletuspaikka'];
+
     if ($error) return false;
 
     if ($lisavaruste == "LISAVARUSTE") {
@@ -25361,10 +25364,25 @@ if (!function_exists('hyllysiirto')) {
       }
     }
 
+    # Jos kohdepaikasta tehd‰‰n oletuspaikka
+    # h‰lyrajat ja tilausm‰‰r‰t seuraavat mukana
+    if (!empty($kohdepaikasta_oletuspaikka)) {
+      $haly_tilausmaara_lisa  = "halytysraja = '{$mistarow['halytysraja']}',";
+      $haly_tilausmaara_lisa .= "tilausmaara = '{$mistarow['tilausmaara']}',";
+      $haly_tilausmaara_lisa .= "oletus = 'X',";
+
+      $mista_oletuspaikka_pois = "oletus = '',";
+    }
+    else {
+      $haly_tilausmaara_lisa = "";
+      $mista_oletuspaikka_pois = "";
+    }
+
     // Mist‰ varastosta otetaan?
     $query = "UPDATE tuotepaikat
               set saldo = saldo - {$kappaleet},
               {$lisavarlisa1}
+              {$mista_oletuspaikka_pois}
               saldoaika     = now(),
               muuttaja      = '{$kukarow['kuka']}',
               muutospvm     = now()
@@ -25377,6 +25395,7 @@ if (!function_exists('hyllysiirto')) {
     $query = "UPDATE tuotepaikat
               set saldo   = saldo + {$kappaleet},
               {$lisavarlisa2}
+              {$haly_tilausmaara_lisa}
               saldoaika     = now(),
               muuttaja      = '{$kukarow['kuka']}',
               muutospvm     = now()

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -572,6 +572,7 @@ if ($tee == 'N') {
   }
 
   if (!isset($_poikkeavalaskutuspvm)) $_poikkeavalaskutuspvm = "";
+  if (!isset($kohdepaikasta_oletuspaikka)) $kohdepaikasta_oletuspaikka = "";
 
   for ($iii=0; $iii< count($tuotteet); $iii++) {
 
@@ -587,6 +588,7 @@ if ($tee == 'N') {
       'selite' => !isset($selite) ? '' : $selite,
       'tun' => !isset($tun) ? 0 : $tun,
       'poikkeavalaskutuspvm' => $_poikkeavalaskutuspvm,
+      'kohdepaikasta_oletuspaikka' => $kohdepaikasta_oletuspaikka,
     );
 
     hyllysiirto($params);

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -310,6 +310,8 @@ if ($tee == 'MUUTA') {
   else {
     $tee = 'M';
   }
+
+  if ($kutsuja == "varastopaikka_aineistolla.php") $tee = 'MEGALOMAANINEN_ONNISTUMINEN';
 }
 
 // Siirret‰‰n saldo, jos se on viel‰ olemassa

--- a/varastopaikka_aineistolla.php
+++ b/varastopaikka_aineistolla.php
@@ -8,6 +8,9 @@ if (strpos($_SERVER['SCRIPT_NAME'], "varastopaikka_aineistolla.php")  !== FALSE)
 if (!isset($tee) or (isset($varasto_valinta) and $varasto_valinta == '')) $tee = "";
 if (!isset($virheviesti)) $virheviesti = "";
 
+if ($toim == "FOO" and !isset($kohdepaikasta_oletuspaikka)) $kohdepaikasta_oletuspaikka = 'selected';
+else $kohdepaikasta_oletuspaikka = '';
+
 if ($tee == "AJA") {
   $virhe = 0;
   $kaikki_tiedostorivit = array();
@@ -121,6 +124,23 @@ if ($tee == "AJA") {
 
         // Jos kohdetuotepaikkaa ei löydy, yritetään perustaa sellainen
         if (mysql_num_rows($kvresult) == 0) {
+
+          if ($yhtiorow['kerayserat'] == 'K') {
+            $ahyllyalue = strtoupper($ahyllyalue);
+            $ahyllynro = strtoupper($ahyllynro);
+            $ahyllyvali = strtoupper($ahyllyvali);
+            $ahyllytaso = strtoupper($ahyllytaso);
+
+            if (!tarkista_varaston_hyllypaikka($ahyllyalue, $ahyllynro, $ahyllyvali, $ahyllytaso)) {
+              echo "<font class='error'>";
+              echo t("VIRHE: Varastopaikkaa ei ole olemassa")."!";
+              echo " {$tuoteno} {$ahyllyalue}-{$ahyllynro}-{$ahyllyvali}-{$ahyllytaso}";
+              echo "</font><br>";
+              $virhe = 1;
+              continue;
+            }
+          }
+
           $tee         = "UUSIPAIKKA";
           $kutsuja      = "varastopaikka_aineistolla.php";
           $ahalytysraja = 0;
@@ -239,8 +259,24 @@ if ($tee == "") {
     echo "<option value='{$varasto['tunnus']}' $sel>{$varasto['nimitys']}</option>";
   }
 
-  echo "  </select></td><td class='back'><font class='error'>{$virheviesti}</font></td></tr>
-      </table>
+  echo "</select></td><td class='back'><font class='error'>{$virheviesti}</font></td></tr>";
+
+  if ($toim == "FOO") {
+
+    $sel = $kohdepaikasta_oletuspaikka ? "selected" : "";
+
+    echo "<tr>";
+    echo "<th>",t("Kohdepaikasta tehdään oletuspaikka"),"</th>";
+    echo "<td>";
+    echo "<select name='kohdepaikasta_oletuspaikka'>";
+    echo "<option value=''>",t("Ei"),"</option>";
+    echo "<option value='x' {$sel}>",t("Kyllä"),"</option>";
+    echo "</select>";
+    echo "</td>";
+    echo "</tr>";
+  }
+
+  echo "</table>
       <br><input type = 'submit' value = '".t("Hae")."'>
       </form>";
 }

--- a/varastopaikka_aineistolla.php
+++ b/varastopaikka_aineistolla.php
@@ -242,7 +242,6 @@ if ($tee == "AJA") {
           $tee = "MUUTA";
           $oletus = $minne;
 
-
           $qry = "SELECT *
                   FROM tuotepaikat use index (tuote_index)
                   WHERE tuoteno = '{$tuoteno}'
@@ -253,6 +252,10 @@ if ($tee == "AJA") {
 
           # Siirret‰‰n h‰lytysrajat
           $halyraja2[$minne] = $mista_chk_row['halytysraja'];
+          $tilausmaara2[$minne] = $mista_chk_row['tilausmaara'];
+
+          $kutsuja = "varastopaikka_aineistolla.php";
+          require "muuvarastopaikka.php";
         }
       }
 

--- a/varastopaikka_aineistolla.php
+++ b/varastopaikka_aineistolla.php
@@ -290,6 +290,9 @@ if ($tee == "AJA") {
 
           $kutsuja = "varastopaikka_aineistolla.php";
           require "muuvarastopaikka.php";
+          
+          unset($halyraja2);
+          unset($tilausmaara2);
         }
       }
 
@@ -382,7 +385,7 @@ if ($tee == 'VALITSE_TIEDOSTO' and $varasto_valinta != '') {
     $sel = $kohdepaikasta_oletuspaikka ? "selected" : "";
 
     echo "<tr>";
-    echo "<th>",t("Kohdepaikasta tehd‰‰n oletuspaikka"),"</th>";
+    echo "<th>",t("Kohdepaikasta tehd‰‰n oletuspaikka"),"<br>(",t("Siirret‰‰n samalla avoimet tilausrivit uudelle oletuspaikalle"),")</th>";
     echo "<td>";
     echo "<select name='kohdepaikasta_oletuspaikka'>";
     echo "<option value=''>",t("Ei"),"</option>";

--- a/varastopaikka_aineistolla.php
+++ b/varastopaikka_aineistolla.php
@@ -8,9 +8,16 @@ if (strpos($_SERVER['SCRIPT_NAME'], "varastopaikka_aineistolla.php")  !== FALSE)
 if (!isset($tee) or (isset($varasto_valinta) and $varasto_valinta == '')) $tee = "";
 if (!isset($virheviesti)) $virheviesti = "";
 
+if (!isset($toim)) {
+  $toim = "";
+}
+else {
+  $toim = strtolower($toim);
+}
+
 if ($tee == '' and !isset($varasto_valinta)) $varasto_valinta = $kukarow['oletus_varasto'];
 
-if ($toim == "FOO") {
+if ($toim == "oletuspaikka") {
   if (!isset($kohdepaikasta_oletuspaikka)) {
     $kohdepaikasta_oletuspaikka = 'selected';
   }
@@ -42,6 +49,9 @@ if ($tee == "AJA") {
       }
 
       $kaikki_tiedostorivit = array_filter($kaikki_tiedostorivit);
+
+      reset($kaikki_tiedostorivit);
+      unset($tiedr);
 
       # Etsit‰‰n tuoteperheit‰ joilla on runko-tuotteita
       foreach ($kaikki_tiedostorivit as $rowkey => $tiedr) {
@@ -135,7 +145,7 @@ if ($tee == "AJA") {
           continue;
         }
 
-        if ($toim == "FOO" and !empty($kohdepaikasta_oletuspaikka)) {
+        if ($toim == "oletuspaikka" and !empty($kohdepaikasta_oletuspaikka)) {
 
           if (empty($tvrow['oletus'])) {
             echo "<font class='error'>";
@@ -261,7 +271,7 @@ if ($tee == "AJA") {
         $kutsuja = "varastopaikka_aineistolla.php";
         require "muuvarastopaikka.php";
 
-        if ($tee == 'MEGALOMAANINEN_ONNISTUMINEN' and $toim == "FOO" and !empty($kohdepaikasta_oletuspaikka)) {
+        if ($tee == 'MEGALOMAANINEN_ONNISTUMINEN' and $toim == "oletuspaikka" and !empty($kohdepaikasta_oletuspaikka)) {
           # P‰ivitet‰‰n oletuspaikka
           $tee = "MUUTA";
           $oletus = $minne;
@@ -367,7 +377,7 @@ if ($tee == 'VALITSE_TIEDOSTO' and $varasto_valinta != '') {
       <input type='hidden' name='tee' value='AJA'>
       <table>";
 
-  if ($toim == "FOO") {
+  if ($toim == "oletuspaikka") {
 
     $sel = $kohdepaikasta_oletuspaikka ? "selected" : "";
 

--- a/varastopaikka_aineistolla.php
+++ b/varastopaikka_aineistolla.php
@@ -111,6 +111,35 @@ if ($tee == "AJA") {
           continue;
         }
 
+        if ($toim == "FOO" and !empty($kohdepaikasta_oletuspaikka)) {
+
+          if (empty($tvrow['oletus'])) {
+            echo "<font class='error'>";
+            echo t("Tuotteen %s lähdevarastopaikka %s %s %s %s ei ole oletuspaikka",
+                    "",
+                    $tuoteno,
+                    $lhyllyalue, $lhyllynro, $lhyllyvali, $lhyllytaso
+                  );
+            echo "!</font><br>";
+            $virhe = 1;
+            continue;
+          }
+
+          if ($lahdetsekki != $kohdetsekki) {
+            echo "<font class='error'>";
+            echo t("Tuotteen %s lähdevarastopaikka %s %s %s %s ja
+                    kohdevarastopaikka %s %s %s %s ei sijaitse samassa varastossa",
+                    "",
+                    $tuoteno,
+                    $lhyllyalue, $lhyllynro, $lhyllyvali, $lhyllytaso,
+                    $ahyllyalue, $ahyllynro, $ahyllyvali, $ahyllytaso
+                  );
+            echo "!</font><br>";
+            $virhe = 1;
+            continue;
+          }
+        }
+
         // Onko kohdetuotepaikka olemassa
         $query_ktp = "SELECT *
                       FROM tuotepaikat use index (tuote_index)

--- a/varastopaikka_aineistolla.php
+++ b/varastopaikka_aineistolla.php
@@ -236,6 +236,24 @@ if ($tee == "AJA") {
         $tee = "N";
         $kutsuja = "varastopaikka_aineistolla.php";
         require "muuvarastopaikka.php";
+
+        if ($toim == "FOO" and !empty($kohdepaikasta_oletuspaikka)) {
+          # P‰ivitet‰‰n oletuspaikka
+          $tee = "MUUTA";
+          $oletus = $minne;
+
+
+          $qry = "SELECT *
+                  FROM tuotepaikat use index (tuote_index)
+                  WHERE tuoteno = '{$tuoteno}'
+                  AND yhtio     = '{$kukarow['yhtio']}'
+                  AND tunnus    = '$mista'";
+          $mista_chk_res = pupe_query($qry);
+          $mista_chk_row = mysql_fetch_assoc($mista_chk_res);
+
+          # Siirret‰‰n h‰lytysrajat
+          $halyraja2[$minne] = $mista_chk_row['halytysraja'];
+        }
       }
 
       // Merkataan viel‰ l‰hdevarastopaikka poistettavaksi jos se ei ole oletuspaikka


### PR DESCRIPTION
Kun käytetään ohjelmassa alanimeä "oletuspaikka", niin näytetään käyttäjälle vaihtoehto jonka avulla oletuspaikan voi siirtää lähdepaikasta kohdepaikalle.

* Oletuspaikka-optiota käytettäessä lähdepaikan pitää olla entinen oletuspaikka, tai muuten ei tehdä koko aineistolle mitään
* Hälytysrajojen ja tilausmäärien siirto tuotepaikalla seuraa oletuspaikan vaihdossa mukana
* Tarkistetaan että ei ole mahdollista siirtää oletuspaikkaa mikäli se ei ole saman varaston sisällä
* Oletuspaikan mukana siirretään myynnit, ostot, siirrot yms. vanhalta oletuspaikalta uudelle
* Lisätty tuki rungoille (ohita keräys tuoteperhe). Siirtyy isätuotteen mukana samoilla ehdoilla.

Lisätty tarkistus jos käytetään "varaston hyllypaikka" -ominaisuutta. Tällöin kohdepaikka täytyy olla olemassa "varaston hyllypaikat"-taulussa. 