### PR TITLE
Myyntitilaus kommentti2

### DIFF
--- a/tilauskasittely/luo_myyntitilausotsikko.inc
+++ b/tilauskasittely/luo_myyntitilausotsikko.inc
@@ -139,6 +139,7 @@ if (!function_exists("luo_myyntitilausotsikko")) {
 
       $valkoodi       = $asiakasrow["valkoodi"];
       $sisviesti1      = $asiakasrow["sisviesti1"];
+      $sisviesti2      = $asiakasrow["sisviesti2"];
       $rahtivapaa     = $asiakasrow["rahtivapaa"];
 
       if ($asiakasrow["myynti_kommentti1"] != "") {


### PR DESCRIPTION
Asiakaskortilla määritelty kommentti 2 kentän sisältö ei virheellisesti tullut myyntitilauksen otsikolle, jos myyntitilaus luotiin pikatilauksena. Jatkossa myös pikatilauksessa tuo tieto siirtyy myyntitilaukselle.