### PR TITLE
Sarjanumerollisen tuotteen valmistus

### DIFF
--- a/tilauskasittely/valmista_tilaus.php
+++ b/tilauskasittely/valmista_tilaus.php
@@ -920,7 +920,7 @@ if ($tee == 'TEEVALMISTUS') {
                         varattu        = 0
                         WHERE yhtio    = '$kukarow[yhtio]'
                         and otunnus    = '$tilrivirow[otunnus]'
-                        and tyyppi     in ('W','V','M')
+                        and tyyppi     in ('W','V','M','O')
                         and perheid    = '$tilrivirow[perheid]'";
               $updresult = pupe_query($query);
 


### PR DESCRIPTION
Kun valmisteella on sarjanumero, niin sarjanumeron syötön yhteydessä tehtiin uusi rivi sarjanumerolliselle tuotteelle, jota ei kuitenkaan päivitetty valmiiksi niin kuin valmistuksen muut rivit. Tästä seurasi se, että valmistetta oli myytävissä valmistuksen verran likaa. Saldo ja hyllyssä -luvut olivat oikein.