### PR TITLE
Muutoksia ylläpitosopimuksiin

### DIFF
--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -4772,3 +4772,17 @@ if ($fieldname == "viitemaksujen_oikaisut") {
 
   $jatko = 0;
 }
+
+if ($fieldname == "laskun_kanavointitidon_syotto") {
+  $apu = $trow[$i];
+  $sel = array($apu => " selected");
+
+  $ulos = "<td>
+             <select name='{$nimi}' ".js_alasvetoMaxWidth($nimi, 400).">
+               <option value='0'>".t("Laskun kanavointitietoa ei voi syöttää käsin")."
+               <option value='1'{$sel["1"]}>".t("Laskun kanavointitiedon voi syöttää käsin ylläpitosopimukselle")."
+             </select>
+           </td>";
+
+  $jatko = 0;
+}

--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -2256,16 +2256,21 @@ if ($fieldname == "viitteen_kasinsyotto") {
 
   $sel1="";
   $sel2="";
+  $sel3="";
 
   if ($trow[$i] == "") {
     $sel1 = "selected";
   }
-  else {
+  elseif ($trow[$i] == "X") {
     $sel2 = "selected";
+  }
+  else {
+    $sel3 = "selected";
   }
 
   $ulos .= "<option value=''  $sel1>".t("Viitettä ei saa syöttää käsin")."</option>";
   $ulos .= "<option value='X' $sel2>".t("Viitteen saa syöttää käsin")."</option>";
+  $ulos .= "<option value='Y' $sel3>".t("Viitteen saa syöttää käsin ylläpitosopimuksille")."</option>";
   $ulos .= "</select></td>";
 
   $jatko = 0;

--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -4769,7 +4769,7 @@ if ($fieldname == "viitemaksujen_oikaisut") {
   $jatko = 0;
 }
 
-if ($fieldname == "laskun_kanavointitidon_syotto") {
+if ($fieldname == "laskun_kanavointitiedon_syotto") {
   $apu = $trow[$i];
   $sel = array($apu => " selected");
 

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -411,8 +411,19 @@ if (isset($jatka)) {
   }
 }
 
+switch ($yhtiorow["viitteen_kasinsyotto"]) {
+case "Y":
+  $viitten_kasinsyotto_sallittu = $toim == "YLLAPITO";
+  break;
+case "X":
+  $viitten_kasinsyotto_sallittu = true;
+  break;
+default:
+  $viitten_kasinsyotto_sallittu = false;
+}
+
 //  Tarkastetaan käsinsyötetty viite
-if (isset($jatka) and $kasinsyotetty_viite != "" and $yhtiorow["viitteen_kasinsyotto"] != "") {
+if (isset($jatka) and $kasinsyotetty_viite != "" and $viitten_kasinsyotto_sallittu) {
   if (substr($kasinsyotetty_viite, 0, 2) != "RF" and tarkista_viite($kasinsyotetty_viite) === FALSE) {
     echo "<font class='error'>".t("VIRHE: Syötetty viite '%s' on väärin", $kieli, $kasinsyotetty_viite)."!</font><br>";
     $tee  = "OTSIK";
@@ -1715,7 +1726,7 @@ if ($tila == "" and !isset($jatka)) {
     $oikea_sarake[$oikea] .= "</td>";
     $oikea++;
 
-    if ($yhtiorow["viitteen_kasinsyotto"] != "") {
+    if ($viitten_kasinsyotto_sallittu) {
       $vasen_sarake[$vasen] = "<td>".t("Viitenumero").":</td><td>";
       $vasen_sarake[$vasen] .= "<input type='text' id='kasinsyotetty_viite' name='kasinsyotetty_viite' value='$srow[kasinsyotetty_viite]' size='20'>";
       $vasen_sarake[$vasen] .= "<a href='' onclick='lisaa_tarkiste(); return false;'><img src='{$palvelin2}pics/lullacons/add.png'>".t("Lisää tarkiste")."</a>";

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -3956,7 +3956,7 @@ if (isset($jatka)) {
     $chn = '999';
   }
   elseif ($liitostunnus != "" &&
-          !($yhtiorow["laskun_kanavointitiedon_syotto"] == 1 && !empty($chn)) && $toim == "YLLAPITO") {
+          !($yhtiorow["laskun_kanavointitiedon_syotto"] == 1 && !empty($chn) && $toim == "YLLAPITO")) {
     $chn = $asiarow['chn'];
 
     if ($chn == '') {

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -3056,6 +3056,26 @@ if ($tila == "" and !isset($jatka)) {
       if ($yhtiorow['laiterekisteri_kaytossa'] != '') {
         echo "<tr><td>".t("Sopimusnumero")."</td><td colspan='3'><input type='text' name='sopimus_numero' size='30' value='{$srow['sopimus_numero']}'></td></tr>";
       }
+
+      if ($yhtiorow["laskun_kanavointitidon_syotto"] == 1 && $toim == "YLLAPITO") {
+        $sel                   = array();
+        $sel[$laskurow["chn"]] = " selected";
+
+        echo "<tr>";
+        echo "<td>" . t("Laskun kanavointitieto") . "</td>";
+        echo "<td colspan='3'><select name='chn'>";
+        echo "<option value='100' {$sel['100']}>" . hae_chn_teksti('100') . "</option>";
+        echo "<option value='010' {$sel['010']}>" . hae_chn_teksti('010') . "</option>";
+        echo "<option value='020' {$sel['020']}>" . hae_chn_teksti('020') . "</option>";
+        echo "<option value='030' {$sel['030']}>" . hae_chn_teksti('030') . "</option>";
+        echo "<option value='111' {$sel['111']}>" . hae_chn_teksti('111') . "</option>";
+        echo "<option value='112' {$sel['112']}>" . hae_chn_teksti('112') . "</option>";
+        echo "<option value='666' {$sel['666']}>" . hae_chn_teksti('666') . "</option>";
+        echo "<option value='667' {$sel['667']}>" . hae_chn_teksti('667') . "</option>";
+        echo "<option value='999' {$sel['999']}>" . hae_chn_teksti('999') . "</option>";
+        echo "</select></td>";
+        echo "</tr>";
+      }
     }
 
     echo "</table><br>";
@@ -3935,7 +3955,8 @@ if (isset($jatka)) {
   if ($laskutuskielto != '') {
     $chn = '999';
   }
-  elseif ($liitostunnus != "") {
+  elseif ($liitostunnus != "" &&
+          !($yhtiorow["laskun_kanavointitidon_syotto"] == 1 && !empty($chn)) && $toim == "YLLAPITO") {
     $chn = $asiarow['chn'];
 
     if ($chn == '') {

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -3057,7 +3057,7 @@ if ($tila == "" and !isset($jatka)) {
         echo "<tr><td>".t("Sopimusnumero")."</td><td colspan='3'><input type='text' name='sopimus_numero' size='30' value='{$srow['sopimus_numero']}'></td></tr>";
       }
 
-      if ($yhtiorow["laskun_kanavointitidon_syotto"] == 1 && $toim == "YLLAPITO") {
+      if ($yhtiorow["laskun_kanavointitiedon_syotto"] == 1 && $toim == "YLLAPITO") {
         $sel                   = array();
         $sel[$laskurow["chn"]] = " selected";
 
@@ -3956,7 +3956,7 @@ if (isset($jatka)) {
     $chn = '999';
   }
   elseif ($liitostunnus != "" &&
-          !($yhtiorow["laskun_kanavointitidon_syotto"] == 1 && !empty($chn)) && $toim == "YLLAPITO") {
+          !($yhtiorow["laskun_kanavointitiedon_syotto"] == 1 && !empty($chn)) && $toim == "YLLAPITO") {
     $chn = $asiarow['chn'];
 
     if ($chn == '') {


### PR DESCRIPTION
- Voidaan syöttää viitenumero käsin ylläpitosopimuksille, jos yhtiön parametri viitteen_kasinsyotto on oikeassa asennossa
- Voidaan syöttää laskun kanavointitieto käsin ylläpitosopimukselle, jos yhtiön parametri laskun_kanavointitidon_syotto on oikeassa asennossa
- Arvot kopioituvat ylläpitosopimuksesta generoiduille laskuille