### PR TITLE
Myyntilaskut: laskutusviikonpäivä

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -13569,13 +13569,13 @@ if (!function_exists("laskutuspaiva")) {
     }
     elseif ($mika == 'keski') {
       // Keskimmäinen
-      $keskipaiva = date('N', mktime(0, 0, 0, date('m'), round(date('t')/2), date('Y')));
+      $keskipaiva = date('N', mktime(0, 0, 0, (date('m')+$seuraava_kk), round(date('t')/2), date('Y')));
 
       if ($arki and $keskipaiva > 5) {
-        $seuraavalaskutus = date('Y-m-d', mktime(0, 0, 0, date('m'), round(date('t')/2)+(8-$keskipaiva), date('Y')));
+        $seuraavalaskutus = date('Y-m-d', mktime(0, 0, 0, (date('m')+$seuraava_kk), round(date('t')/2)+(8-$keskipaiva), date('Y')));
       }
       else {
-        $seuraavalaskutus = date('Y-m-d', mktime(0, 0, 0, date('m'), round(date('t')/2), date('Y')));
+        $seuraavalaskutus = date('Y-m-d', mktime(0, 0, 0, (date('m')+$seuraava_kk), round(date('t')/2), date('Y')));
       }
     }
     elseif ($mika == 'vika') {


### PR DESCRIPTION
Myyntilaskuja tehtäessä, jos oli asiakkaan takana valittuna kuukauden keskimmäinen päivä ja oli ohitettu jo kuukauden keskimmäinen päivä meni laskun päivämääräksi silti aina sen kyseisen kuukauden keskimmäinen päivämäärä. Esimerkiksi jos tilaus tehdään 23.11 menisi laskun päivämääräksi aina 16.11 eikä 15.12. Nyt tämä on korjattu ja jos kuukauden keskimmäinen päivämäärä on ohitettu menee laskutuspäivämääräksi seuraavan kuukauden keskimmäinen päivämäärä.