### PR TITLE
Laskutusajo: koontilaskut_alarajasumma

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -11472,8 +11472,6 @@ if (!function_exists("hae_yhtion_parametrit")) {
       }
     }
 
-    $yhtiorow['koontilaskut_alarajasumma'] = (float) $yhtiorow['koontilaskut_alarajasumma'];
-
     return $yhtiorow;
   }
 }

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -11472,6 +11472,8 @@ if (!function_exists("hae_yhtion_parametrit")) {
       }
     }
 
+    $yhtiorow['koontilaskut_alarajasumma'] = (float) $yhtiorow['koontilaskut_alarajasumma'];
+
     return $yhtiorow;
   }
 }

--- a/tilauskasittely/valitse_laskutettavat_tilaukset.php
+++ b/tilauskasittely/valitse_laskutettavat_tilaukset.php
@@ -507,7 +507,7 @@ if ($tee == "VALITSE") {
 
     mysql_data_seek($res, 0);
 
-    if (!empty($yhtiorow['koontilaskut_alarajasumma'])) {
+    if ((float) $yhtiorow['koontilaskut_alarajasumma'] > 0) {
       echo "<table>";
       echo "<tr>";
       echo "<th>",t("Koontilaskujen alarajasumma"),"</th>";
@@ -1175,7 +1175,7 @@ if ($tee == "") {
 
   if (mysql_num_rows($tilre) > 0) {
 
-    if (!empty($yhtiorow['koontilaskut_alarajasumma'])) {
+    if ((float) $yhtiorow['koontilaskut_alarajasumma'] > 0) {
       echo "<table>";
       echo "<tr>";
       echo "<th>",t("Koontilaskujen alarajasumma"),"</th>";

--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -912,7 +912,7 @@ else {
       $tulos_ulos .= $tulos_ulos_ehtosplit;
     }
 
-    if ($php_cli and !empty($yhtiorow['koontilaskut_alarajasumma'])) {
+    if ($php_cli and (float) $yhtiorow['koontilaskut_alarajasumma'] > 0) {
 
       // Tehdään ketjutus (group by PITÄÄ OLLA sama kuin alhaalla) rivi ~1243
       $query = "SELECT


### PR DESCRIPTION
Yhtiön parametri "Koontilaskut_alarajasumma" on pois päältä, jos siinä on arvo 0.00. Tästä huolimatta automaattisesti tapahtuvassa laskutusajossa ei voinut hyvityslaskuja laskuttaa, koska niiden summa oli alle tuon arvon. Korjattu nyt niin, että parametriä "Koontilaskut_alarajasumma" käsitellään oikein ja näin ollen myös hyvitykset saa laskutettua.