### PR TITLE
Varastopaikkojen muutos aineistolla fix

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -22012,7 +22012,7 @@ if (!function_exists('paivita_oletuspaikka')) {
       elseif ($yhtiorow['paivita_oletuspaikka'] == 'M') {
         $wherelisa = "";
         $joinlisa = "JOIN lasku ON (lasku.yhtio = t.yhtio AND lasku.tunnus = t.otunnus AND lasku.tila IN ('N','O') and lasku.alatila != 'X')";
-        $tyyppilisa = "AND t.tyyppi IN ('O','L','G')";
+        $tyyppilisa = "AND t.tyyppi IN ('O','L')";
       }
       else {
         $wherelisa = "AND t.uusiotunnus = '0'";
@@ -22042,6 +22042,25 @@ if (!function_exists('paivita_oletuspaikka')) {
       $return["paivitetyt_ostorivit"] = mysql_affected_rows();
 
       if ($yhtiorow['paivita_oletuspaikka'] == 'M') {
+
+        // P‰ivitet‰‰n siirtorivien l‰hdepaikka
+        $query = "UPDATE tilausrivi AS t
+                  JOIN lasku ON (lasku.yhtio = t.yhtio AND lasku.tunnus = t.otunnus AND lasku.tila = 'G' and lasku.alatila not in ('V','D','X'))
+                  SET t.hyllyalue  = '{$hylly['hyllyalue']}',
+                  t.hyllynro       = '{$hylly['hyllynro']}',
+                  t.hyllyvali      = '{$hylly['hyllyvali']}',
+                  t.hyllytaso      = '{$hylly['hyllytaso']}'
+                  WHERE t.yhtio    = '{$kukarow['yhtio']}'
+                  AND t.tuoteno    = '{$tuoteno}'
+                  AND t.hyllyalue  = '{$oletusrow['hyllyalue']}'
+                  AND t.hyllynro   = '{$oletusrow['hyllynro']}'
+                  AND t.hyllytaso  = '{$oletusrow['hyllytaso']}'
+                  AND t.hyllyvali  = '{$oletusrow['hyllyvali']}'
+                  AND t.tyyppi     = 'G'
+                  AND t.kpl        = '0'
+                  AND t.varattu   != '0'";
+        $result = pupe_query($query);
+
         // P‰ivitet‰‰n siirtorivien kohdepaikka
         $query = "UPDATE tilausrivin_lisatiedot AS tt
                   JOIN tilausrivi AS t ON (t.yhtio = tt.yhtio AND

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -510,7 +510,7 @@ if ($tee == 'N') {
         $myytavissa += $kappaleet[$iii];
       }
 
-      if ($kappaleet[$iii] > $myytavissa and $kutsuja != "vastaanota.php") {
+      if ($kappaleet[$iii] > $myytavissa and !in_array($kutsuja, array('varastopaikka_aineistolla.php', 'vastaanota.php'))) {
         echo "Tuotetta ei voida siirt‰‰. Saldo ei riitt‰nyt. $tuotteet[$iii] $kappaleet[$iii] ($mistarow[hyllyalue] $mistarow[hyllynro] $mistarow[hyllyvali] $mistarow[hyllytaso])<br>";
         $saldook++;
       }

--- a/varastopaikka_aineistolla.php
+++ b/varastopaikka_aineistolla.php
@@ -122,6 +122,9 @@ if ($tee == "AJA") {
           list($saldo, $hyllyssa, $myytavissa) = saldo_myytavissa($tuoteno, '', $varasto_valinta, '', $lhyllyalue, $lhyllynro, $lhyllyvali, $lhyllytaso);
 
           if ($kpl == "X" or $kpl > $myytavissa) $tiedr[1] = $myytavissa;
+          if ($yhtiorow['paivita_oletuspaikka'] == 'M' and ($kpl == "X" or $kpl > $saldo)) {
+            $tiedr[1] = $saldo;
+          }
         }
 
         // Tarkistetaan onko annettu lähdevarastopaikka valitussa varastossa
@@ -290,7 +293,7 @@ if ($tee == "AJA") {
 
           $kutsuja = "varastopaikka_aineistolla.php";
           require "muuvarastopaikka.php";
-          
+
           unset($halyraja2);
           unset($tilausmaara2);
         }


### PR DESCRIPTION
Korjattiin tilanne, missä yhtiön parametri paivita_oletuspaikka oli arvossa "Päivitetään uusi oletuspaikka avoimille ja saapumisiin liitetyille ostoriveille, myyntiriveille ja siirtoriveille". Aiemmin kävi niin, että esim keskeneräinen myyntirivi päivitettiin uudelle oletuspaikalle, mutta sen varaama saldo jäi vanhalle paikalle. 

Jatkossa koko saldo siirretään uudelle oletuspaikalle tuon parametrin option ollessa käytössä.