### PR TITLE
Myyntitilaus: lähdön valitseminen

### DIFF
--- a/tilauskasittely/tilaus-valmis.inc
+++ b/tilauskasittely/tilaus-valmis.inc
@@ -329,6 +329,10 @@ elseif ($luottorajavirhe != '' or $ylivito > 0) {
     echo "<font class='error'>" . $errortext . t("Reklamaatiota ei merkitä valmiiksi"), ".</font><br/><br/>";
   }
   else {
+    if ($yhtiorow['kerayserat'] == 'K' and isset($toimitustavan_lahto) and is_string($toimitustavan_lahto)) {
+      $toimitustavan_lahto = unserialize(urldecode($toimitustavan_lahto));
+    }
+
     echo "<font class='error'>" . $errortext . t("Tilausta ei merkitä valmiiksi"), ".</font><br/><br/>";
   }
 }


### PR DESCRIPTION
Myyntitilausta valmiiksi laitettaessa, jos asiakkaan luottoraja ylittyi myyntitilauksen valmiiksi laitossa johti tämä ongelmaan lähdön valitsemisessa. Vaikka tämän jälkeen asiakaan luottoraja olisi muutettu tai myyntitilaukselta rivejä poistettu ja tilaus saatu laitettua valmiiksi epäonnistui lähdön valitseminen tilaukselle. Tämä on nyt korjattu ja jatkossa tähän ongelmaan ei pitäisi päätyä.