### PR TITLE
* Tuotteen vientirajaukset maahryhmittäin

### DIFF
--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -186,7 +186,7 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "OLETUSPAIKKA")     $ulos .= "<option value='OLETUSPAIKKA' $avain_sel[OLETUSPAIKKA]>      ".t("Tuoteryhmän tai tuotestatuksen oletuspaikka")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "ELINKAARI")     $ulos .= "<option value='ELINKAARI' {$avain_sel['ELINKAARI']}>      ".t("Tuotteen elinkaarityyppi")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "KOPIOITUOTE") $ulos .= "<option value='KOPIOITUOTE' {$avain_sel['KOPIOITUOTE']}>      ".t("Kopioi tuote parametri")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "KIELIALUE") $ulos .= "<option value='KIELIALUE' {$avain_sel['KIELIALUE']}>".t("Sallittu kielialue")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "MAARYHMA") $ulos .= "<option value='MAARYHMA' {$avain_sel['MAARYHMA']}>".t("Sallittu maaryhmä")."</option>";
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
   if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Asiakkaiden avainsanat")."'>";

--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -186,6 +186,7 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "OLETUSPAIKKA")     $ulos .= "<option value='OLETUSPAIKKA' $avain_sel[OLETUSPAIKKA]>      ".t("Tuoteryhmän tai tuotestatuksen oletuspaikka")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "ELINKAARI")     $ulos .= "<option value='ELINKAARI' {$avain_sel['ELINKAARI']}>      ".t("Tuotteen elinkaarityyppi")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "KOPIOITUOTE") $ulos .= "<option value='KOPIOITUOTE' {$avain_sel['KOPIOITUOTE']}>      ".t("Kopioi tuote parametri")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "KIELIALUE") $ulos .= "<option value='KIELIALUE' {$avain_sel['KIELIALUE']}>".t("Sallittu kielialue")."</option>";
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
   if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Asiakkaiden avainsanat")."'>";

