### PR TITLE
Koontilähetysfix

### DIFF
--- a/rahtikirja.php
+++ b/rahtikirja.php
@@ -1140,9 +1140,6 @@ if ($tee == 'add') {
         if ($toimitustaparow['osoitelappu'] == 'intrade') {
           require 'tilauskasittely/osoitelappu_intrade_pdf.inc';
         }
-        elseif ($toimitustaparow['osoitelappu'] == 'hornbach') {
-          require 'tilauskasittely/osoitelappu_hornbach_pdf.inc';
-        }
         else {
           require "tilauskasittely/osoitelappu_pdf.inc";
         }

--- a/tilauskasittely/rahtikirja_erittely_pdf.inc
+++ b/tilauskasittely/rahtikirja_erittely_pdf.inc
@@ -123,9 +123,17 @@ if (!function_exists('rivi_erittely')) {
       $pdf->draw_text(62, $kala-18, t("Ytunnus", $kieli)." ".$laskurow['ytunnus'],    $firstpage, $kirj);
 
       if ($toitarow['erittely'] == 'k') {
-        $pdf->draw_text(62, $kala-28, $laskurow['nimi']." ".$laskurow['nimitark'],    $firstpage, $kirj);
-        $pdf->draw_text(62, $kala-38, $laskurow['osoite'],  $firstpage, $kirj);
-        $pdf->draw_text(62, $kala-48, $laskurow['postino']." ".$laskurow['postitp'],  $firstpage, $kirj);
+        // jos toimitustavan takana on annettu osoitetiedot, käytetään niitä koontitilauksella
+        if (!empty($toitarow['toim_nimi']) and !empty($toitarow['toim_osoite']) and !empty($toitarow['toim_postino']) and !empty($toitarow['toim_postitp'])) {
+          $pdf->draw_text(62, $kala-28, $toitarow['toim_nimi']." ".$toitarow['toim_nimitark'],    $firstpage, $kirj);
+          $pdf->draw_text(62, $kala-38, $toitarow['toim_osoite'],  $firstpage, $kirj);
+          $pdf->draw_text(62, $kala-48, $toitarow['toim_postino']." ".$toitarow['toim_postitp'],  $firstpage, $kirj);
+        }
+        else {
+          $pdf->draw_text(62, $kala-28, $laskurow['nimi']." ".$laskurow['nimitark'],    $firstpage, $kirj);
+          $pdf->draw_text(62, $kala-38, $laskurow['osoite'],  $firstpage, $kirj);
+          $pdf->draw_text(62, $kala-48, $laskurow['postino']." ".$laskurow['postitp'],  $firstpage, $kirj);
+        }
       }
       else {
         $pdf->draw_text(62, $kala-28, $laskurow['toim_nimi']." ".$laskurow['toim_nimitark'],    $firstpage, $kirj);

--- a/tilauskasittely/rahtikirja_erittely_pdf.inc
+++ b/tilauskasittely/rahtikirja_erittely_pdf.inc
@@ -123,8 +123,8 @@ if (!function_exists('rivi_erittely')) {
       $pdf->draw_text(62, $kala-18, t("Ytunnus", $kieli)." ".$laskurow['ytunnus'],    $firstpage, $kirj);
 
       if ($toitarow['erittely'] == 'k') {
-        // jos toimitustavan takana on annettu osoitetiedot, käytetään niitä koontitilauksella
-        if (!empty($toitarow['toim_nimi']) and !empty($toitarow['toim_osoite']) and !empty($toitarow['toim_postino']) and !empty($toitarow['toim_postitp'])) {
+        // jos tulostustapa on koonti ja toimitustavan takana on annettu osoitetiedot, käytetään niitä
+        if ($toitarow['tulostustapa'] == 'K' and !empty($toitarow['toim_nimi']) and !empty($toitarow['toim_postitp'])) {
           $pdf->draw_text(62, $kala-28, $toitarow['toim_nimi']." ".$toitarow['toim_nimitark'],    $firstpage, $kirj);
           $pdf->draw_text(62, $kala-38, $toitarow['toim_osoite'],  $firstpage, $kirj);
           $pdf->draw_text(62, $kala-48, $toitarow['toim_postino']." ".$toitarow['toim_postitp'],  $firstpage, $kirj);

--- a/tilauskasittely/tulosta_dgd.inc
+++ b/tilauskasittely/tulosta_dgd.inc
@@ -55,8 +55,8 @@ if (!function_exists('alku_dgd')) {
     }
 
     $pdf->pages[$sivu]->drawText($laskurow["rahtikirjanro"], mm_pt(110), mm_pt(263), 'LATIN1');
-    // jos toimitustavan takana on annettu osoitetiedot, käytetään niitä
-    if (!empty($toitarow['toim_nimi']) and !empty($toitarow['toim_osoite']) and !empty($toitarow['toim_postino']) and !empty($toitarow['toim_postitp']) and !empty($toitarow['toim_maa'])) {
+    // jos tulostustapa on koonti ja toimitustavan takana on annettu osoitetiedot, käytetään niitä
+    if ($toitarow['tulostustapa'] == 'K' and !empty($toitarow['toim_nimi']) and !empty($toitarow['toim_postitp'])) {
       $pdf->pages[$sivu]->drawText($toitarow["toim_nimi"], mm_pt(15), mm_pt(242), 'LATIN1');
       $pdf->pages[$sivu]->drawText($toitarow["toim_osoite"], mm_pt(15), mm_pt(238), 'LATIN1');
       $pdf->pages[$sivu]->drawText($toitarow["toim_postino"]." ".$toitarow["toim_postitp"], mm_pt(15), mm_pt(234), 'LATIN1');

--- a/tilauskasittely/tulosta_dgd.inc
+++ b/tilauskasittely/tulosta_dgd.inc
@@ -12,6 +12,14 @@ if (!function_exists('alku_dgd')) {
       ${$key} = $val;
     }
 
+    // haetaan toimitustavan tiedot
+    $query = "SELECT *
+              FROM toimitustapa
+              WHERE yhtio = '{$kukarow['yhtio']}'
+              AND selite  = '{$laskurow['toimitustapa']}'";
+    $toitares = pupe_query($query);
+    $toitarow = mysql_fetch_assoc($toitares);
+
     //PDF parametrit
     if ($pdf === NULL) {
       $pdf = Zend_Pdf::load($GLOBALS["pupe_root_polku"]."/tilauskasittely/DGDpohja.pdf");
@@ -47,11 +55,19 @@ if (!function_exists('alku_dgd')) {
     }
 
     $pdf->pages[$sivu]->drawText($laskurow["rahtikirjanro"], mm_pt(110), mm_pt(263), 'LATIN1');
-
-    $pdf->pages[$sivu]->drawText($laskurow["toim_nimi"], mm_pt(15), mm_pt(242), 'LATIN1');
-    $pdf->pages[$sivu]->drawText($laskurow["toim_osoite"], mm_pt(15), mm_pt(238), 'LATIN1');
-    $pdf->pages[$sivu]->drawText($laskurow["toim_postino"]." ".$laskurow["toim_postitp"], mm_pt(15), mm_pt(234), 'LATIN1');
-    $pdf->pages[$sivu]->drawText(maa($laskurow["toim_maa"], $kieli), mm_pt(15), mm_pt(230), 'LATIN1');
+    // jos toimitustavan takana on annettu osoitetiedot, käytetään niitä
+    if (!empty($toitarow['toim_nimi']) and !empty($toitarow['toim_osoite']) and !empty($toitarow['toim_postino']) and !empty($toitarow['toim_postitp']) and !empty($toitarow['toim_maa'])) {
+      $pdf->pages[$sivu]->drawText($toitarow["toim_nimi"], mm_pt(15), mm_pt(242), 'LATIN1');
+      $pdf->pages[$sivu]->drawText($toitarow["toim_osoite"], mm_pt(15), mm_pt(238), 'LATIN1');
+      $pdf->pages[$sivu]->drawText($toitarow["toim_postino"]." ".$toitarow["toim_postitp"], mm_pt(15), mm_pt(234), 'LATIN1');
+      $pdf->pages[$sivu]->drawText(maa($toitarow["toim_maa"], $kieli), mm_pt(15), mm_pt(230), 'LATIN1');
+    }
+    else {
+      $pdf->pages[$sivu]->drawText($laskurow["toim_nimi"], mm_pt(15), mm_pt(242), 'LATIN1');
+      $pdf->pages[$sivu]->drawText($laskurow["toim_osoite"], mm_pt(15), mm_pt(238), 'LATIN1');
+      $pdf->pages[$sivu]->drawText($laskurow["toim_postino"]." ".$laskurow["toim_postitp"], mm_pt(15), mm_pt(234), 'LATIN1');
+      $pdf->pages[$sivu]->drawText(maa($laskurow["toim_maa"], $kieli), mm_pt(15), mm_pt(230), 'LATIN1');
+    }
 
     // Ruksit
     $pdf->pages[$sivu]->drawLine(mm_pt(15), mm_pt(202), mm_pt(55), mm_pt(197));


### PR DESCRIPTION
- Käytetään rahtikirjaerittelyssä sekä dgd:llä ensisijaisesti toimitustavan takaa löytyviä osoitetietoja, mikäli sellaiset on asetettu