### PR TITLE
Myyntitilaukset: Odottaa asiakkaan suoritusta

### DIFF
--- a/inc/laskutyyppi.inc
+++ b/inc/laskutyyppi.inc
@@ -87,6 +87,9 @@ case "L":
   case "D":
     $alatila = "Toimitettu";
     break;
+  case "G":
+    $alatila = "Odottaa asiakkaan suoritusta";
+    break;
   case "J":
     $alatila = "Odottaa loppulaskutusta";
     break;

--- a/tilauskasittely/tilaus-valmis-valitsetila.inc
+++ b/tilauskasittely/tilaus-valmis-valitsetila.inc
@@ -370,6 +370,52 @@ elseif ($kerattavia > 0 and $kutsuja != 'keraa.php' and !$tilaus_toimitetuksi) {
     pupe_query($query);
   }
 
+  $query = "SELECT tilausrivi.kerattyaika,
+            tilausrivi.toimitettuaika
+            FROM tilausrivi
+            JOIN tuote ON (tuote.yhtio = tilausrivi.yhtio AND tuote.tuoteno = tilausrivi.tuoteno)
+            WHERE tilausrivi.yhtio = '{$kukarow["yhtio"]}'
+            AND tilausrivi.otunnus = '{$laskurow["tunnus"]}'
+            AND tilausrivi.kerattyaika != '0000-00-00 00:00:00'
+            AND tuote.ei_saldoa = ''
+            ORDER BY tilausrivi.toimitettuaika DESC
+            LIMIT 1";
+  $kerattyja = pupe_query($query);
+
+  if (mysql_num_rows($kerattyja) > 0) {
+    $kerattyjarow = mysql_fetch_assoc($kerattyja);
+
+    $tila = 'L';
+    $alatila = 'C';
+
+    // P‰ivitet‰‰n samalla kaikki uudetkin rivit ker‰tyiksi
+    $query = "UPDATE tilausrivi
+                SET keratty = '$kukarow[kuka]', kerattyaika = now()
+                WHERE yhtio  = '$kukarow[yhtio]'
+                and otunnus  = '$laskurow[tunnus]'
+                and keratty  = ''
+                and var      not in ('P','J','O','S')
+                and tyyppi  != 'D'";
+    $result = pupe_query($query);
+
+    if ($kerattyjarow["toimitettuaika"] != "0000-00-00 00:00:00") {
+      $tila = 'L';
+      $alatila = 'D';
+
+      // P‰ivitet‰‰n samalla kaikki uudetkin rivit toimitetuiksi
+      $query = "UPDATE tilausrivi
+                SET toimitettu = '$kukarow[kuka]', toimitettuaika = now()
+                WHERE yhtio     = '$kukarow[yhtio]'
+                and otunnus     = '$laskurow[tunnus]'
+                and keratty    != ''
+                and toimitettu  = ''
+                and var         not in ('P','J','O','S')
+                and tyyppi     != 'D'";
+      $result = pupe_query($query);
+
+    }
+  }
+
   $query  = "UPDATE lasku SET
              tila        = '{$tila}',
              alatila     = '{$alatila}'


### PR DESCRIPTION
Myyntitilauksen ollessa jo kerätty tai toimitettu tilassa ja kun tilaukselle tästä huolimatta käytiin lisäämässä rivejä niin, että asiakkaan luottoraja ylittyi meni myyntitilaus tilaan "Myyntitilaus G". Tämä esti aivan oikein myyntitilauksen eteenpäin laittamisen, mutta oli aika epäinformatiivinen. Tila on nyt lisätty ja jatkossa nämä "Myyntitilaus G" tilassa olevat ovat "Myyntitilaus Odottaa asiakkaan suoritusta".

Samalla korjattiin toinen ongelma liittyen siihen tilanteeseen, kun asiakkaalla taas vapaata luottorajaa oli ja tälläinen "Myyntitilaus G" tilaus laitettiin eteenpäin. "Myyntitilaus G" tilaisen tilauksen eteenpäin laittaminen saattoi saada myyntitilauksen hassuun tilaan ja jumiin, mutta nyt nämä tilaukset on määritelty toimivaksi kuten normaalitkin tilaukset eli seuraavan kaavan mukaan:

- Myyntitilaus keratty: myyntitilauksen ollessa kerätty ja kun siihen lisätään uusia rivejä merkitään nämä rivit myyntitilauksen valmiiksi klikkaamisen yhteydessä kerätyiksi
- Myyntitilaus toimitettu: myyntitilauksen ollessa toimitettu ja kun siihen lisätään uusia rivejä merkitään nämä uudet rivit myyntitilauksen valmiiksi klikkaamisen yhteydessä toimitetuiksi