### PR TITLE
Myyntitilauksen otsikko: asiakkaan piiri

### DIFF
--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -2432,7 +2432,7 @@ if ($tila == "" and !isset($jatka)) {
 
     $pres = t_avainsana("PIIRI");
 
-    $vasen_sarake[$vasen] .= "<select name='piiri'>";
+    $vasen_sarake[$vasen] .= "<select name='piiri'><option value=' '>".t("Ei piiriä")."</option>";
 
     while ($prow = mysql_fetch_assoc($pres)) {
       $chk = "";

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -2432,7 +2432,7 @@ if ($tila == "" and !isset($jatka)) {
 
     $pres = t_avainsana("PIIRI");
 
-    $vasen_sarake[$vasen] .= "<select name='piiri'><option value=' '>".t("Ei piiriä")."</option>";
+    $vasen_sarake[$vasen] .= "<select name='piiri'><option value=''>".t("Ei piiriä")."</option>";
 
     while ($prow = mysql_fetch_assoc($pres)) {
       $chk = "";


### PR DESCRIPTION
Myyntitilauksen otsikolla ei pystynyt valitsemaan "ei piiriä" vaihtoehtoa, vaikka sellainen asiakkaiden takana on olemassa. Korjattu nyt niin, että myös myyntitilauksella on vaihtoehtona "ei piiriä" vaihtoehto.