### PR TITLE
Presta yhteensopivuus

### DIFF
--- a/rajapinnat/presta/presta_product_stocks.php
+++ b/rajapinnat/presta/presta_product_stocks.php
@@ -29,6 +29,9 @@ class PrestaProductStocks extends PrestaClient {
       $xml = $existing_stock;
     }
 
+    // we need to floor quantity, as Presta does not allow decimal numbers
+    $quantity = is_numeric($stock['saldo']) ? floor($stock['saldo']) : 0;
+
     $xml->stock_available->quantity = $stock['saldo'];
     $xml->stock_available->id_product = $stock['product_id'];
 

--- a/rajapinnat/presta/presta_products.php
+++ b/rajapinnat/presta/presta_products.php
@@ -62,7 +62,7 @@ class PrestaProducts extends PrestaClient {
 
     $xml->product->reference = utf8_encode($product['tuoteno']);
     $xml->product->supplier_reference = utf8_encode($product['tuoteno']);
-    $xml->product->ean13 = utf8_encode($product['ean']);
+    $xml->product->ean13 = is_numeric($product['ean']) ? $product['ean'] : '';
 
     $xml->product->price = $product['myyntihinta'];
     $xml->product->wholesale_price = $product['myyntihinta'];
@@ -109,7 +109,7 @@ class PrestaProducts extends PrestaClient {
 
     // we must set these for all languages
     for ($i=0; $i < $languages; $i++) {
-      $xml->product->name->language[$i]              = utf8_encode($product['nimi']);
+      $xml->product->name->language[$i]              = empty($product['nimi']) ? '-' : utf8_encode($product['nimi']);
       $xml->product->description->language[$i]       = utf8_encode($product['kuvaus']);
       $xml->product->description_short->language[$i] = utf8_encode($product['lyhytkuvaus']);
       $xml->product->link_rewrite->language[$i]      = $this->saniteze_link_rewrite("{$product['tuoteno']}_{$product['nimi']}");
@@ -479,6 +479,12 @@ class PrestaProducts extends PrestaClient {
 
       $current++;
       $this->logger->log("[{$current}/{$total}] tuote {$sku} ({$product_id}) saldo {$stock}");
+
+      // could not find product or
+      // this is a virtual product, no stock management
+      if ($product_id === false or $stock === null) {
+        continue;
+      }
 
       $this->presta_stock->create_or_update($product_id, $stock);
     }

--- a/rajapinnat/presta/presta_specific_prices.php
+++ b/rajapinnat/presta/presta_specific_prices.php
@@ -65,12 +65,14 @@ class PrestaSpecificPrices extends PrestaClient {
       $xml->specific_price->from_quantity = $specific_price['minkpl'];
     }
 
+    $currency_id = empty($specific_price['valkoodi']) ? 0 : $this->get_currency_id($specific_price['valkoodi']);
+
     $xml->specific_price->id_product = $specific_price['presta_product_id'];
     $xml->specific_price->reduction_type = 'amount';
     $xml->specific_price->reduction = 0;
     $xml->specific_price->id_shop = $this->shop['id'];
     $xml->specific_price->id_cart = 0;
-    $xml->specific_price->id_currency = $this->get_currency_id($specific_price['valkoodi']);
+    $xml->specific_price->id_currency = $currency_id;
     $xml->specific_price->id_country = 0;
 
     // price or percentage
@@ -229,6 +231,11 @@ class PrestaSpecificPrices extends PrestaClient {
   }
 
   private function get_currency_id($code) {
+    if (empty($code) or !isset($this->currency_codes[$code])) {
+      // zero means "all currencies"
+      return 0;
+    }
+
     $value = $this->currency_codes[$code];
 
     if (empty($value)) {

--- a/rajapinnat/presta/presta_specific_prices.php
+++ b/rajapinnat/presta/presta_specific_prices.php
@@ -132,6 +132,11 @@ class PrestaSpecificPrices extends PrestaClient {
             continue;
           }
 
+          if (!empty($price['hinta']) and empty($price['valkoodi'])) {
+            $this->logger->log("Ohitettu special price tuotteelle {$price['tuoteno']} koska hinnalla {$price['hinta']} ei ole valuuttaa!");
+            continue;
+          }
+
           $this->create($price);
 
           $message = "Lisätty tuotteelle '{$price['tuoteno']}'";


### PR DESCRIPTION
* Saldottomien tuotteiden saldoksi null
* Pyöristetään saldot alaspäin, Presta ei tue desimaalilukuja saldoissa
* Sallitaan vaan numeeriset EAN koodit
* Jos nimi on tyhjää, laitetaan "-", koska nimi on pakollinen
* Merkataan tuntemattomat valuutat "all"
* Ohitetaan asiakashinnat, jos hinnalla ei ole valuuttaa 