### PR TITLE
Ostotilaus: uuden rivin kentät

### DIFF
--- a/tilauskasittely/syotarivi_ostotilaus.inc
+++ b/tilauskasittely/syotarivi_ostotilaus.inc
@@ -63,7 +63,6 @@ if ($variaaritorivi === FALSE) {
       <tr>
       <th>".t("Tuoteno")."</th>
       <th>".t("M‰‰r‰")."</th>
-      <th>".t("M‰‰r‰")."</th>
       <th>".t("Hinta")."</th>";
 
   for ($alepostfix = 1; $alepostfix <= $yhtiorow['oston_alekentat']; $alepostfix++) {
@@ -95,9 +94,8 @@ if ($variaaritorivi === FALSE) {
     }
   }
 
-  echo "<td>$kpl</td>
-    <td><input type='text' size='7' name='kpl' value = '$kpl'></td>
-    <td><input type='text' size='7' name='hinta' value = '$hinta'></td>";
+  echo "<td><input type='text' size='7' name='kpl' value = '$kpl'></td>
+        <td><input type='text' size='7' name='hinta' value = '$hinta'></td>";
 
   $backspan = 5;
   for ($alepostfix = 1; $alepostfix <= $yhtiorow['oston_alekentat']; $alepostfix++) {


### PR DESCRIPTION
Ostotilauksella oli kaksi määrä kenttää uuden rivin syöttössä. Toista kenttä ei pystynyt muokkaamaan ja toinen kenttä oli sellainen, että siihen pystyi syöttämään arvoja. Poistettiin tämä toinen ylimääräinen määrä kenttä.