### PR TITLE
ABC tuote kulutus: aputaulunrakennuskorjaus

### DIFF
--- a/raportit/abc_tuote_aputaulun_rakennus.php
+++ b/raportit/abc_tuote_aputaulun_rakennus.php
@@ -110,7 +110,6 @@ if ($tee == 'YHTEENVETO') {
               FROM tilausrivi USE INDEX (yhtio_tyyppi_toimitettuaika)
               $tuotejoin
               JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio AND lasku.tunnus = tilausrivi.otunnus)
-              JOIN asiakas ON (asiakas.yhtio = lasku.yhtio AND asiakas.tunnus = lasku.liitostunnus AND asiakas.myynninseuranta = '')
               WHERE tilausrivi.yhtio        = '$kukarow[yhtio]'
               AND tilausrivi.tyyppi         = 'V'
               AND tilausrivi.toimitettuaika >= '$vva-$kka-$ppa 00:00:00'


### PR DESCRIPTION
ABC tuote kulutus raporttiin tarvittavaan ABC-aputaulun rakennukseen oli päässyt bugi joka esti kyseisen taulun rakentamisen. Koska taulua ei saatu rakennettua esti tämä myös koko ABC tuote kulutus raportin ajamisen.