### PR TITLE
Matkallaolevat laskuittain: varastoonvientipäivä

### DIFF
--- a/raportit/matkallaolevat_laskuittain.php
+++ b/raportit/matkallaolevat_laskuittain.php
@@ -207,7 +207,7 @@ if ($alisa != "" and $llisa != "") {
 
         // Milloin rivit on viety saldoille keskim‰‰rin
         $query = "SELECT
-                  DATE_FORMAT(FROM_UNIXTIME(AVG(UNIX_TIMESTAMP(laskutettuaika))),'%Y-%m-%d') AS laskutettuaika
+                  if (laskutettuaika != '0000-00-00', DATE_FORMAT(FROM_UNIXTIME(AVG(UNIX_TIMESTAMP(laskutettuaika))),'%Y-%m-%d'), laskutettuaika) AS laskutettuaika
                   FROM tilausrivi
                   WHERE yhtio     = '{$kukarow['yhtio']}'
                   AND uusiotunnus = {$keikrow['tunnus']}


### PR DESCRIPTION
Jos ostotilausrivi oli liitetty saapumiselle, mutta sitä ei oltu vielä viety varastoon näkyi Matkallaolevat laskuittain raportissa varastoonvientipäivämäärän kohdalla 01.01.1970. Tämä siis on virheellinen päivämäärä ja johtuu siitä, että ostotilausrivi oli vain liitetty saapumiseen, mutta ei vielä viety varastoon. Tämä on nyt korjattu ja tälläisissä tapauksissa jossa ostotilausrivi on liitetty saapumisen, mutta ei vielä viety varastoon näytetään jatkossa Matkallolevat laskuittain raportissa varastoonvientipäivämäärän kohdalla tyhjää.