### PR TITLE
Extranetkäyttäjän päivittäminen

### DIFF
--- a/kayttajat.php
+++ b/kayttajat.php
@@ -512,6 +512,10 @@ else {
 $result = pupe_query($query);
 $selkukarow = mysql_fetch_assoc($result);
 
+if (mysql_num_rows($result) > 0) {
+  $selkuka = $selkukarow["tunnus"];
+}
+
 //muutetaan kayttajan tietoja tai syotetaan uuden kayttajan tiedot
 if ($tee == 'MUUTA') {
 
@@ -623,6 +627,7 @@ if ($tee == 'MUUTA') {
     $query = "SELECT nimi, kuka, tunnus
               FROM kuka
               WHERE tunnus = '{$selkuka}'";
+
     $result = pupe_query($query);
     $selkukarow = mysql_fetch_assoc($result);
 

--- a/kayttajat.php
+++ b/kayttajat.php
@@ -627,7 +627,6 @@ if ($tee == 'MUUTA') {
     $query = "SELECT nimi, kuka, tunnus
               FROM kuka
               WHERE tunnus = '{$selkuka}'";
-
     $result = pupe_query($query);
     $selkukarow = mysql_fetch_assoc($result);
 


### PR DESCRIPTION
Extranet käyttäjän päivittämisessä, jos haki extranet käyttäjän suoraan käyttäjätunnuksella ei extranet käyttäjän ulkoisia tunnuksia pystynyt tällöin päivittämään. Tämä tilanne on nyt korjattu ja jatkossa extranet käyttäjän saa päivitettyä myös silloin, kun käyttäjän on hakenut suoraan extranet käyttäjän tunnuksella.