### PR TITLE
Myyntitilaus: keskihankintahinta ja kate korjaus

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -6207,7 +6207,6 @@ if ($tee == '') {
                tilausrivi.ale_peruste,
                tuote.tunnus as tuote_tunnus,
                concat_ws(' ', tilausrivi.hyllyalue, tilausrivi.hyllynro, tilausrivi.hyllyvali, tilausrivi.hyllytaso) paikka,
-               tuote.kehahin,
                $kommentti_select
                $sorttauskentta
                FROM tilausrivi use index (yhtio_otunnus)


### PR DESCRIPTION
Myyntitilauksen katelaskut eivät huomioineet tuotteen epäkuranttisuutta - sama virhe oli myös tuotteen keskihankitahintojen näyttämisessä. Tämä on nyt korjattu ja jatkossa epäkuranttisuus huomioidaan oikein näissä luvuissa.