--- a/inc/tuoterivi.inc
+++ b/inc/tuoterivi.inc
@@ -133,18 +133,18 @@ if (mysql_field_name($result, $i) == "vienti") {
   $query = "SELECT *
             FROM avainsana
             WHERE yhtio = '{$kukarow['yhtio']}'
-            and laji    = 'kielialue'";
-  $kielialueres = pupe_query($query);
+            and laji    = 'maaryhma'";
+  $maaryhmares = pupe_query($query);
 
-  if (mysql_num_rows($kielialueres) > 0) {
+  if (mysql_num_rows($maaryhmares) > 0) {
     $ulos .= "&nbsp;";
 
-    $ulos .= "<select name='kielialue_vienti' ".js_alasvetoMaxWidth($nimi, 300).">";
-    $ulos .= "<option value = ''>".t("Ei kielialuetta")."</option>";
+    $ulos .= "<select name='maaryhma_vienti' ".js_alasvetoMaxWidth($nimi, 300).">";
+    $ulos .= "<option value = ''>".t("Ei maaryhm‰‰")."</option>";
 
-    while ($kielialuerow = mysql_fetch_assoc($kielialueres)) {
-      $sel = $trow[$i] == $kielialuerow['selite'] ? " selected" : "";
-      $ulos .= "<option value='{$kielialuerow['selite']}'{$sel}>{$kielialuerow['selitetark']}</option>";
+    while ($maaryhmarow = mysql_fetch_assoc($maaryhmares)) {
+      $sel = $trow[$i] == $maaryhmarow['selite'] ? " selected" : "";
+      $ulos .= "<option value='{$maaryhmarow['selite']}'{$sel}>{$maaryhmarow['selitetark']}</option>";
     }
 
     $ulos .= "</select>";

--- a/inc/tuoterivi.inc
+++ b/inc/tuoterivi.inc
@@ -126,6 +126,35 @@ if (mysql_field_name($result, $i) == "tuotetyyppi") {
   $jatko=0;
 }
 
+if (mysql_field_name($result, $i) == "vienti") {
+  $ulos = "<td>";
+  $ulos .= "<input type='text' name='{$nimi}' value='{$trow[$i]}' />";
+
+  $query = "SELECT *
+            FROM avainsana
+            WHERE yhtio = '{$kukarow['yhtio']}'
+            and laji    = 'kielialue'";
+  $kielialueres = pupe_query($query);
+
+  if (mysql_num_rows($kielialueres) > 0) {
+    $ulos .= "&nbsp;";
+
+    $ulos .= "<select name='kielialue_vienti' ".js_alasvetoMaxWidth($nimi, 300).">";
+    $ulos .= "<option value = ''>".t("Ei kielialuetta")."</option>";
+
+    while ($kielialuerow = mysql_fetch_assoc($kielialueres)) {
+      $sel = $trow[$i] == $kielialuerow['selite'] ? " selected" : "";
+      $ulos .= "<option value='{$kielialuerow['selite']}'{$sel}>{$kielialuerow['selitetark']}</option>";
+    }
+
+    $ulos .= "</select>";
+  }
+
+  $ulos .= "</td>";
+
+  $jatko = 0;
+}
+
 if (mysql_field_name($result, $i) == "myynninseuranta") {
   $sel = $trow[$i] == "E" ? " selected" : "";
 

--- a/inc/tuotteen_avainsanatrivi.inc
+++ b/inc/tuotteen_avainsanatrivi.inc
@@ -33,6 +33,7 @@ if (mysql_field_name($result, $i) == "laji") {
   $ulos .= "<option value='toimpalautus' {$sel['toimpalautus']}>".t("Palautus toimittajalle")."</option>";
   $ulos .= "<option value='varastopalautus' {$sel['varastopalautus']}>".t("Palautus sallittuihin varastoihin")."</option>";
   $ulos .= "<option value='hinnastoryhmittely' {$sel['hinnastoryhmittely']}>".t("hinnastoryhmittely")."</option>";
+  $ulos .= "<option value='kielialue' {$sel['kielialue']}>".t("Sallittu kielialue")."</option>";
 
   // Tuotteiden avainsanojen laji
   // N‰m‰ on dynaamisia ja k‰ytet‰‰n ainoastaan raporteissa/erikoistapauksissa, johon erikseen hardcoodattu sovittu arvo.
@@ -91,6 +92,24 @@ if (mysql_field_name($result, $i) == "selite") {
 
       $ulos .= "</select></td>";
     }
+
+    $jatko = 0;
+  }
+  elseif (strtolower($tem_laji) == "kielialue") {
+    $vresult = t_avainsana("KIELIALUE");
+
+    $ulos = "<td><select name='{$nimi}'>";
+    $ulos .= "<option value=''>".t("Ei kielialuetta")."</option>";
+
+    if (mysql_num_rows($vresult) > 0) {
+
+      while ($vrow = mysql_fetch_assoc($vresult)) {
+        $sel = $trow[$i] == $vrow['selite'] ? 'selected' : '';
+        $ulos .= "<option value='{$vrow['selite']}' {$sel}>{$vrow['selitetark']}</option>";
+      }
+    }
+
+    $ulos .= "</select></td>";
 
     $jatko = 0;
   }

--- a/inc/tuotteen_avainsanatrivi.inc
+++ b/inc/tuotteen_avainsanatrivi.inc
@@ -33,7 +33,6 @@ if (mysql_field_name($result, $i) == "laji") {
   $ulos .= "<option value='toimpalautus' {$sel['toimpalautus']}>".t("Palautus toimittajalle")."</option>";
   $ulos .= "<option value='varastopalautus' {$sel['varastopalautus']}>".t("Palautus sallittuihin varastoihin")."</option>";
   $ulos .= "<option value='hinnastoryhmittely' {$sel['hinnastoryhmittely']}>".t("hinnastoryhmittely")."</option>";
-  $ulos .= "<option value='kielialue' {$sel['kielialue']}>".t("Sallittu kielialue")."</option>";
 
   // Tuotteiden avainsanojen laji
   // N‰m‰ on dynaamisia ja k‰ytet‰‰n ainoastaan raporteissa/erikoistapauksissa, johon erikseen hardcoodattu sovittu arvo.
@@ -92,24 +91,6 @@ if (mysql_field_name($result, $i) == "selite") {
 
       $ulos .= "</select></td>";
     }
-
-    $jatko = 0;
-  }
-  elseif (strtolower($tem_laji) == "kielialue") {
-    $vresult = t_avainsana("KIELIALUE");
-
-    $ulos = "<td><select name='{$nimi}'>";
-    $ulos .= "<option value=''>".t("Ei kielialuetta")."</option>";
-
-    if (mysql_num_rows($vresult) > 0) {
-
-      while ($vrow = mysql_fetch_assoc($vresult)) {
-        $sel = $trow[$i] == $vrow['selite'] ? 'selected' : '';
-        $ulos .= "<option value='{$vrow['selite']}' {$sel}>{$vrow['selitetark']}</option>";
-      }
-    }
-
-    $ulos .= "</select></td>";
 
     $jatko = 0;
   }

--- a/lue_data.php
+++ b/lue_data.php
@@ -583,6 +583,22 @@ if ($kasitellaan_tiedosto) {
     }
   }
 
+  // Tarkistetaan käytetäänkö maaryhmiä
+  if (in_array("tuote", $taulut)) {
+    $maaryhmaquery = "SELECT *
+                       FROM avainsana
+                       WHERE yhtio = '{$kukarow['yhtio']}'
+                       and laji    = 'maaryhma'
+                       and selite != ''
+                       ORDER BY jarjestys";
+    $maaryhmares = pupe_query($maaryhmaquery);
+
+    $maaryhma_kaytossa = mysql_num_rows($maaryhmares) > 0 ? true : false;
+  }
+  else {
+    $maaryhma_kaytossa = false;
+  }
+
   /*
   foreach ($taulunrivit as $taulu => $rivit) {
 
@@ -1565,22 +1581,22 @@ if ($kasitellaan_tiedosto) {
               }
             }
 
-            if ($table_mysql == 'tuote' and $otsikko == 'VIENTI' and $taulunrivit[$taulu][$eriviindex][$r] != "") {
+            if ($maaryhma_kaytossa and $table_mysql == 'tuote' and $otsikko == 'VIENTI' and $taulunrivit[$taulu][$eriviindex][$r] != "") {
 
               $_selitetark = mysql_real_escape_string($taulunrivit[$taulu][$eriviindex][$r]);
 
-              $kielialuequery = "SELECT *
+              $maaryhmaquery = "SELECT *
                                  FROM avainsana
                                  WHERE yhtio = '{$kukarow['yhtio']}'
-                                 and laji    = 'kielialue'
+                                 and laji    = 'maaryhma'
                                  and selite != ''
                                  and selitetark = '{$_selitetark}'
                                  ORDER BY jarjestys";
-              $kielialueres = pupe_query($kielialuequery);
+              $maaryhmares = pupe_query($maaryhmaquery);
 
-              if (mysql_num_rows($kielialueres) > 0) {
-                $kielialuerow = mysql_fetch_assoc($kielialueres);
-                $taulunrivit[$taulu][$eriviindex][$r] = $kielialuerow['selite'];
+              if (mysql_num_rows($maaryhmares) > 0) {
+                $maaryhmarow = mysql_fetch_assoc($maaryhmares);
+                $taulunrivit[$taulu][$eriviindex][$r] = $maaryhmarow['selite'];
               }
             }
 

--- a/lue_data.php
+++ b/lue_data.php
@@ -1565,6 +1565,25 @@ if ($kasitellaan_tiedosto) {
               }
             }
 
+            if ($table_mysql == 'tuote' and $otsikko == 'VIENTI' and $taulunrivit[$taulu][$eriviindex][$r] != "") {
+
+              $_selitetark = mysql_real_escape_string($taulunrivit[$taulu][$eriviindex][$r]);
+
+              $kielialuequery = "SELECT *
+                                 FROM avainsana
+                                 WHERE yhtio = '{$kukarow['yhtio']}'
+                                 and laji    = 'kielialue'
+                                 and selite != ''
+                                 and selitetark = '{$_selitetark}'
+                                 ORDER BY jarjestys";
+              $kielialueres = pupe_query($kielialuequery);
+
+              if (mysql_num_rows($kielialueres) > 0) {
+                $kielialuerow = mysql_fetch_assoc($kielialueres);
+                $taulunrivit[$taulu][$eriviindex][$r] = $kielialuerow['selite'];
+              }
+            }
+
             if ($table_mysql == 'tuote' and ($otsikko == 'EPAKURANTTI25PVM' or $otsikko == 'EPAKURANTTI50PVM' or $otsikko == 'EPAKURANTTI75PVM' or $otsikko == 'EPAKURANTTI100PVM') and $taulunrivit[$taulu][$eriviindex][$r] != "") {
 
               if (trim($taulunrivit[$taulu][$eriviindex][$r]) != '' and trim($taulunrivit[$taulu][$eriviindex][$r]) != '0000-00-00' and $otsikko == 'EPAKURANTTI100PVM') {

--- a/yllapito.php
+++ b/yllapito.php
@@ -489,6 +489,10 @@ if ($upd == 1) {
             }
           }
 
+          if ($toim == 'tuote' and mysql_field_name($result, $i) == 'vienti' and !empty($kielialue_vienti)) {
+            $t[$i] = $kielialue_vienti;
+          }
+
           if (mysql_field_type($result, $i) == 'real') {
             $t[$i] = $t[$i] != "NULL" ? "'".(float) str_replace(",", ".", $t[$i])."'" : $t[$i];
 

--- a/yllapito.php
+++ b/yllapito.php
@@ -489,8 +489,8 @@ if ($upd == 1) {
             }
           }
 
-          if ($toim == 'tuote' and mysql_field_name($result, $i) == 'vienti' and !empty($kielialue_vienti)) {
-            $t[$i] = $kielialue_vienti;
+          if ($toim == 'tuote' and mysql_field_name($result, $i) == 'vienti' and !empty($maaryhma_vienti)) {
+            $t[$i] = $maaryhma_vienti;
           }
 
           if (mysql_field_type($result, $i) == 'real') {


### PR DESCRIPTION
Sallitut kielialueet määritellään yhtiön avainsanoissa. Tämän jälkeen tuotteen ylläpidossa voi valita halutun kielialueen "Sallitut maat"-kentän alasvetovalikosta. Jos alasvetovalikosta on valittuna muu kuin "Ei kielialuetta", yli ajaa tämä "Sallitut maat"-syöttökentän arvot tallennuksen yhteydessä.

Kielialueen selite on samaa muotoa kuin olemassa olevat "sallitut maat" eli maakoodeja pilkulla eroteltuna.