### PR TITLE
Poistuvat tuotteet parametri & tuotekysely

### DIFF
--- a/inc/tuotehaku.inc
+++ b/inc/tuotehaku.inc
@@ -195,6 +195,13 @@ if (!$enarimatch) {
       }
     }
 
+    if ($yhtiorow['poistuvat_tuotteet'] == 'X') {
+      $havinglisa = "HAVING tuote.status not in ('P','X') and saldo > 0";
+    }
+    else {
+      $havinglisa = "HAVING (tuote.status not in ('P','X') or saldo > 0)";
+    }
+
     // Poistettuja tuotteita ei näytetä paitsi jos niillä on saldoa
     // Joinataan korvaavat mukaan
     $query = "SELECT
@@ -222,7 +229,7 @@ if (!$enarimatch) {
               WHERE tuote.$yhtiot
               $kieltolisa
               $th_lisa1
-              HAVING (tuote.status not in ('P','X') or saldo > 0)
+              {$havinglisa}
               ORDER BY tuote.tuoteno
               LIMIT 201";
     $thresult = pupe_query($query);

--- a/inc/tuotehaku.inc
+++ b/inc/tuotehaku.inc
@@ -196,7 +196,7 @@ if (!$enarimatch) {
     }
 
     if ($yhtiorow['poistuvat_tuotteet'] == 'X') {
-      $havinglisa = "HAVING tuote.status not in ('P','X') and saldo > 0";
+      $havinglisa = "HAVING tuote.status not in ('P','X') and saldo > 0 and ei_saldoa = ''";
     }
     else {
       $havinglisa = "HAVING (tuote.status not in ('P','X') or saldo > 0)";

--- a/inc/tuotehaku.inc
+++ b/inc/tuotehaku.inc
@@ -195,7 +195,7 @@ if (!$enarimatch) {
       }
     }
 
-    if ($yhtiorow['poistuvat_tuotteet'] == 'X') {
+    if (strpos($_SERVER['SCRIPT_NAME'], "tuote.php") !== false and $kukarow["extranet"] == "" and $yhtiorow['poistuvat_tuotteet'] == 'X') {
       $havinglisa = "HAVING tuote.status not in ('P','X') and saldo > 0 and ei_saldoa = ''";
     }
     else {

--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -2318,7 +2318,7 @@ if ($fieldname == "poistuvat_tuotteet") {
 
   $ulos = "<td><select name='{$nimi}' ".js_alasvetoMaxWidth($nimi, 400).">";
   $ulos .= "<option value=''>".t("Näytä poistuvat tuotteet oletuksena tuotekyselyssä")."</option>";
-  $ulos .= "<option value='X' {$sel}>".t("Älä näytä poistuvia tuotteita oletuksena tuotekyselyssä")."</option>";
+  $ulos .= "<option value='X' {$sel}>".t("Älä näytä poistuvia, poistettuja, saldottomia ja varastoimattomia tuotteita oletuksena tuotekyselyssä")."</option>";
   $ulos .= "</select></td>";
 
   $jatko = 0;

--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -2314,20 +2314,11 @@ if ($fieldname == "viitteen_kasinsyotto") {
 
 if ($fieldname == "poistuvat_tuotteet") {
 
-  $ulos = "<td><select name='$nimi' ".js_alasvetoMaxWidth($nimi, 400).">";
+  $sel = $trow[$i] == 'X' ? 'selected' : '';
 
-  $sel1="";
-  $sel2="";
-
-  if ($trow[$i] == "") {
-    $sel1 = "selected";
-  }
-  else {
-    $sel2 = "selected";
-  }
-
-  $ulos .= "<option value=''  $sel1>".t("Älä näytä poistuvia tuotteita oletuksena")."</option>";
-  $ulos .= "<option value='X' $sel2>".t("Näytä poistuvat tuotteet oletuksena")."</option>";
+  $ulos = "<td><select name='{$nimi}' ".js_alasvetoMaxWidth($nimi, 400).">";
+  $ulos .= "<option value=''>".t("Näytä poistuvat tuotteet oletuksena tuotekyselyssä")."</option>";
+  $ulos .= "<option value='X' {$sel}>".t("Älä näytä poistuvia tuotteita oletuksena tuotekyselyssä")."</option>";
   $ulos .= "</select></td>";
 
   $jatko = 0;


### PR DESCRIPTION
Poistuvat tuotteet -parametri on herätetty henkiin ja nyt se puree tuotekyselyyn vain jos hakutuloksia on monta ja piirretään tästä johtuen pudotusvalikko. Pudotusvalikossa ei näytetä poistuvia, poistettuja, saldottomia tai varastoimattomia tuotteita.