### PR TITLE
Myyntitili: tilausrivien määrän jakaminen

### DIFF
--- a/tilauskasittely/laskuta_myyntitilirivi.inc
+++ b/tilauskasittely/laskuta_myyntitilirivi.inc
@@ -92,7 +92,6 @@ if ($tilatapa == "PAIVITA") {
             break;
           case 'kpl':
           case 'tilkpl':
-          case 'varattu':
             $values .= ", '$erotus'";
             break;
           case 'kate_korjattu':


### PR DESCRIPTION
Myyntitilirivien ei kuulu varata varastosta saldoa, koska nehän on jo toimitettu asiakkaalle ja se, että ne ovat myyntitilillä tarkoittaa, että ne ovat jo asiakkaalla. Nyt kuitenkin, kun myyntitilirivin määrän jakoi laskutusta tai varastoon palauttamista varten laittoi Pupe uuden rivin määrän varatuksi, jonka takia tämä uusi rivi näkyi varastosiirtona tuotekyselyssä tuotteen tilauksissa ja varauksena myyntitilivarastopaikan saldolla. Tästä huolimatta rivit pystyi käsittelemään normaalisti, vaikka myyntitilirivit oudosti näkyivätkin.