### PR TITLE
Ennakkotilaukset: osatoimitustäppä

### DIFF
--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -2467,7 +2467,7 @@ if ($tila == "" and !isset($jatka)) {
       $vasen++;
     }
 
-    if ($toim != "MYYNTITILI") {
+    if ($toim != "MYYNTITILI" AND $toim != "ENNAKKO") {
       $oikea_sarake[$oikea] = "<td>".t("Tilausta ei osatoimiteta").":</td><td><input type='checkbox' name='osatoimitus' $osath></td>";
       $oikea++;
     }


### PR DESCRIPTION
Ennakkotilauksien kohdalla osatoimituskielto-ominaisuutta ei ole olemassa. Tästä huolimatta ennakkotilauksien otsikolla on ollut valittavissa osatoimituskielto-täppä. Nyt osatoimituskielto täppä on otettu kokonaan ennakkotilauksilta pois hämäämästä.