### PR TITLE
Ennakkolaskulle miinus rivi

### DIFF
--- a/maksusopimus_laskutukseen.php
+++ b/maksusopimus_laskutukseen.php
@@ -257,7 +257,7 @@ if (!function_exists("ennakkolaskuta")) {
     $query = "SELECT
               sum(if (tilausrivi.jaksotettu=lasku.jaksotettu, tilausrivi.hinta / if ('$yhtiorow[alv_kasittely]' = '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.jt) * {$query_ale_lisa}, 0)) jaksotettavaa
               FROM lasku
-              JOIN tilausrivi ON tilausrivi.yhtio = lasku.yhtio and tilausrivi.otunnus = lasku.tunnus and tilausrivi.tyyppi = 'L' and (tilausrivi.varattu+tilausrivi.jt) > 0 and tilausrivi.jaksotettu=lasku.jaksotettu
+              JOIN tilausrivi ON tilausrivi.yhtio = lasku.yhtio and tilausrivi.otunnus = lasku.tunnus and tilausrivi.tyyppi = 'L' and tilausrivi.jaksotettu=lasku.jaksotettu
               WHERE lasku.yhtio    = '$kukarow[yhtio]'
               and lasku.jaksotettu = '$tunnus'
               GROUP by lasku.jaksotettu";
@@ -278,7 +278,7 @@ if (!function_exists("ennakkolaskuta")) {
                 if (tilausrivi.jaksotettu=lasku.jaksotettu, tilausrivi.hinta / if ('{$yhtiorow['alv_kasittely']}' = '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1), 0) summa,
                 if (tilausrivi.alv >= 600 or tilausrivi.alv < 500, tilausrivi.alv, 0) alv
                 FROM lasku
-                JOIN tilausrivi ON (tilausrivi.yhtio = lasku.yhtio and tilausrivi.otunnus = lasku.tunnus and tilausrivi.tyyppi = 'L' and (tilausrivi.varattu + tilausrivi.jt) > 0 and tilausrivi.jaksotettu = lasku.jaksotettu)
+                JOIN tilausrivi ON (tilausrivi.yhtio = lasku.yhtio and tilausrivi.otunnus = lasku.tunnus and tilausrivi.tyyppi = 'L' and tilausrivi.jaksotettu = lasku.jaksotettu)
                 WHERE lasku.yhtio    = '$kukarow[yhtio]'
                 and lasku.jaksotettu = '$tunnus'";
     }
@@ -287,7 +287,7 @@ if (!function_exists("ennakkolaskuta")) {
                 sum(if (tilausrivi.jaksotettu=lasku.jaksotettu, tilausrivi.hinta / if ('{$yhtiorow['alv_kasittely']}' = '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.jt) * {$query_ale_lisa}, 0)) summa,
                 if (tilausrivi.alv >= 600 or tilausrivi.alv < 500, tilausrivi.alv, 0) alv
                 FROM lasku
-                JOIN tilausrivi ON (tilausrivi.yhtio = lasku.yhtio and tilausrivi.otunnus = lasku.tunnus and tilausrivi.tyyppi = 'L' and (tilausrivi.varattu + tilausrivi.jt) > 0 and tilausrivi.jaksotettu = lasku.jaksotettu)
+                JOIN tilausrivi ON (tilausrivi.yhtio = lasku.yhtio and tilausrivi.otunnus = lasku.tunnus and tilausrivi.tyyppi = 'L' and tilausrivi.jaksotettu = lasku.jaksotettu)
                 WHERE lasku.yhtio    = '$kukarow[yhtio]'
                 and lasku.jaksotettu = '$tunnus'
                 GROUP BY lasku.jaksotettu, alv";


### PR DESCRIPTION
Sallitaan negatiiviset rivit ennakkolaskulla. Ennakkolaskun tulee kuitenkin olla yhteensä positiivinen.

Aikaisemmin ennakkolaskulla ei osattu piirtää negatiivisia rivejä, ja ennakkolaskun summa jyvitettiin tasaisesti positiivisille riveille. Jatkossa osataan näyttää myös negatiiviset rivit.