### PR TITLE
Hae ja selaa: Takaisin tilaukselle-nappi

### DIFF
--- a/tilauskasittely/tuote_selaus_haku.php
+++ b/tilauskasittely/tuote_selaus_haku.php
@@ -379,7 +379,7 @@ if ($verkkokauppa == "") {
         <input type='hidden' name='aktivoinnista' value='true'>
         <input type='hidden' name='tee' value='AKTIVOI'>
         <input type='hidden' name='tilausnumero' value='$kukarow[kesken]'>
-        <input type='submit' value='".t("347 Takaisin tilaukselle")."'>
+        <input type='submit' value='".t("Takaisin tilaukselle")."'>
         </form><br><br>";
   }
   elseif ($kukarow["kuka"] != "" and $laskurow["tila"] != "" and $laskurow["tila"] != "K" and $toim_kutsu != "" and $toim_kutsu != "EXTENNAKKO") {
@@ -402,7 +402,7 @@ if ($verkkokauppa == "") {
         <input type='hidden' name='toim' value='$toim_kutsu'>
         <input type='hidden' name='tilausnumero' value='$kukarow[kesken]'>
         <input type='hidden' name='tyojono' value='$tyojono'>
-        <input type='submit' value='".t("371 Takaisin tilaukselle")."'>
+        <input type='submit' value='".t("Takaisin tilaukselle")."'>
         </form><br><br>";
   }
   elseif ($toim_kutsu == "EXTENNAKKO" and $kukarow["extranet"] != "") {
@@ -412,7 +412,7 @@ if ($verkkokauppa == "") {
         <input type='hidden' name='tilausnumero' value='$tilausnumero'>
         <input type='hidden' name='valittu_tarjous_tunnus' value='$valittu_tarjous_tunnus'>
         <input type='hidden' name='action' value='nayta_tarjous'>
-        <input type='submit' value='".t("381 Takaisin tilaukselle")."'>
+        <input type='submit' value='".t("Takaisin tilaukselle")."'>
         </form><br><br>";
   }
 }

--- a/tilauskasittely/tuote_selaus_haku.php
+++ b/tilauskasittely/tuote_selaus_haku.php
@@ -187,6 +187,15 @@ if (isset($vierow)) {
   elseif ($vierow["tila"] == "A") {
     $toim_kutsu = "TYOMAARAYS";
   }
+  elseif ($vierow["tila"] == "R") {
+    $toim_kutsu = "PROJEKTI";
+  }
+  elseif ($vierow["tila"] == "S") {
+    $toim_kutsu = "SIIRTOTYOMAARAYS";
+  }
+  elseif ($vierow["tilaustyyppi"] == "0") {
+    $toim_kutsu = "YLLAPITO";
+  }
 }
 
 if (isset($vierow) and $vierow["maa"] != "") {


### PR DESCRIPTION
Jos käyttäjä oli poistunut esimerkiksi varastosiirrolta niin, että kyseinen varastosiirto oli jäänyt hänelle "kesken" tilaan ja käyttäjän meni normaalin hae ja selaa ohjelmaan niin tällöin kun käyttäjä painoi "takaisin tilaukselle" nappia palautti Pupe käyttäjän myyntitilaukselle. Myyntitilauksen tunnus oli sama kuin varastosiirron, mutta varastosiirron rivejä ei ollut nähtävissä. Tässä vaiheessa käyttäjä pystyi vaihtamaan tilaukselle asiakkaan ja samalla muuttamaan varastosiirrosta myyntitilauksen. Tämä johti ongelmatilanteeseen, jossa aiemmin varastosiirrolle lisätyt rivit jäivät jumiin varaamaan saldoa.