### PR TITLE
Myynninseurantaraportti: excelkorjaus

### DIFF
--- a/raportit/myyntiseuranta.php
+++ b/raportit/myyntiseuranta.php
@@ -3489,7 +3489,7 @@ else {
 
               if ($rivimaara <= $rivilimitti) echo "<td class='tumma' align='right'>{$vsum}</td>";
 
-              if (isset($worksheet)) {
+              if (isset($worksheet) and $vnim != "asiakkaittain" and $vnim != "tuotteittain") {
                 $worksheet->writeNumber($excelrivi, $excelsarake++, $vsum);
               }
             }
@@ -3544,7 +3544,7 @@ else {
 
             if ($rivimaara <= $rivilimitti) echo "<td class='tumma' align='right'>{$vsum}</td>";
 
-            if (isset($worksheet)) {
+            if (isset($worksheet) and $vnim != "asiakkaittain" and $vnim != "tuotteittain") {
               $worksheet->writeNumber($excelrivi, $excelsarake++, $vsum);
             }
           }

--- a/raportit/myyntiseuranta.php
+++ b/raportit/myyntiseuranta.php
@@ -2855,7 +2855,7 @@ else {
 
                   if ($rivimaara <= $rivilimitti) echo "<td class='tumma' align='right'>{$vsum}</td>";
 
-                  if (isset($worksheet)) {
+                  if (isset($worksheet) and $vnim != "asiakkaittain" and $vnim != "tuotteittain") {
                     $worksheet->writeNumber($excelrivi, $excelsarake++, $vsum);
                   }
                 }


### PR DESCRIPTION
Otettaessa myynninseurantaraportti asiakasosastoittain tai tuoteosastoittain siirtyivät excelissä välisumma ja loppusumma sarakkeet pykälän tai kaksi liian oikealle valituista hakuehdoista riippuen. Nyt tämä oikealle siirtyminen on korjattu ja välisumma ja loppusumma tiedot tulevat oikeaan sarakkeeseen.