### PR TITLE
Tase/tuloslaskelma: tasonimikorjaus

### DIFF
--- a/budjetinyllapito.php
+++ b/budjetinyllapito.php
@@ -289,8 +289,14 @@ else {
     // millä tasolla ollaan (1,2,3,4,5,6)
     $tasoluku = strlen($tasorow["taso"]);
 
-    // tasonimi talteen (rightpäddätään Ö:llä, niin saadaan oikeaan järjestykseen)
-    $apusort = str_pad($tasorow["taso"], 20, "Z");
+    // tasonimi talteen (rightpäddätään Z:lla tai Ö:llä, niin saadaan oikeaan järjestykseen)
+    if (PUPE_UNICODE) {
+      $apusort = str_pad($tasorow["taso"], 20, "Z");
+    }
+    else {
+      $apusort = str_pad($tasorow["taso"], 20, "Ö");
+    }
+
     $tasonimi[$apusort] = $tasorow["nimi"];
 
     // pilkotaan taso osiin
@@ -424,7 +430,13 @@ else {
     // loopataan tasot läpi
     foreach ($tasonimi as $key_c => $value) {
 
-      $key = str_replace("Z", "", $key_c); // Ö-kirjaimet pois
+      // Päddäykset pois
+      if (PUPE_UNICODE) {
+        $key = str_replace("Z", "", $key_c); // Z-kirjaimet pois
+      }
+      else {
+        $key = str_replace("Ö", "", $key_c); // Ö-kirjaimet pois
+      }
 
       // tulostaan rivi vain jos se kuuluu rajaukseen
       if (strlen($key) <= $rtaso or $rtaso == "TILI") {

--- a/raportit/tuloslaskelma.php
+++ b/raportit/tuloslaskelma.php
@@ -930,8 +930,14 @@ else {
       // mill‰ tasolla ollaan (1,2,3,4,5,6)
       $tasoluku = strlen($tasorow["taso"]);
 
-      // tasonimi talteen (rightp‰dd‰t‰‰n ÷:ll‰, niin saadaan oikeaan j‰rjestykseen)
-      $apusort = str_pad($tasorow["taso"], 20, "÷");
+      // tasonimi talteen (rightp‰dd‰t‰‰n Z:lla tai ÷:ll‰, niin saadaan oikeaan j‰rjestykseen)
+      if (PUPE_UNICODE) {
+        $apusort = str_pad($tasorow["taso"], 20, "Z");
+      }
+      else {
+        $apusort = str_pad($tasorow["taso"], 20, "÷");
+      }
+
       $tasonimi[$apusort] = $tasorow["nimi"];
 
       // Jos tasolla on oletusarvo per kk. Esim poistot, jotka kirjataan vasta tilinp‰‰tˆksess‰
@@ -1168,7 +1174,13 @@ else {
 
       $px++;
 
-      $key = str_replace("÷", "", $key_c); // ÷-kirjaimet pois
+      // P‰dd‰ykset pois
+      if (PUPE_UNICODE) {
+        $key = str_replace("Z", "", $key_c); // Z-kirjaimet pois
+      }
+      else {
+        $key = str_replace("÷", "", $key_c); // ÷-kirjaimet pois
+      }
 
       // tulostaan rivi vain jos se kuuluu rajaukseen
       if (strlen($key) <= $rtaso or $rtaso == "TILI") {

--- a/raportit/tuloslaskelma.php
+++ b/raportit/tuloslaskelma.php
@@ -931,7 +931,7 @@ else {
       $tasoluku = strlen($tasorow["taso"]);
 
       // tasonimi talteen (rightpäddätään Ö:llä, niin saadaan oikeaan järjestykseen)
-      $apusort = str_pad($tasorow["taso"], 20, "Z");
+      $apusort = str_pad($tasorow["taso"], 20, "Ö");
       $tasonimi[$apusort] = $tasorow["nimi"];
 
       // Jos tasolla on oletusarvo per kk. Esim poistot, jotka kirjataan vasta tilinpäätöksessä
@@ -1168,7 +1168,7 @@ else {
 
       $px++;
 
-      $key = str_replace("Z", "", $key_c); // Ö-kirjaimet pois
+      $key = str_replace("Ö", "", $key_c); // Ö-kirjaimet pois
 
       // tulostaan rivi vain jos se kuuluu rajaukseen
       if (strlen($key) <= $rtaso or $rtaso == "TILI") {


### PR DESCRIPTION
Taseessa tasojen nimet menivät sekaisin ja sinne tuli vääriä nimiä. Korjattu niin, että näkyviin tulevat oikeat nimet.