### PR TITLE
Synkronoi tuotteet ulkoiseen järjestelmään: status

### DIFF
--- a/inc/tuotetarkista.inc
+++ b/inc/tuotetarkista.inc
@@ -3,8 +3,15 @@
 if (!function_exists("tuotetarkista")) {
   function tuotetarkista(&$t, $i, $result, $tunnus, &$virhe, $trow) {
     global $kukarow, $yhtiorow, $alias_set, $laji, $poistolukko, $luedata_toiminto;
+    global $ftp_logmaster_host, $ftp_logmaster_user, $ftp_logmaster_pass, $ftp_logmaster_path;
+    global $ftp_posten_logistik_host, $ftp_posten_logistik_user, $ftp_posten_logistik_pass, $ftp_posten_logistik_path;
 
-    static $tem_tuoteno, $tem_tullinimike1, $tem_eisaldoa, $tem_kehahin, $tem_kehahin_ind, $tem_tuotetyyppi, $tem_status, $tem_status_vanha, $tem_try, $tem_try_vanha;
+    static $tem_tuoteno, $tem_tullinimike1, $tem_eisaldoa, $tem_kehahin, $tem_kehahin_ind;
+    static $tem_tuotetyyppi, $tem_status, $tem_status_vanha, $tem_try, $tem_try_vanha;
+    static $tem_eankoodi, $tem_yksikko, $tem_nimitys, $tem_tuotemassa;
+
+    $onkologmaster = (!empty($ftp_logmaster_host) and !empty($ftp_logmaster_user) and !empty($ftp_logmaster_pass) and !empty($ftp_logmaster_path));
+    $onkoposten    = (!empty($ftp_posten_logistik_host) and !empty($ftp_posten_logistik_user) and !empty($ftp_posten_logistik_pass) and !empty($ftp_posten_logistik_path));
 
     $fieldname = mysql_field_name($result, $i);
 
@@ -149,6 +156,8 @@ if (!function_exists("tuotetarkista")) {
     }
 
     if ($fieldname == "nimitys") {
+      $tem_nimitys = $t[$i];
+
       if (trim($t[$i]) == '') {
         $virhe[$i] .= t("Nimitys puuttuu")."!";
       }
@@ -191,6 +200,14 @@ if (!function_exists("tuotetarkista")) {
     if ($fieldname == "tullinimike2" and $tem_tullinimike1 != "") {
       // jos tyhj‰‰ laitetaan nollaksi
       if ($t[$i] == "") $t[$i] = "00";
+    }
+
+    if ($fieldname == "yksikko") {
+      $tem_yksikko = $t[$i];
+    }
+
+    if ($fieldname == "tuotemassa") {
+      $tem_tuotemassa = $t[$i];
     }
 
     if ($fieldname == "tuotetyyppi") {
@@ -320,6 +337,8 @@ if (!function_exists("tuotetarkista")) {
     }
 
     if ($fieldname == "eankoodi") {
+      $tem_eankoodi = $t[$i];
+
       if (trim($t[$i]) != 0 and trim($t[$i] != '')) {
         $query  = "SELECT eankoodi
                    FROM tuote
@@ -442,6 +461,23 @@ if (!function_exists("tuotetarkista")) {
                   laatija   = '$kukarow[kuka]',
                   laadittu  = now()";
         $chkressires = pupe_query($query);
+      }
+
+      if (count($virhe) == 0 and
+          ($onkologmaster or $onkoposten) and
+          ($tem_status     != $trow['status']     or
+           $tem_eankoodi   != $trow['eankoodi']   or
+           $tem_yksikko    != $trow['yksikko']    or
+           $tem_nimitys    != $trow['nimitys']    or
+           $tem_tuotemassa != $trow['tuotemassa'] or
+           $tem_try        != $tem_try_vanha)) {
+
+        $query = "UPDATE tuotteen_avainsanat SET
+                  selite = ''
+                  WHERE yhtio = '{$kukarow['yhtio']}'
+                  AND laji = 'synkronointi'
+                  AND tuoteno = '{$tem_tuoteno}'";
+        $updres = pupe_query($query);
       }
 
       if (count($virhe) == 0

--- a/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
+++ b/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
@@ -45,11 +45,10 @@ else {
     $wherelisa = "";
   }
 
-  $query = "SELECT tuote.*, ta.selite AS synkronointi
+  $query = "SELECT tuote.*, ta.selite AS synkronointi, ta.tunnus AS tuotteen_avainsanat_tunnus
             FROM tuote
             LEFT JOIN tuotteen_avainsanat AS ta ON (ta.yhtio = tuote.yhtio AND ta.tuoteno = tuote.tuoteno AND ta.laji = 'synkronointi' AND ta.selite != '')
             WHERE tuote.yhtio    = '{$kukarow['yhtio']}'
-            AND tuote.status    != 'P'
             AND tuote.ei_saldoa  = ''
             {$wherelisa}
             AND ta.selite IS NULL";
@@ -115,7 +114,14 @@ else {
         $line = $items->addChild('Line');
         $line->addAttribute('No', $i);
 
-        $line->addChild('Type', 'U');
+        if (is_numeric($row['tuotteen_avainsanat_tunnus'])) {
+          $type = 'M';
+        }
+        else {
+          $type = 'U';
+        }
+
+        $line->addChild('Type', $type);
 
         $eankoodi = substr($row['eankoodi'], 0, 20);
 
@@ -147,7 +153,20 @@ else {
         $line->addChild('Length', 0);
         $line->addChild('PackageSize', 0);
         $line->addChild('PalletSize', 0);
-        $line->addChild('Status', 0);
+
+        switch ($row['status']) {
+        case 'A':
+          $status = 1;
+          break;
+        case 'P':
+          $status = 9;
+          break;
+        default:
+          $status = 0;
+          break;
+        }
+
+        $line->addChild('Status', $status);
         $line->addChild('WholesalePackageSize', 0);
         $line->addChild('EANCode', utf8_encode($eankoodi));
         $line->addChild('EANCode2', 0);

--- a/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
+++ b/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
@@ -47,11 +47,13 @@ else {
 
   $query = "SELECT tuote.*, ta.selite AS synkronointi
             FROM tuote
-            LEFT JOIN tuotteen_avainsanat AS ta ON (ta.yhtio = tuote.yhtio AND ta.tuoteno = tuote.tuoteno AND ta.laji = 'synkronointi' AND ta.selite != '')
+            LEFT JOIN tuotteen_avainsanat AS ta ON (ta.yhtio = tuote.yhtio AND ta.tuoteno = tuote.tuoteno AND ta.laji = 'synkronointi')
             WHERE tuote.yhtio    = '{$kukarow['yhtio']}'
             AND tuote.ei_saldoa  = ''
             {$wherelisa}
-            AND ta.selite IS NULL";
+            HAVING (ta.tunnus IS NOT NULL AND ta.selite = '') OR
+                    # jos avainsanaa ei ole olemassa ja status P niin ei haluta näitä tuotteita jatkossakaan
+                   (ta.tunnus IS NULL AND tuote.status != 'P')";
   $res = pupe_query($query);
 
   if (mysql_num_rows($res) > 0) {
@@ -109,19 +111,6 @@ else {
                 AND tuoteno = '{$row['tuoteno']}'
                 AND selite = ''";
       $tunnus_chkres = pupe_query($query);
-
-      if (mysql_num_rows($tunnus_chkres) == 0 and $row['status'] == 'P') {
-
-        # jos avainsanaa ei ole olemassa ja status P niin ei haluta näitä tuotteita jatkossakaan
-        $query = "UPDATE tuotteen_avainsanat SET
-                  selite      = 'x'
-                  WHERE yhtio = '{$kukarow['yhtio']}'
-                  AND tuoteno = '{$row['tuoteno']}'
-                  AND laji    = 'synkronointi'";
-        pupe_query($query);
-
-        continue;
-      }
 
       if ($tee == '') {
 

--- a/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
+++ b/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
@@ -104,14 +104,6 @@ else {
 
     while ($row = mysql_fetch_assoc($res)) {
 
-      $query = "SELECT *
-                FROM tuotteen_avainsanat
-                WHERE yhtio = '{$kukarow['yhtio']}'
-                AND laji = 'synkronointi'
-                AND tuoteno = '{$row['tuoteno']}'
-                AND selite = ''";
-      $tunnus_chkres = pupe_query($query);
-
       if ($tee == '') {
 
         echo "<tr>";
@@ -124,7 +116,7 @@ else {
         $line = $items->addChild('Line');
         $line->addAttribute('No', $i);
 
-        if (mysql_num_rows($tunnus_chkres) > 0) {
+        if (!is_null($row['synkronointi']) and $row['synkronointi'] == '') {
           $type = 'M';
         }
         else {
@@ -208,7 +200,7 @@ else {
         $line->addChild('ModelOrder', 0);
         $line->addChild('TransportTemperature', 0);
 
-        if (is_null($row['synkronointi']) and mysql_num_rows($tunnus_chkres) == 0) {
+        if (is_null($row['synkronointi'])) {
 
           $query = "INSERT INTO tuotteen_avainsanat SET
                     yhtio      = '{$kukarow['yhtio']}',

--- a/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
+++ b/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
@@ -45,7 +45,7 @@ else {
     $wherelisa = "";
   }
 
-  $query = "SELECT tuote.*, ta.selite AS synkronointi
+  $query = "SELECT tuote.*, ta.selite AS synkronointi, ta.tunnus AS ta_tunnus
             FROM tuote
             LEFT JOIN tuotteen_avainsanat AS ta ON (ta.yhtio = tuote.yhtio AND ta.tuoteno = tuote.tuoteno AND ta.laji = 'synkronointi')
             WHERE tuote.yhtio    = '{$kukarow['yhtio']}'

--- a/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
+++ b/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
@@ -45,7 +45,7 @@ else {
     $wherelisa = "";
   }
 
-  $query = "SELECT tuote.*, ta.selite AS synkronointi, ta.tunnus AS tuotteen_avainsanat_tunnus
+  $query = "SELECT tuote.*, ta.selite AS synkronointi
             FROM tuote
             LEFT JOIN tuotteen_avainsanat AS ta ON (ta.yhtio = tuote.yhtio AND ta.tuoteno = tuote.tuoteno AND ta.laji = 'synkronointi' AND ta.selite != '')
             WHERE tuote.yhtio    = '{$kukarow['yhtio']}'

--- a/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
+++ b/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
@@ -114,7 +114,15 @@ else {
         $line = $items->addChild('Line');
         $line->addAttribute('No', $i);
 
-        if (is_numeric($row['tuotteen_avainsanat_tunnus'])) {
+        $query = "SELECT *
+                  FROM tuotteen_avainsanat
+                  WHERE yhtio = '{$kukarow['yhtio']}'
+                  AND laji = 'synkronointi'
+                  AND tuoteno = '{$row['tuoteno']}'
+                  AND selite = ''";
+        $tunnus_chkres = pupe_query($query);
+
+        if (mysql_num_rows($tunnus_chkres) > 0) {
           $type = 'M';
         }
         else {

--- a/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
+++ b/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
@@ -102,6 +102,27 @@ else {
 
     while ($row = mysql_fetch_assoc($res)) {
 
+      $query = "SELECT *
+                FROM tuotteen_avainsanat
+                WHERE yhtio = '{$kukarow['yhtio']}'
+                AND laji = 'synkronointi'
+                AND tuoteno = '{$row['tuoteno']}'
+                AND selite = ''";
+      $tunnus_chkres = pupe_query($query);
+
+      if (mysql_num_rows($tunnus_chkres) == 0 and $row['status'] == 'P') {
+
+        # jos avainsanaa ei ole olemassa ja status P niin ei haluta näitä tuotteita jatkossakaan
+        $query = "UPDATE tuotteen_avainsanat SET
+                  selite      = 'x'
+                  WHERE yhtio = '{$kukarow['yhtio']}'
+                  AND tuoteno = '{$row['tuoteno']}'
+                  AND laji    = 'synkronointi'";
+        pupe_query($query);
+
+        continue;
+      }
+
       if ($tee == '') {
 
         echo "<tr>";
@@ -113,14 +134,6 @@ else {
 
         $line = $items->addChild('Line');
         $line->addAttribute('No', $i);
-
-        $query = "SELECT *
-                  FROM tuotteen_avainsanat
-                  WHERE yhtio = '{$kukarow['yhtio']}'
-                  AND laji = 'synkronointi'
-                  AND tuoteno = '{$row['tuoteno']}'
-                  AND selite = ''";
-        $tunnus_chkres = pupe_query($query);
 
         if (mysql_num_rows($tunnus_chkres) > 0) {
           $type = 'M';
@@ -206,7 +219,7 @@ else {
         $line->addChild('ModelOrder', 0);
         $line->addChild('TransportTemperature', 0);
 
-        if (is_null($row['synkronointi'])) {
+        if (is_null($row['synkronointi']) and mysql_num_rows($tunnus_chkres) == 0) {
 
           $query = "INSERT INTO tuotteen_avainsanat SET
                     yhtio      = '{$kukarow['yhtio']}',
@@ -228,7 +241,7 @@ else {
                     WHERE yhtio = '{$kukarow['yhtio']}'
                     AND tuoteno = '{$row['tuoteno']}'
                     AND laji    = 'synkronointi'";
-          pupe_query($query_dump());
+          pupe_query($query);
         }
 
         $i++;


### PR DESCRIPTION
Sanomalle menevä status riippuu nyt tuotteen statuksesta. Sanoman tyyppi on U jos uusi tuote, ja M jos aiemmin synkronoitu.

Jos tuotteen  eankoodia, yksikköä, nimitystä, tuoteryhmää, massaa tai statusta muuttaa, tyhjennetään mahdollinen tuotteen synkronointi-avainsana, jotta seuraavalla synkronointikerralla tuote menisi aineiston mukana.