### PR TITLE
Myyntitilaus: toimitustapa otsikko korjaus

### DIFF
--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -1,5 +1,9 @@
 <?php
 
+function pupe_strtoupper(&$item, $key) {
+  $item = strtoupper($item);
+}
+
 $DAY_ARRAY = array(1 => t("Ma"), t("Ti"), t("Ke"), t("To"), t("Pe"), t("La"), t("Su"));
 
 if (php_sapi_name() != 'cli' and (!isset($ei_kayttoliittymaa) or $ei_kayttoliittymaa != "kylla")) {
@@ -316,7 +320,8 @@ if (isset($jatka) and $asiakasid != "") {
       );
       $toimitustavat = hae_toimitustavat($params);
       $toimitustavat_selitteet = array_column($toimitustavat, 'selite');
-      if (!in_array($toimitustapa, $toimitustavat_selitteet)) {
+      array_walk($toimitustavat_selitteet, "pupe_strtoupper");
+      if (!in_array(strtoupper($toimitustapa), $toimitustavat_selitteet)) {
         echo "<font class='error'>".t("VIRHE: Varaston toimipaikalla ei ole valittua toimitustapaa")."!</font><br>";
         $tee = "OTSIK";
         $tila = "";

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -1,7 +1,9 @@
 <?php
 
-function pupe_strtoupper(&$item, $key) {
-  $item = strtoupper($item);
+if (!function_exists("pupe_strtoupper")) {
+  function pupe_strtoupper(&$item, $key) {
+    $item = strtoupper($item);
+  }
 }
 
 $DAY_ARRAY = array(1 => t("Ma"), t("Ti"), t("Ke"), t("To"), t("Pe"), t("La"), t("Su"));
@@ -320,7 +322,9 @@ if (isset($jatka) and $asiakasid != "") {
       );
       $toimitustavat = hae_toimitustavat($params);
       $toimitustavat_selitteet = array_column($toimitustavat, 'selite');
+
       array_walk($toimitustavat_selitteet, "pupe_strtoupper");
+
       if (!in_array(strtoupper($toimitustapa), $toimitustavat_selitteet)) {
         echo "<font class='error'>".t("VIRHE: Varaston toimipaikalla ei ole valittua toimitustapaa")."!</font><br>";
         $tee = "OTSIK";


### PR DESCRIPTION
Myyntitilauksen otsikolla oli ongelma käytettävien toimitustapojen vertailun kanssa mistä johtuen tuli virheellinen virheilmoitus: "VIRHE: Varaston toimipaikalla ei ole valittua toimitustapaa". Vertailu on nyt korjattu ja virheellistä virheilmoitusta ei tule.