### PR TITLE
Generoi tuotepaikkoja: korjaus

### DIFF
--- a/generoi_tuotepaikkoja.php
+++ b/generoi_tuotepaikkoja.php
@@ -28,7 +28,8 @@ require "inc/functions.inc";
 // Generoidaan jokaiselle yhtiön tuotteelle tuotepaikka jokaiseen yhtiön varastoon
 $query = "SELECT *
           FROM varastopaikat
-          WHERE yhtio = '$yhtio'";
+          WHERE yhtio = '$yhtio'
+          AND alkuhyllyalue != '!!M'";
 $varastoresult = pupe_query($query);
 
 // Kaikki tuotteet
@@ -50,7 +51,7 @@ while ($tuoterow = mysql_fetch_assoc($tuoteresult)) {
               AND varasto = '$varastorow[tunnus]'";
     $paikkaresult = pupe_query($query);
 
-    if (mysql_num_rows($paikkaresult) == 0 and $varastorow["alkuhyllyalue"] != "!!M") {
+    if (mysql_num_rows($paikkaresult) == 0) {
       lisaa_tuotepaikka($tuoterow["tuoteno"], $varastorow["alkuhyllyalue"], $varastorow["alkuhyllynro"], '0', '0', 'Lisättiin tuotepaikka generoinnissa');
     }
   }

--- a/generoi_tuotepaikkoja.php
+++ b/generoi_tuotepaikkoja.php
@@ -13,7 +13,7 @@ if (!isset($argv[1]) or $argv[1] == '') {
   exit(1);
 }
 else {
-  $yhtio = $argv[1];
+  $kukarow['yhtio'] = $yhtio = $argv[1];
 }
 
 // otetaan includepath aina rootista
@@ -50,8 +50,8 @@ while ($tuoterow = mysql_fetch_assoc($tuoteresult)) {
               AND varasto = '$varastorow[tunnus]'";
     $paikkaresult = pupe_query($query);
 
-    if (mysql_num_rows($paikkaresult) == 0) {
-      lisaa_tuotepaikka($tuoterow["tuoteno"], $varastorow["alkuhyllyalue"], $varastorow["hyllynro"], '0', '0', 'Lisättiin tuotepaikka generoinnissa');
+    if (mysql_num_rows($paikkaresult) == 0 and $varastorow["alkuhyllyalue"] != "!!M") {
+      lisaa_tuotepaikka($tuoterow["tuoteno"], $varastorow["alkuhyllyalue"], $varastorow["alkuhyllynro"], '0', '0', 'Lisättiin tuotepaikka generoinnissa');
     }
   }
 


### PR DESCRIPTION
Generoi tuoteppaikkoja ohjelma perusti tuotepaikkoja vailinaisilla tiedoilla, mikä teki uusista tuotepaikoista rikkinäisiä. Niitä ei näkynyt missää eikä niitä voinut siis käyttää. Tämän lisäksi tuotepaikkojen automaattigenerointiohjelma perusti tuotepaikan myyntitilivarastoon mikäli sellainen löytyi - tätä ei kuuluisi tehdä sillä myyntitilivarastossa kuuluu olla pelkästään asiakaskohtaisia tuotepaikkoja. Molemmat ongelmat on nyt korjattu ja jatkossa generoi tuotepaikkoja osaa perustaa tuotepaikat oikein.