### PR TITLE
Kulujen erottaminen saapumisen laskuilta

### DIFF
--- a/inc/muutosite.inc
+++ b/inc/muutosite.inc
@@ -1803,18 +1803,19 @@ if ($tila == 'ostolasku_kulut') {
         $alv_tili = $yhtiorow["alv"];
       }  
       
-      $query = "SELECT tapvm, sum(summa) summa
+      $query = "SELECT substring(laadittu, 1, 10), sum(summa) summa
                 from tiliointi
                 where yhtio = '{$kukarow['yhtio']}'
                 and ltunnus = '{$tunnus}'
                 and tilino = '{$alv_tili}'
                 and korjattu != ''
                 group by 1
-                order by 1 desc";
+                order by 1 asc";
+echo "1814: $query <br><br>";
       $old_alv_chk_res = pupe_query($query);
       $old_alv_chk_row = mysql_fetch_assoc($old_alv_chk_res);
       
-      $query = "SELECT sum(summa) summa
+      $query = "SELECT sum(summa) summa, group_concat(tunnus) tunnukset
                 from tiliointi
                 where yhtio = '{$kukarow['yhtio']}'
                 and ltunnus = '{$tunnus}'
@@ -1822,31 +1823,44 @@ if ($tila == 'ostolasku_kulut') {
                 and korjattu = ''";
       $new_alv_chk_res = pupe_query($query);
       $new_alv_chk_row = mysql_fetch_assoc($new_alv_chk_res);
-      
+echo "1825: $alv_tili, $old_alv_chk_row[summa], $new_alv_chk_row[summa], $satu1, $satu2 <br><br>";      
       if (mysql_num_rows($old_alv_chk_res) > 0 and mysql_num_rows($new_alv_chk_res) > 0) {
 
-        $old_alv = (int) $old_alv_chk_row['summa'] * 10000;
-        $new_alv = (int) $new_alv_chk_row['summa'] * 10000;
-      
+        $old_alv = (int) ($old_alv_chk_row['summa'] * 10000);
+        $new_alv = (int) ($new_alv_chk_row['summa'] * 10000);
+echo "1828: $alv_tili, $old_alv_chk_row[summa], $new_alv_chk_row[summa], $old_alv, $new_alv <br><br>";      
         if ($old_alv != $new_alv) {
           $alvin_ero = $old_alv_chk_row['summa'] - $new_alv_chk_row['summa'];
-          $kulu_tili = $yhtiorow[key($laskun_kulut)];
           
           $query = "SELECT *
                     from tiliointi
                     where yhtio = '{$kukarow['yhtio']}'
                     and ltunnus = '{$tunnus}'
-                    and tilino = '{$kulu_tili}'
+                    and tilino IN ('{$yhtiorow['osto_rahti']}', '{$yhtiorow['osto_kulu']}', '{$yhtiorow['osto_rivi_kulu']}')
                     and korjattu = ''";
+echo "1842: $query <br><br>";
           $kulu_chk_res = pupe_query($query);
           $kulu_chk_row = mysql_fetch_assoc($kulu_chk_res);
           
-          $kulu_chk_row['summa'] += $alvin_ero;
+          $kulu_chk_row['summa'] -= $alvin_ero;
           
           $query = "UPDATE tiliointi SET
                     summa = '{$kulu_chk_row['summa']}'
                     where yhtio = '{$kukarow['yhtio']}'
                     and tunnus = '{$kulu_chk_row['tunnus']}'";
+echo "1852: $query <br><br>";
+          $upd_kulut = pupe_query($query);
+
+          list($_tunnus, ) = explode(',', $new_alv_chk_row['tunnukset']);
+
+          $query = "UPDATE tiliointi SET
+                    summa = summa + $alvin_ero
+                    where yhtio = '{$kukarow['yhtio']}'
+                    and ltunnus = '{$tunnus}'
+                    and tilino  = '{$alv_tili}'
+                    and korjattu = ''
+                    and tunnus = '{$_tunnus}'";
+echo "1852: $query <br><br>";
           $upd_kulut = pupe_query($query);
         }
       }      

--- a/inc/muutosite.inc
+++ b/inc/muutosite.inc
@@ -1857,7 +1857,6 @@ if ($tila == 'ostolasku_kulut') {
                     and tilino  = '{$alv_tili}'
                     and korjattu = ''
                     and tunnus = '{$_tunnus}'";
-echo "1852: $query <br><br>";
           $upd_kulut = pupe_query($query);
         }
       }      

--- a/inc/muutosite.inc
+++ b/inc/muutosite.inc
@@ -1796,6 +1796,61 @@ if ($tila == 'ostolasku_kulut') {
 
       require "inc/teetiliointi.inc";
     }
