### PR TITLE
Varastosiirto: asiakasvaihtonappi

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -3297,7 +3297,7 @@ if ($tee == '') {
 
       echo "<td>";
       echo "<span id='hae_asiakasta_spani'>";
-#echo "3300 "; var_dump($laskurow); echo "<br><br>";
+
       if ($kukarow["extranet"] == "" and $laskurow["tila"] != "G" and $laskurow["tila"] != "S") {
         echo "<a href='{$palvelin2}crm/asiakasmemo.php?ytunnus={$laskurow['ytunnus']}&asiakasid={$laskurow['liitostunnus']}&from={$toim}&lopetus={$tilmyy_lopetus}//from=LASKUTATILAUS'>{$laskurow['nimi']}</a>";
         echo " <a id='hae_asiakasta_linkki'>";
@@ -6388,7 +6388,7 @@ if ($tee == '') {
       if ($oikeus_nahda_kate and $kukarow["extranet"] == "") {
         $kate_sel["K"] = (!isset($naytetaan_kate) or $naytetaan_kate == "K") ? " checked" : "";
         $kate_sel["E"] = $naytetaan_kate == "E" ? " checked" : "";
-        
+
         echo t("Tilausrivin kate").":<br>";
         echo "<form method='post'>
                 <input type='hidden' name='tilausnumero' value='$tilausnumero'>

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -3297,8 +3297,8 @@ if ($tee == '') {
 
       echo "<td>";
       echo "<span id='hae_asiakasta_spani'>";
-
-      if ($kukarow["extranet"] == "") {
+#echo "3300 "; var_dump($laskurow); echo "<br><br>";
+      if ($kukarow["extranet"] == "" and $laskurow["tila"] != "G" and $laskurow["tila"] != "S") {
         echo "<a href='{$palvelin2}crm/asiakasmemo.php?ytunnus={$laskurow['ytunnus']}&asiakasid={$laskurow['liitostunnus']}&from={$toim}&lopetus={$tilmyy_lopetus}//from=LASKUTATILAUS'>{$laskurow['nimi']}</a>";
         echo " <a id='hae_asiakasta_linkki'>";
 


### PR DESCRIPTION
Varastosiirrolla jos meni painamaan vaihda asiakasta nappia pääsi vaihtamaan varastosiirrolle oikean asiakkaan (varaston tilalle) - samalle tuli muuttaneeksi varastosiirrosta normaalin myyntitilauksen. Tämä sama ongelma oli myös sisäisillä työmääräyksillä, johon oli mahdollista liittää asiakas vaihda asiakasta toiminnolla ja muutta sisäinen työmääräys normaaliksi myyntitilaukseksi. Tämä ongelma on nyt kuitenkin korjattu.