### PR TITLE
Magentotilausten sisäänluku: maksuehto korjaus

### DIFF
--- a/rajapinnat/edi.php
+++ b/rajapinnat/edi.php
@@ -13,7 +13,7 @@ class Edi {
   static function create($order) {
 
     // require 'magento_salasanat.php' muuttujat
-    global $magento_api_ht_edi, $ovt_tunnus, $pupesoft_tilaustyyppi;
+    global $magento_api_ht_edi, $ovt_tunnus, $pupesoft_tilaustyyppi, $magento_maksuehto_ohjaus;
     global $verkkokauppa_asiakasnro, $rahtikulu_tuoteno, $rahtikulu_nimitys, $verkkokauppa_erikoiskasittely;
 
     if (empty($magento_api_ht_edi) or empty($ovt_tunnus) or empty($pupesoft_tilaustyyppi)) exit("Parametrejä puuttuu\n");


### PR DESCRIPTION
Magentotilausten kanssa, jos oli käytössä usammasta magentomaksuehdosta yhteen Pupen maksuehtoon konversio tämä ei aivan toiminut vaan käyttöön tuli aina asiakkaan oletusmaksuehto. Nyt tämä on korjattu ja jatkossa käytetään aina ennalta määriteltyjä maksuehtomuunnoksia.