### PR TITLE
Reklamaatiot: purkulistakorjaus

### DIFF
--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -152,15 +152,14 @@ if (!function_exists('alku_kerayslista')) {
       //maksuehto tekstinä
       $maksuehto = t_tunnus_avainsanat($masrow, "teksti", "MAKSUEHTOKV", $kieli);
 
-      $pdf->draw_text(410, 815, $laskurow["hyvaksynnanmuutos"],   $thispage, $iso);
+      $pdf->draw_text(550, 815, $laskurow["hyvaksynnanmuutos"],   $thispage, $iso);
       $prioriteetin_kuvaus = ($laskurow["hyvaksynnanmuutos"] != "") ? t_avainsana("ASIAKASLUOKKA", $kieli, "and avainsana.selite = '{$laskurow["hyvaksynnanmuutos"]}'", "", "", "selitetark") : "X";
 
       if ($tyyppi == "SIIRTOLISTA") {
         $pdf->draw_text(310, 815, t("Siirtolista", $kieli),     $thispage, $iso);
       }
       elseif ($tyyppi == "REKLAMAATIO") {
-        list($ff_string, $ff_font) = pdf_fontfit(t("Reklamaatio/Purkulista", $kieli), 200, $pdf, $iso);
-        $pdf->draw_text(240, 815, $ff_string, $thispage, $ff_font);
+        $pdf->draw_text(310, 815, t("Reklamaatio/Purkulista", $kieli), $thispage, $iso);
       }
       elseif ($tyyppi == "TAKUU") {
         $pdf->draw_text(310, 815, t("Takuu", $kieli),     $thispage, $iso);
@@ -528,14 +527,13 @@ if (!function_exists('uusi_sivu_kerayslista')) {
 
     tulosta_logo_pdf($pdf, $thispage, $laskurow);
 
-    $pdf->draw_text(410, 815, $laskurow["hyvaksynnanmuutos"],       $thispage, $iso);
+    $pdf->draw_text(550, 815, $laskurow["hyvaksynnanmuutos"],       $thispage, $iso);
 
     if ($tyyppi == "SIIRTOLISTA") {
       $pdf->draw_text(310, 815, t("Siirtolista", $kieli),         $thispage, $iso);
     }
     elseif ($tyyppi == "REKLAMAATIO") {
-      list($ff_string, $ff_font) = pdf_fontfit(t("Reklamaatio/Purkulista", $kieli), 200, $pdf, $iso);
-      $pdf->draw_text(240, 815, $ff_string, $thispage, $ff_font);
+      $pdf->draw_text(310, 815, t("Reklamaatio/Purkulista", $kieli),     $thispage, $iso);
     }
     elseif ($tyyppi == "TAKUU") {
       $pdf->draw_text(310, 815, t("Takuu", $kieli),     $thispage, $iso);
@@ -557,8 +555,9 @@ if (!function_exists('uusi_sivu_kerayslista')) {
       $pdf->draw_text(310, 782, $kerayseran_numero,        $thispage, $boldi);
     }
     else {
-      $pdf->draw_text(310, 792, t("Tilausnumero(t)", $kieli),   $thispage, $pieni);
-      $pdf->draw_text(310, 782, $tilausnumeroita,          $thispage, $boldi);
+      list($ff_string, $ff_font) = pdf_fontfit($tilausnumeroita, 270, $pdf, $boldi);
+      $pdf->draw_text(310, 792, t("Tilausnumero(t)", $kieli),     $thispage, $pieni);
+      $pdf->draw_text(310, 782, $ff_string, $thispage, $ff_font);
     }
 
     $pdf->draw_rectangle(779, 300, 758, 580, $thispage, $rectparam);

--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -159,7 +159,8 @@ if (!function_exists('alku_kerayslista')) {
         $pdf->draw_text(310, 815, t("Siirtolista", $kieli),     $thispage, $iso);
       }
       elseif ($tyyppi == "REKLAMAATIO") {
-        $pdf->draw_text(240, 815, t("Reklamaatio/Purkulista", $kieli),     $thispage, $iso);
+        list($ff_string, $ff_font) = pdf_fontfit(t("Reklamaatio/Purkulista", $kieli), 200, $pdf, $iso);
+        $pdf->draw_text(240, 815, $ff_string, $thispage, $ff_font);
       }
       elseif ($tyyppi == "TAKUU") {
         $pdf->draw_text(310, 815, t("Takuu", $kieli),     $thispage, $iso);
@@ -533,7 +534,8 @@ if (!function_exists('uusi_sivu_kerayslista')) {
       $pdf->draw_text(310, 815, t("Siirtolista", $kieli),         $thispage, $iso);
     }
     elseif ($tyyppi == "REKLAMAATIO") {
-      $pdf->draw_text(310, 815, t("Reklamaatio/Purkulista", $kieli),     $thispage, $iso);
+      list($ff_string, $ff_font) = pdf_fontfit(t("Reklamaatio/Purkulista", $kieli), 200, $pdf, $iso);
+      $pdf->draw_text(240, 815, $ff_string, $thispage, $ff_font);
     }
     elseif ($tyyppi == "TAKUU") {
       $pdf->draw_text(310, 815, t("Takuu", $kieli),     $thispage, $iso);
@@ -1022,7 +1024,6 @@ if (!function_exists('rivi_kerayslista')) {
 
         $kala = $kala - $rivinkorkeus + 5;
 
-
         list($ff_string, $ff_font) = pdf_fontfit($row["nimitys"], 350, $pdf, $norm);
         $pdf->draw_text(125, $kala, $ff_string, $thispage, $ff_font);
 
@@ -1170,6 +1171,22 @@ if (!function_exists('rivi_kerayslista')) {
         }
 
         if ($row["kommentti"] != '') {
+          if ($kala-$norm["height"]-5 < 95) {
+
+            $sivu++;
+
+            // Luodaan palautettavat
+            $return = compact(array_keys($params));
+
+            $params = loppu_kerayslista($return);
+            $params = uusi_sivu_kerayslista($params);
+
+            // Luodaan muuttujat
+            extract($params);
+
+            $page[$sivu] = $thispage;
+          }
+
           $pohja = $pdf->draw_paragraph($kala+$norm["height"]+5, 125, 60, 470, $row["kommentti"],  $thispage, $norm);
           $kala = $pohja - $rivinkorkeus;
         }


### PR DESCRIPTION
Reklamaatioiden purkulistojen tulostuksessa saattoi tulla ongelmia rivien tulostuksen kanssa mikäli tilausrivit sattuivat olemaan tietyn korkuisia. Nyt tämä on korjattu niin, että kaikki rivit pitäisi tulla hyvin näkyviin.

Tämän lisäksi Reklamaatio/Purkulista otsikko oli hieman vinossa, jonka takia se ei näkynyt kokonaa, joten otsikkoa siirrettiin hieman.