### PR TITLE
Tuotehaku: tuotetta ei löydy- ilmoitus

### DIFF
--- a/inc/tuotehaku.inc
+++ b/inc/tuotehaku.inc
@@ -308,7 +308,9 @@ if (!$enarimatch) {
       $row = pupe_query($query);
       $row = mysql_fetch_assoc($row);
 
-      $rows[$row["tuoteno"]] = $row;
+      if (!empty($row)) {
+        $rows[$row["tuoteno"]] = $row;
+      }
     }
 
     if (count($rows) >  200) {


### PR DESCRIPTION
Tuotetta lisättäessä myyntitilaukselle tuli aiemmin virheellisestä hausta "tuotetta ei löydy"-ilmoitus mikäli haulla ei yhtään tuotetta löytynyt. Nyt tähän oli kuitenkin tullut bugi ja ilmoitusta ei enää tullut, vaikka tuotetta ei olisi löytynytkään. Tämä on nyt korjattu ja jatkossa kun tuotetta ei löydy infromoidaan käyttäjää "tuotetta ei löydy"-ilmoituksella.