+
+    if (count($laskun_kulut)) {
+      
+      if (!isset($alv_tili) or $alv_tili == "" or !is_numeric($alv_tili)) {
+        $alv_tili = $yhtiorow["alv"];
+      }  
+      
+      $query = "SELECT tapvm, sum(summa) summa
+                from tiliointi
+                where yhtio = '{$kukarow['yhtio']}'
+                and ltunnus = '{$tunnus}'
+                and tilino = '{$alv_tili}'
+                and korjattu != ''
+                group by 1
+                order by 1 desc";
+      $old_alv_chk_res = pupe_query($query);
+      $old_alv_chk_row = mysql_fetch_assoc($old_alv_chk_res);
+      
+      $query = "SELECT sum(summa) summa
+                from tiliointi
+                where yhtio = '{$kukarow['yhtio']}'
+                and ltunnus = '{$tunnus}'
+                and tilino = '{$alv_tili}'
+                and korjattu = ''";
+      $new_alv_chk_res = pupe_query($query);
+      $new_alv_chk_row = mysql_fetch_assoc($new_alv_chk_res);
+      
+      if (mysql_num_rows($old_alv_chk_res) > 0 and mysql_num_rows($new_alv_chk_res) > 0) {
+
+        $old_alv = (int) $old_alv_chk_row['summa'] * 10000;
+        $new_alv = (int) $new_alv_chk_row['summa'] * 10000;
+      
+        if ($old_alv != $new_alv) {
+          $alvin_ero = $old_alv_chk_row['summa'] - $new_alv_chk_row['summa'];
+          $kulu_tili = $yhtiorow[key($laskun_kulut)];
+          
+          $query = "SELECT *
+                    from tiliointi
+                    where yhtio = '{$kukarow['yhtio']}'
+                    and ltunnus = '{$tunnus}'
+                    and tilino = '{$kulu_tili}'
+                    and korjattu = ''";
+          $kulu_chk_res = pupe_query($query);
+          $kulu_chk_row = mysql_fetch_assoc($kulu_chk_res);
+          
+          $kulu_chk_row['summa'] += $alvin_ero;
+          
+          $query = "UPDATE tiliointi SET
+                    summa = '{$kulu_chk_row['summa']}'
+                    where yhtio = '{$kukarow['yhtio']}'
+                    and tunnus = '{$kulu_chk_row['tunnus']}'";
+          $upd_kulut = pupe_query($query);
+        }
+      }      
+    }
   }
 }
 

--- a/inc/muutosite.inc
+++ b/inc/muutosite.inc
@@ -1811,7 +1811,6 @@ if ($tila == 'ostolasku_kulut') {
                 and korjattu != ''
                 group by 1
                 order by 1 asc";
-echo "1814: $query <br><br>";
       $old_alv_chk_res = pupe_query($query);
       $old_alv_chk_row = mysql_fetch_assoc($old_alv_chk_res);
       
@@ -1823,12 +1822,12 @@ echo "1814: $query <br><br>";
                 and korjattu = ''";
       $new_alv_chk_res = pupe_query($query);
       $new_alv_chk_row = mysql_fetch_assoc($new_alv_chk_res);
-echo "1825: $alv_tili, $old_alv_chk_row[summa], $new_alv_chk_row[summa], $satu1, $satu2 <br><br>";      
+      
       if (mysql_num_rows($old_alv_chk_res) > 0 and mysql_num_rows($new_alv_chk_res) > 0) {
 
         $old_alv = (int) ($old_alv_chk_row['summa'] * 10000);
         $new_alv = (int) ($new_alv_chk_row['summa'] * 10000);
-echo "1828: $alv_tili, $old_alv_chk_row[summa], $new_alv_chk_row[summa], $old_alv, $new_alv <br><br>";      
+      
         if ($old_alv != $new_alv) {
           $alvin_ero = $old_alv_chk_row['summa'] - $new_alv_chk_row['summa'];
           
@@ -1838,7 +1837,6 @@ echo "1828: $alv_tili, $old_alv_chk_row[summa], $new_alv_chk_row[summa], $old_al
                     and ltunnus = '{$tunnus}'
                     and tilino IN ('{$yhtiorow['osto_rahti']}', '{$yhtiorow['osto_kulu']}', '{$yhtiorow['osto_rivi_kulu']}')
                     and korjattu = ''";
-echo "1842: $query <br><br>";
           $kulu_chk_res = pupe_query($query);
           $kulu_chk_row = mysql_fetch_assoc($kulu_chk_res);
           
@@ -1848,7 +1846,6 @@ echo "1842: $query <br><br>";
                     summa = '{$kulu_chk_row['summa']}'
                     where yhtio = '{$kukarow['yhtio']}'
                     and tunnus = '{$kulu_chk_row['tunnus']}'";
-echo "1852: $query <br><br>";
           $upd_kulut = pupe_query($query);
 
           list($_tunnus, ) = explode(',', $new_alv_chk_row['tunnukset']);


### PR DESCRIPTION
Kun lasku liitettiin saapumiseen, niin että osa laskusta merkittiin rahdiksi tai kuluksi, jotka muuttivat laskun tiliöintejä, saattoi syntyä pyöristyseroja, jotka muuttivat kokonais-alv:n määrää.

Kokonais-alv pitää kuitenkin pysyä samana, ja nyt tarkistetaan, että kokonais-alv:in määrä ei muutu, vaikka osa laskusta tiliöidään rahdiksi/kuluksi