### PR TITLE
* Varastosiirto: myyntierän pyöristys

### DIFF
--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -3600,16 +3600,12 @@ if ($fieldname == "myyntiera_pyoristys" ) {
 
   $sela = $selb = "";
 
-  if ($trow[$i] == 'K') {
-    $selb = "selected";
-  }
-  else {
-    $sela = "selected";
-  }
+  $sel = array($trow[$i] => 'selected') + array('','K','S');
 
-  $ulos = "<td><select name='$nimi' ".js_alasvetoMaxWidth($nimi, 400).">
-        <option value = ' ' $sela>".t("Myyntirivin määrää ei pyöristetä seuraavaan täyteen myyntierään")."</option>
-        <option value = 'K' $selb>".t("Myyntirivin määrä pyöristetään seuraavaan täyteen myyntierään")."</option>
+  $ulos = "<td><select name='{$nimi}' ".js_alasvetoMaxWidth($nimi, 400).">
+        <option value = ' '>".t("Myyntirivin määrää ei pyöristetä seuraavaan täyteen myyntierään")."</option>
+        <option value = 'K' {$sel['K']}>".t("Myyntirivin määrä pyöristetään seuraavaan täyteen myyntierään")."</option>
+        <option value = 'S' {$sel['S']}>".t("Myyntirivin ja siirtorivin määrä pyöristetään seuraavaan täyteen myyntierään")."</option>
       </select></td>";
 
   $jatko = 0;

--- a/tilauskasittely/generoi_siirtolista.php
+++ b/tilauskasittely/generoi_siirtolista.php
@@ -365,7 +365,14 @@ if (!$php_cli) {
 
   echo "<tr><th>", t("Jätä siirtolista kesken"), ":</th><td><input type='checkbox' name = 'kesken' value='X' {$c}></td></tr>";
   echo "<tr><th>", t("Siirrä myös tuoteperheen lapsituotteet"), ":</th><td><input type='checkbox' name = 'lapsituotteet' value='X' {$lapsituote_chk}></td></tr>";
-  echo "<tr><th>", t("Huomioi siirrettävän tuotteen myyntierä"), ":</th><td><input type='checkbox' name = 'myyntiera' value='X' {$myyntiera_chk}></td></tr>";
+
+  if ($yhtiorow['myyntiera_pyoristys'] != 'S') {
+    echo "<tr><th>", t("Huomioi siirrettävän tuotteen myyntierä"), ":</th><td><input type='checkbox' name = 'myyntiera' value='X' {$myyntiera_chk}></td></tr>";
+  }
+  else {
+    $myyntiera = "";
+  }
+
   echo "<tr><th>", t("Rivejä per siirtolista (tyhjä = 20)"), ":</th><td><input type='text' size='8' value='{$olliriveja}' name='olliriveja'></td></tr>";
   echo "<tr><th>", t("Ei siirretä jos tarve on suurempi tai yhtä suuri kuin saatavilla oleva määrä"), "</th>";
   echo "<td><input type='checkbox' name='ei_siirreta_jos_tarve_ylittyy' value='X' {$ei_siirreta_jos_tarve_ylittyy_chk} /></td></tr>";

--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -494,7 +494,13 @@ else {
   unset($varasto);
 }
 
-if ((!isset($from_tee_jt_tilaus) or !$from_tee_jt_tilaus) and $kpl > 0 and (($trow['myynti_era'] > 0 and $yhtiorow['myyntiera_pyoristys'] == 'K') or $trow['minimi_era'] > 0) and ($rivityyppi == 'L' or $rivityyppi == 'E') and $rivitunnus == 0 and ($toim == 'RIVISYOTTO' or $toim == 'PIKATILAUS' or $toim == 'ENNAKKO' or $toim == 'EXTRANET' or ($kutsuja == "EDITILAUS" and $edi_tyyppi != "magento"))) {
+if ((!isset($from_tee_jt_tilaus) or !$from_tee_jt_tilaus) and
+    $kpl > 0 and
+    (($trow['myynti_era'] > 0 and in_array($yhtiorow['myyntiera_pyoristys'], array('K','S'))) or $trow['minimi_era'] > 0) and
+    ((in_array($rivityyppi, array('L','E')) and $yhtiorow['myyntiera_pyoristys'] == 'K') or ($rivityyppi == 'G' and $yhtiorow['myyntiera_pyoristys'] == 'S' and (!isset($varastosiirtotyyppi) or !in_array($varastosiirtotyyppi, array('P','K'))))) and
+    $rivitunnus == 0 and
+    (in_array($toim, array('RIVISYOTTO','PIKATILAUS','ENNAKKO','EXTRANET','SIIRTOLISTA')) or ($kutsuja == "EDITILAUS" and $edi_tyyppi != "magento"))
+    ) {
 
   $org_kpl = $kpl;
 
@@ -502,7 +508,7 @@ if ((!isset($from_tee_jt_tilaus) or !$from_tee_jt_tilaus) and $kpl > 0 and (($tr
     $kpl = $trow['minimi_era'];
   }
 
-  if ($yhtiorow['myyntiera_pyoristys'] == 'K') {
+  if (in_array($yhtiorow['myyntiera_pyoristys'], array('K','S'))) {
     if ($kpl <= $trow['myynti_era']) {
       $kpl = $trow['myynti_era'];
     }

--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -497,7 +497,7 @@ else {
 if ((!isset($from_tee_jt_tilaus) or !$from_tee_jt_tilaus) and
     $kpl > 0 and
     (($trow['myynti_era'] > 0 and in_array($yhtiorow['myyntiera_pyoristys'], array('K','S'))) or $trow['minimi_era'] > 0) and
-    ((in_array($rivityyppi, array('L','E')) and $yhtiorow['myyntiera_pyoristys'] == 'K') or ($rivityyppi == 'G' and $yhtiorow['myyntiera_pyoristys'] == 'S' and (!isset($varastosiirtotyyppi) or !in_array($varastosiirtotyyppi, array('P','K'))))) and
+    (((in_array($rivityyppi, array('L','E')) and in_array($yhtiorow['myyntiera_pyoristys'], array('K','S'))) or ($rivityyppi == 'G' and $yhtiorow['myyntiera_pyoristys'] == 'S')) and (!isset($varastosiirtotyyppi) or !in_array($varastosiirtotyyppi, array('P','K')))) and
     $rivitunnus == 0 and
     (in_array($toim, array('RIVISYOTTO','PIKATILAUS','ENNAKKO','EXTRANET','SIIRTOLISTA')) or ($kutsuja == "EDITILAUS" and $edi_tyyppi != "magento"))
     ) {

--- a/tilauskasittely/tarkistarivi.inc
+++ b/tilauskasittely/tarkistarivi.inc
@@ -396,7 +396,7 @@ if (isset($myyntierahuom) and is_array($myyntierahuom) and in_array($row['tunnus
     $mimyhuom .= " minimierään";
   }
 
-  if ($trow['myynti_era'] > 0 and $yhtiorow['myyntiera_pyoristys'] == 'K') {
+  if ($trow['myynti_era'] > 0 and in_array($yhtiorow['myyntiera_pyoristys'], array('K','S'))) {
     if ($trow["minimi_era"] > 0) {
       $mimyhuom .= " tai";
     }
@@ -419,8 +419,8 @@ if (isset($myyntierahuom) and is_array($myyntierahuom) and in_array($row['tunnus
 }
 else {
 
-   if ($trow['myynti_era'] > 0 and $trow['myynti_era'] != $kpl_st and $yhtiorow['myyntiera_pyoristys'] != 'K') {
-     
+   if ($trow['myynti_era'] > 0 and $trow['myynti_era'] != $kpl_st and !in_array($yhtiorow['myyntiera_pyoristys'], array('K','S'))) {
+
      $mimyhuom = t("HUOM: Tuotteella on myyntierä"). " " . $trow['myynti_era'];
      $varaosakommentti .= $mimyhuom."<br>";
    }

--- a/tilauskasittely/tilauksesta_varastosiirto.inc
+++ b/tilauskasittely/tilauksesta_varastosiirto.inc
@@ -306,7 +306,9 @@ if (!function_exists('luo_varastosiirtorivi')) {
       ${'ale'.$alepostfix} = "";
     }
 
-    $toim = 'SIIRTOLISTA';
+    if ($varastosiirtotyyppi == "G") {
+      $toim = 'SIIRTOLISTA';
+    }
 
     require 'lisaarivi.inc';
 

--- a/tilauskasittely/tilauksesta_varastosiirto.inc
+++ b/tilauskasittely/tilauksesta_varastosiirto.inc
@@ -306,6 +306,8 @@ if (!function_exists('luo_varastosiirtorivi')) {
       ${'ale'.$alepostfix} = "";
     }
 
+    $toim = 'SIIRTOLISTA';
+
     require 'lisaarivi.inc';
 
     return $lisatyt_rivit1;


### PR DESCRIPTION
Varastosiirroissa huomioidaan tuotteen myyntierä, jolla pyöristetään rivi täyteen myyntierään (kuten myynnissä).

* Lisätty parametri tätä varten, uusi optio parametriin myyntiera_pyoristys ("Myyntirivin ja siirtorivin määrä pyöristetään seuraavaan täyteen myyntierään")
* Normaaleille- ja generoiduille siirtoriveille uusi optio purisi. Kirjanpidollinen- ja palautus-siirtoriveille pyöristystä ei tehdä.