### PR TITLE
Avoimet ostorivit: toimitusajan muuttaminen riveille

### DIFF
--- a/tilauskasittely/ostotilausrivien_hallinta.php
+++ b/tilauskasittely/ostotilausrivien_hallinta.php
@@ -154,7 +154,7 @@ if ($ytunnus != '') {
       else {
         $mitkakaikkipvm = " and otunnus in ({$tilaus_otunnukset}) and uusiotunnus=0 ";
       }
-echo "157 toimpp $toimpp toimkk $toimkk toimvv $toimvv toimaika $toimaika <br><br>";
+
       $query = "UPDATE tilausrivi
                 SET toimaika = '{$toimvv}-{$toimkk}-{$toimpp}'
                 WHERE yhtio = '{$kukarow['yhtio']}'
@@ -163,7 +163,6 @@ echo "157 toimpp $toimpp toimkk $toimkk toimvv $toimvv toimaika $toimaika <br><b
     }
 
     if ($tee == "PAIVITARIVI") {
-
       foreach ($toimaikarivi as $tunnus => $toimaika) {
         if (strpos($toimaika, ".") !== false) {
            $_aika = explode(".", $toimaika);

--- a/tilauskasittely/ostotilausrivien_hallinta.php
+++ b/tilauskasittely/ostotilausrivien_hallinta.php
@@ -154,7 +154,7 @@ if ($ytunnus != '') {
       else {
         $mitkakaikkipvm = " and otunnus in ({$tilaus_otunnukset}) and uusiotunnus=0 ";
       }
-
+echo "157 toimpp $toimpp toimkk $toimkk toimvv $toimvv toimaika $toimaika <br><br>";
       $query = "UPDATE tilausrivi
                 SET toimaika = '{$toimvv}-{$toimkk}-{$toimpp}'
                 WHERE yhtio = '{$kukarow['yhtio']}'
@@ -165,6 +165,14 @@ if ($ytunnus != '') {
     if ($tee == "PAIVITARIVI") {
 
       foreach ($toimaikarivi as $tunnus => $toimaika) {
+        if (strpos($toimaika, ".") !== false) {
+           $_aika = explode(".", $toimaika);
+
+           if (count($_aika) == 3) {
+             $toimaika = "{$_aika["2"]}-{$_aika["1"]}-{$_aika["0"]}";
+           }
+        }
+
         $query = "UPDATE tilausrivi SET toimaika = '{$toimaika}' WHERE yhtio = '{$kukarow['yhtio']}' and tunnus = '{$tunnus}' and tyyppi = 'O'";
         $result = pupe_query($query);
       }


### PR DESCRIPTION
Avoimet ostorivit ohjelmassa rivikohtaisia toimitusaikoja syötettäessä Pupe käsitteli hassusti pp.kk.vvvv muodossa syötettyjä päivämääriä ja muutti ne kummalisiksi. Tämä on nyt korjattu ja jatkossa päivämääriä voi syöttää myös muodossa pp.kk.vvvv.