### PR TITLE
Siirtolistojen jt-rivien vapauttaminen tuloutuksen yhteydessä

### DIFF
--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -403,6 +403,8 @@ if (!function_exists("tee_jt_tilaus")) {
             $fieldname == 'maksettu' or
             $fieldname == 'maa_maara' or
             $fieldname == 'kuljetusmuoto' or
+            $fieldname == 'vakisin_kerays' or
+            $fieldname == 'siirtolistan_vastaanotto' or
             $fieldname == 'kauppatapahtuman_luonne' or
             $fieldname == 'sisamaan_kuljetus' or
             $fieldname == 'sisamaan_kuljetusmuoto' or

--- a/tilauskasittely/tilaus-valmis-siirtolista.inc
+++ b/tilauskasittely/tilaus-valmis-siirtolista.inc
@@ -446,6 +446,9 @@ else {
         $tilauksia++;
       }
     }
+    else  {
+      $splitatut = NULL;
+    }
 
     // tyhjennetään muuttujat
     $varasto   = '';


### PR DESCRIPTION
Kun siirtolistoja vapautui useampi automaattisesti tuloutuksen yhteydessä, vain ensimmäiselle päivitettiin toimitustavan lähtö.

Tämä korjattu niin, että lähtö päivittyy kaikille siirtolistoille