### PR TITLE
Presta tuotteen näkyvyys

### DIFF
--- a/rajapinnat/presta/presta_functions.php
+++ b/rajapinnat/presta/presta_functions.php
@@ -217,8 +217,6 @@ function hae_tuotteet() {
             FROM tuote
             WHERE tuote.yhtio = '{$kukarow['yhtio']}'
             {$tuoterajaus}";
-            echo $query;
-            exit;
   $res = pupe_query($query);
   $dnstuote = array();
 

--- a/rajapinnat/presta/presta_functions.php
+++ b/rajapinnat/presta/presta_functions.php
@@ -288,6 +288,7 @@ function hae_tuotteet() {
       'nakyvyys'                  => $row["nakyvyys"],
       'nimi'                      => $row["nimitys"],
       'osasto'                    => $row["osasto"],
+      'status'                    => $row["status"],
       'try'                       => $row["try"],
       'tunnus'                    => $row['tunnus'],
       'tuotemassa'                => $row["tuotemassa"],

--- a/rajapinnat/presta/presta_products.php
+++ b/rajapinnat/presta/presta_products.php
@@ -54,6 +54,24 @@ class PrestaProducts extends PrestaClient {
     $xml->product->price = $product['myyntihinta'];
     $xml->product->wholesale_price = $product['myyntihinta'];
 
+    // by default product is visible everywhere
+    // values: both, catalog, search, none
+    $visibility = 'both';
+
+    // if we are moving all products to presta, hide the product if we don't want to show it
+    if ($this->visibility_type == 2) {
+      if (empty($product['nakyvyys'])) {
+        $this->logger->log("Tuote '{$product['tuoteno']}' n‰kyvyys tyhj‰‰, ei n‰ytet‰ verkkokaupassa.");
+        $visibility = 'none';
+      }
+      elseif ($product['status'] == 'P' and $product['saldo'] <= 0) {
+        $this->logger->log("Tuote '{$product['tuoteno']}' poistettu ja ei saldoa, ei n‰ytet‰ verkkokaupassa.");
+        $visibility = 'none';
+      }
+    }
+
+    $xml->product->visibility = $visibility;
+
     $xml->product->id_tax_rules_group = $this->get_tax_group_id($product["alv"]);
 
     $xml->product->width  = str_replace(",", ".", $product['tuoteleveys']);

--- a/rajapinnat/presta/presta_products.php
+++ b/rajapinnat/presta/presta_products.php
@@ -23,6 +23,7 @@ class PrestaProducts extends PrestaClient {
   private $presta_all_products = null;
   private $tax_rates_table = null;
   private $languages_table = null;
+  private $visibility_type = null;
 
   // Päivitetäänkö tuotekategoriat
   private $_category_sync = true;
@@ -340,5 +341,9 @@ class PrestaProducts extends PrestaClient {
     if (is_array($value)) {
       $this->languages_table = $value;
     }
+  }
+
+  public function set_visibility_type($value) {
+    $this->visibility_type = $value;
   }
 }

--- a/rajapinnat/presta/presta_products.php
+++ b/rajapinnat/presta/presta_products.php
@@ -7,26 +7,16 @@ class PrestaProducts extends PrestaClient {
 
   const RESOURCE = 'products';
 
-  /**
-  * Dynaamiset tuoteparametrien lista
-  */
+  private $_category_sync = true;
   private $_dynamic_fields = array();
-
-  /**
-   * Ohitettavien tuoteparametrien lista
-   */
   private $_removable_fields = array();
-
+  private $languages_table = null;
+  private $presta_all_products = null;
   private $presta_categories = null;
   private $presta_home_category_id = null;
   private $pupesoft_all_products = null;
-  private $presta_all_products = null;
   private $tax_rates_table = null;
-  private $languages_table = null;
   private $visibility_type = null;
-
-  // Päivitetäänkö tuotekategoriat
-  private $_category_sync = true;
 
   public function __construct($url, $api_key, $presta_home_category_id) {
     $this->presta_categories = new PrestaCategories($url, $api_key, $presta_home_category_id);

--- a/rajapinnat/presta/presta_tuote_export.php
+++ b/rajapinnat/presta/presta_tuote_export.php
@@ -151,6 +151,11 @@ if (!isset($presta_valuuttakoodit)) {
     // "EUR" => 2,
   );
 }
+if (!isset($presta_tuotekasittely)) {
+  // 1 = siirretään tuotteet joiden status != 'P' ja nakyvyys != ''
+  // 2 = siirretään kaikki pupen tuotteet prestaan (poistetutkin), mutta merkataan ne hiddeniksi
+  $presta_tuotekasittely = 1;
+}
 
 // Haetaan timestamp
 $datetime_checkpoint_res = t_avainsana("TUOTE_EXP_CRON");

--- a/rajapinnat/presta/presta_tuote_export.php
+++ b/rajapinnat/presta/presta_tuote_export.php
@@ -187,13 +187,15 @@ if (array_key_exists('tuotteet', $synkronoi)) {
 
   echo date("d.m.Y @ G:i:s")." - Siirretään tuotetiedot.\n";
   $presta_products = new PrestaProducts($presta_url, $presta_api_key, $presta_home_category_id);
-  $presta_products->set_dynamic_fields($presta_dynaamiset_tuoteparametrit);
-  $presta_products->set_removable_fields($presta_ohita_tuoteparametrit);
-  $presta_products->set_category_sync($presta_synkronoi_tuotepuu);
-  $presta_products->set_tax_rates_table($presta_verokannat);
-  $presta_products->set_languages_table($presta_kieliversiot);
+
   $presta_products->set_all_products($kaikki_tuotteet);
+  $presta_products->set_category_sync($presta_synkronoi_tuotepuu);
+  $presta_products->set_dynamic_fields($presta_dynaamiset_tuoteparametrit);
+  $presta_products->set_languages_table($presta_kieliversiot);
+  $presta_products->set_removable_fields($presta_ohita_tuoteparametrit);
+  $presta_products->set_tax_rates_table($presta_verokannat);
   $presta_products->set_visibility_type($presta_tuotekasittely);
+
   $presta_products->sync_products($tuotteet);
 }
 

--- a/rajapinnat/presta/presta_tuote_export.php
+++ b/rajapinnat/presta/presta_tuote_export.php
@@ -193,6 +193,7 @@ if (array_key_exists('tuotteet', $synkronoi)) {
   $presta_products->set_tax_rates_table($presta_verokannat);
   $presta_products->set_languages_table($presta_kieliversiot);
   $presta_products->set_all_products($kaikki_tuotteet);
+  $presta_products->set_visibility_type($presta_tuotekasittely);
   $presta_products->sync_products($tuotteet);
 }
 


### PR DESCRIPTION
Voidaan siirtää kaikki Pupesoftin tuotteet Prestaan ja piilottaa tuotteet verkkokaupassa, joita ei haluta näyttää. Huom, siirtää myös poistetut tuotteet.

Tuote piilotetaan verkkokaupassa jos nakyvyys -kenttä on tyhjää, tai tuote on poistettu ja sillä ei ole saldoa.