### PR TITLE
Lähete: automaattinen kielivalinta

### DIFF
--- a/tilauskasittely/tulosta_lahete.inc
+++ b/tilauskasittely/tulosta_lahete.inc
@@ -7,7 +7,7 @@ if ($kieli == '') {
   $querykiel = "SELECT kieli
                 FROM asiakas
                 WHERE yhtio = '$kukarow[yhtio]'
-                and ytunnus = '$laskurow[ytunnus]'";
+                and tunnus = '$laskurow[liitostunnus]'";
   $kielresult = pupe_query($querykiel);
   $kielrow = mysql_fetch_assoc($kielresult);
 


### PR DESCRIPTION
Automaattinen kielivalinta saatettiin joissain tilanteissa tehdä ytunnuksen perusteella. Tämä saattoi aiheuttaa ongelmia, mikäli samalla ytunnuksella oli eri asiakkuuksia perustettuna, joille oli määriteltynä eri kielet. Tällöin lähete ei välttämättä tulostunut lähetteen asiakkuuden kielellä vaan jollain jonkin toisen saman ytunnuksen asiakkuuden kielellä.