### PR TITLE
Ostolasku: kulujen syöttö

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -29414,13 +29414,13 @@ if (!function_exists('osatoimitus')) {
       $_osatoimitus_myyntitilaus = (
         $_yhtiorow['myyntitilaus_osatoimitus'] == 'E'
         and $kukarow["kesken"] == 0
-        and in_array($toim, array("RIVISYOTTO", "PIKATILAUS"))
+        and in_array($toim, array("RIVISYOTTO", "PIKATILAUS", "TYOMAARAYS"))
       );
     }
     else {
       $_osatoimitus_myyntitilaus = (
         $_yhtiorow['myyntitilaus_osatoimitus'] == 'E'
-        and in_array($toim, array("RIVISYOTTO", "PIKATILAUS"))
+        and in_array($toim, array("RIVISYOTTO", "PIKATILAUS", "TYOMAARAYS"))
       );
     }
 

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -29414,13 +29414,13 @@ if (!function_exists('osatoimitus')) {
       $_osatoimitus_myyntitilaus = (
         $_yhtiorow['myyntitilaus_osatoimitus'] == 'E'
         and $kukarow["kesken"] == 0
-        and in_array($toim, array("RIVISYOTTO", "PIKATILAUS", "TYOMAARAYS"))
+        and in_array($toim, array("RIVISYOTTO", "PIKATILAUS"))
       );
     }
     else {
       $_osatoimitus_myyntitilaus = (
         $_yhtiorow['myyntitilaus_osatoimitus'] == 'E'
-        and in_array($toim, array("RIVISYOTTO", "PIKATILAUS", "TYOMAARAYS"))
+        and in_array($toim, array("RIVISYOTTO", "PIKATILAUS"))
       );
     }
 

--- a/inc/muutosite.inc
+++ b/inc/muutosite.inc
@@ -1454,9 +1454,20 @@ if ($tila == 'ostolasku_kulut') {
     $tila = '';
   }
 
-  $osto_rahti    = str_replace(",", ".", trim($osto_rahti));
-  $osto_kulu    = str_replace(",", ".", trim($osto_kulu));
-  $osto_rivi_kulu    = str_replace(",", ".", trim($osto_rivi_kulu));
+  // Tehdään pistemuutos vaan, jos on setattu
+  // koska muuten setataan kyseiset muuttujan tyhjiksi
+  // ja sit failataan myöhemmin muuten.
+  if (isset($osto_rahti)) {
+    $osto_rahti = str_replace(",", ".", trim($osto_rahti));
+  }
+
+  if (isset($osto_kulu)) {
+    $osto_kulu = str_replace(",", ".", trim($osto_kulu));
+  }
+
+  if (isset($osto_rivi_kulu)) {
+    $osto_rivi_kulu = str_replace(",", ".", trim($osto_rivi_kulu));
+  }
 
   if (isset($osto_rahti) and ((trim($osto_rahti) != '' and !is_numeric($osto_rahti)) or trim($osto_rahti) == '')) {
     echo "<font class='error'>", t("Vaihto-omaisuuslaskun rahtikulu ei ole numeerinen"), " {$osto_rahti}</font><br>";


### PR DESCRIPTION
Vaihto-omaisuuslaskun tietojen syötössä, jos on käytössä vain osa mahdollisista ostolaskulle syötettävistä kuluista; rahti, kulut ja rivikohtaiset kulu antoi Pupe virheellisen virheilmoituksen, jos näitä kuluja ostolaskulle yritti syöttää. Tämä on nyt kuitenkin korjattu.