### PR TITLE
Myyntitilaus: poikkeuksellinen nimitys tilausrivillä

### DIFF
--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -737,11 +737,10 @@ if (!function_exists("tee_jt_tilaus")) {
               $kommentti .= trim($lisataanrow['kommentti']);
             }
 
-            // Rivin
+            // Rivin nimitys voi olla ollut käsinsyötetty, joten otetaan se tässä talteen
             $tuotenimitys = "";
 
             if (trim($lisataanrow['nimitys']) != "" and !empty($yhtiorow["nimityksen_muutos_tilauksella"])) {
-              // Tilausriville ollaan voitu syöttä speciaali nimitys -> talnteen
               $tuotenimitys = trim($lisataanrow['nimitys']);
             }
 

--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -737,6 +737,14 @@ if (!function_exists("tee_jt_tilaus")) {
               $kommentti .= trim($lisataanrow['kommentti']);
             }
 
+            // Rivin
+            $tuotenimitys = "";
+
+            if (trim($lisataanrow['nimitys']) != "" and !empty($yhtiorow["nimityksen_muutos_tilauksella"])) {
+              // Tilausriville ollaan voitu syöttä speciaali nimitys -> talnteen
+              $tuotenimitys = trim($lisataanrow['nimitys']);
+            }
+
             unset($orig_laskurow);
 
             if ($lisataanrow["vanha_otunnus"] > 0) {


### PR DESCRIPTION
Myyntitilaukselle on mahdollista määritellä poikkeavia nimityksiä. Nyt jos tälläisen poikkeavan nimityksen omaava tilausrivi jäi jälkitoimitukseen ei tämä poikkeava nimitys seurannut tilausrivin mukana jälkitoimitusrivin vapautuksessa. Laitettiin poikkeava nimi seuraamaan jälkitoimitusrivin vapautuksessa mukana.