### PR TITLE
Jt-selauksen toimitettava määrä

### DIFF
--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -585,6 +585,8 @@ if (!function_exists("tee_jt_tilaus")) {
 
       ///* Tässä meillä on otsikko hallussa se on $id muuttujassa*///
 
+      $kpl[$tunnukset] = str_replace(",", ".", $kpl["$tunnukset"]);
+  
       // Tässä haarassa käyttäjä on syöttänyt jonkun kappalemäärän
       if ($kpl[$tunnukset] > 0 or $loput[$tunnukset] == 'KAIKKI' or $loput[$tunnukset] == 'VAKISIN') {
 


### PR DESCRIPTION
Jos annettu määrä oli desimaaliluku, lukua ei ymmärretty, kun desimaalierottimena oli käytetty pilkkua.

Tämä korjattu niin, että desimaalierottimena voi käyttää joko pilkkua tai pistettä.