### PR TITLE
Myyntitilausotsikko: kerays/toimitusviikko

### DIFF
--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -3667,7 +3667,7 @@ if (isset($jatka)) {
     $nyvuosi  = date("Y");
 
     // Jos mik‰‰n ei ole muuttunut, niin ei tehd‰ vuosisiirtoa,
-    // muuten menneisyyden p‰iv‰m‰‰r‰ siirtyy seuraavalla vuodelle automaattisesti
+    // muuten menneisyyden p‰iv‰m‰‰r‰ siirtyy seuraavalle vuodelle automaattisesti
     // vaika siihen ei koskisi
     if ($toimvko < $nyviikko and ($toimvkolaskulla != $toimvko or $toimvkopvalaskulla != $toimvkopva)) {
       $nyvuosi += 1;
@@ -3696,7 +3696,7 @@ if (isset($jatka)) {
     $nyvuosi = date("Y");
 
     // Jos mik‰‰n ei ole muuttunut, niin ei tehd‰ vuosisiirtoa,
-    // muuten menneisyyden p‰iv‰m‰‰r‰ siirtyy seuraavalla vuodelle automaattisesti
+    // muuten menneisyyden p‰iv‰m‰‰r‰ siirtyy seuraavalle vuodelle automaattisesti
     // vaika siihen ei koskisi
     if ($keraysvko < $nyviikko and ($keraysvkolaskulla != $keraysvko or $keraysvkopvalaskulla != $keraysvkopva)) {
       $nyvuosi += 1;

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -1810,10 +1810,6 @@ if ($tila == "" and !isset($jatka)) {
         $keraysvko = "";
       }
 
-      if ($srow["kerayspvm"] < date("Y-m-d")) {
-        $keraysvko = "";
-      }
-
       $vasen_sarake[$vasen] .= t("Vko").": <input type='text' name='keraysvko' value='$keraysvko' size='2'>";
 
       $vasen_sarake[$vasen] .= "<select name='keraysvkopva'>";
@@ -1907,10 +1903,6 @@ if ($tila == "" and !isset($jatka)) {
         $toimvko = date("W", strtotime($srow["toimaika"]));
       }
       else {
-        $toimvko = "";
-      }
-
-      if ($srow["toimaika"] < date("Y-m-d")) {
         $toimvko = "";
       }
 
@@ -3667,11 +3659,17 @@ if (isset($jatka)) {
 
   if ($toimvko != '') {
 
-    $nyvuosi  = date("Y");
+    $toimvkolaskulla = date("W", strtotime($apuro["toimaika"]));
+    $toimvkopvalaskulla = $apuro["toimvko"];
 
     $toimvkopva = $toimvkopva == '' ? 7 : $toimvkopva;
 
-    if ($toimvko < $nyviikko) {
+    $nyvuosi  = date("Y");
+
+    // Jos mikään ei ole muuttunut, niin ei tehdä vuosisiirtoa,
+    // muuten menneisyyden päivämäärä siirtyy seuraavalla vuodelle automaattisesti
+    // vaika siihen ei koskisi
+    if ($toimvko < $nyviikko and ($toimvkolaskulla != $toimvko or $toimvkopvalaskulla != $toimvkopva)) {
       $nyvuosi += 1;
     }
 
@@ -3690,11 +3688,17 @@ if (isset($jatka)) {
 
   if ($keraysvko != '') {
 
-    $nyvuosi = date("Y");
+    $keraysvkolaskulla = date("W", strtotime($apuro["kerayspvm"]));
+    $keraysvkopvalaskulla = $apuro["keraysvko"];
 
     $keraysvkopva = $keraysvkopva == '' ? 7 : $keraysvkopva;
 
-    if ($keraysvko < $nyviikko) {
+    $nyvuosi = date("Y");
+
+    // Jos mikään ei ole muuttunut, niin ei tehdä vuosisiirtoa,
+    // muuten menneisyyden päivämäärä siirtyy seuraavalla vuodelle automaattisesti
+    // vaika siihen ei koskisi
+    if ($keraysvko < $nyviikko and ($keraysvkolaskulla != $keraysvko or $keraysvkopvalaskulla != $keraysvkopva)) {
       $nyvuosi += 1;
     }
 

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -1810,6 +1810,10 @@ if ($tila == "" and !isset($jatka)) {
         $keraysvko = "";
       }
 
+      if ($srow["kerayspvm"] < date("Y-m-d")) {
+        $keraysvko = "";
+      }
+
       $vasen_sarake[$vasen] .= t("Vko").": <input type='text' name='keraysvko' value='$keraysvko' size='2'>";
 
       $vasen_sarake[$vasen] .= "<select name='keraysvkopva'>";
@@ -1903,6 +1907,10 @@ if ($tila == "" and !isset($jatka)) {
         $toimvko = date("W", strtotime($srow["toimaika"]));
       }
       else {
+        $toimvko = "";
+      }
+
+      if ($srow["toimaika"] < date("Y-m-d")) {
         $toimvko = "";
       }
 


### PR DESCRIPTION
Aiemmin tehtyä myyntitilausta muokattaessa jonka kerays/toimitusviikko on jo mennyt nollataan myyntitilauksen otsikolle mentäessä kerays/toimitusviikko kenttä. Tehdään tämä näin, koska muutoin myyntitilauksen kerayspäivämäärä ja toimitusaika siirtyivät seuraavalle vuodelle seuraavan valitun kerays/toimitusviikkonumeron ollessa vasta seuraavana vuonna.