### PR TITLE
Sisäänlue dataa: asiakashinnat ja -alennukset

### DIFF
--- a/inc/asiakasalennustarkista.inc
+++ b/inc/asiakasalennustarkista.inc
@@ -165,21 +165,6 @@ if (!function_exists("asiakasalennustarkista")) {
       }
     }
 
-    if (mysql_field_name($result, $i) == 'piiri') {
-
-      $rajlask = 0;
-
-      if ($chasiakas_ryhma != '') $rajlask++;
-      if ($chytunnus != '') $rajlask++;
-      if ($chpiiri != '') $rajlask++;
-      if ($chsegmentti > 0) $rajlask++;
-      if ($chastunn > 0) $rajlask++;
-
-      if ($rajlask > 1 or $rajlask == 0) {
-        $virhe[$i] = t("Valitse vain asiakas, ytunnus, asiakasryhmä, asiakassegmentti tai piiri!");
-      }
-    }
-
     if ($chryhma == '' and $chtuoteno == '' and mysql_field_name($result, $i) == 'ryhma') {
       $virhe[$i] = t("Sinun on annettava joko tuote tai ryhmä!");
     }
@@ -245,6 +230,18 @@ if (!function_exists("asiakasalennustarkista")) {
 
     // Ei tsekata turhaan kun rivi dellataan luedatasta
     if (($chasiakas_ryhma != '' or $chytunnus != '' or $chpiiri != '' or $chsegmentti != '' or $chastunn != '') and ($chryhma != '' or $chtuoteno != '') and mysql_field_name($result, $i) == 'tunnus' and (!isset($trow["luedata_toiminto"]) or $trow["luedata_toiminto"] != "POISTA")) {
+
+      $rajlask = 0;
+
+      if ($chasiakas_ryhma != '') $rajlask++;
+      if ($chytunnus != '') $rajlask++;
+      if ($chpiiri != '') $rajlask++;
+      if ($chsegmentti > 0) $rajlask++;
+      if ($chastunn > 0) $rajlask++;
+
+      if ($rajlask > 1 or $rajlask == 0) {
+        $virhe[$i] = t("Valitse vain asiakas, ytunnus, asiakasryhmä, asiakassegmentti tai piiri!");
+      }
 
       $and = '';
 

--- a/inc/asiakashintatarkista.inc
+++ b/inc/asiakashintatarkista.inc
@@ -163,21 +163,6 @@ if (!function_exists("asiakashintatarkista")) {
       }
     }
 
-    if (mysql_field_name($result, $i) == 'piiri') {
-
-      $rajlask = 0;
-
-      if ($chasiakas_ryhma != '') $rajlask++;
-      if ($chytunnus != '') $rajlask++;
-      if ($chpiiri != '') $rajlask++;
-      if ($chsegmentti > 0) $rajlask++;
-      if ($chastunn > 0) $rajlask++;
-
-      if ($rajlask > 1 or $rajlask == 0) {
-        $virhe[$i] = t("Valitse vain asiakas, ytunnus, asiakasryhmä, asiakassegmentti tai piiri!");
-      }
-    }
-
     if ($chryhma == '' and $chtuoteno == '' and mysql_field_name($result, $i) == 'ryhma') {
       $virhe[$i] = t("Sinun on annettava joko tuote tai ryhmä!");
     }
@@ -231,6 +216,18 @@ if (!function_exists("asiakashintatarkista")) {
     }
 
     if (($chasiakas_ryhma != '' or $chytunnus != '' or $chpiiri != '' or $chsegmentti != '' or $chastunn != '') and ($chryhma != '' or $chtuoteno != '') and mysql_field_name($result, $i) == 'tunnus' and (!isset($trow["luedata_toiminto"]) or $trow["luedata_toiminto"] != "POISTA")) {
+
+      $rajlask = 0;
+
+      if ($chasiakas_ryhma != '') $rajlask++;
+      if ($chytunnus != '') $rajlask++;
+      if ($chpiiri != '') $rajlask++;
+      if ($chsegmentti > 0) $rajlask++;
+      if ($chastunn > 0) $rajlask++;
+
+      if ($rajlask > 1 or $rajlask == 0) {
+        $virhe[$i] = t("Valitse vain asiakas, ytunnus, asiakasryhmä, asiakassegmentti tai piiri!");
+      }
 
       $and = '';
 


### PR DESCRIPTION
Asiakashinnoilla ja asiakasalennuksilla kuuluu olla vai yksi asiakkaan tunniste eli vain joko asiakasnumero//asiakastunnus, ytunnus, asiakasryhmä, asiakassegmentti tai piiri. Nyt on pystynyt sisäälue dataa ohjelmalla lukemaan Pupeen sisään sellaisia asiakashintoja ja asiakasalennuksia, joilla on ollut useampia asiakkaan tunnisteita kuin yksi. Tämä on nyt korjattu ja jatkossa näin ei enää pääse tekemään.