### PR TITLE
Osoitelapun SSCC-koodi 

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -22585,7 +22585,7 @@ if (!function_exists("gs1_sscc")) {
       $item_id_space      = 7;
     }
 
-    $sscc_gs1_company_id = str_pad($yhtiorow['ean'], $company_id_space, 0, STR_PAD_LEFT);
+    $sscc_gs1_company_id = str_pad($yhtiorow['ean'], $company_id_space, 0, STR_PAD_RIGHT);
     $sscc_item_id = str_pad(substr($id, -$item_id_space), $item_id_space, 0, STR_PAD_LEFT);
     $sscc_count = str_pad((int) $n, 2, 0, STR_PAD_LEFT);
 

--- a/tilauskasittely/osoitelappu_intrade_pdf.inc
+++ b/tilauskasittely/osoitelappu_intrade_pdf.inc
@@ -84,7 +84,7 @@ else {
   require_once "pdflib/phppdflib.class.php";
 
   // jos php-gd on installoitu niin loidataab barcode library
-  if (in_array("gd", get_loaded_extensions())) {
+  if (false and in_array("gd", get_loaded_extensions())) {
     if (@include_once "viivakoodi/Barcode.php");
     else include_once "Barcode.php";
   }
@@ -187,7 +187,7 @@ else {
       $kirjainlisa = " ".chr(64+$uniq_merkki);
     }
 
-    if (false and isset($uniq_pakkaukset_sscc[$tulostuskpl]) and $uniq_pakkaukset_sscc[$tulostuskpl] != "") {
+    if (isset($uniq_pakkaukset_sscc[$tulostuskpl]) and $uniq_pakkaukset_sscc[$tulostuskpl] != "") {
       $sscc = $uniq_pakkaukset_sscc[$tulostuskpl];
     }
     elseif ($kuljetusliike_sscc) {
@@ -212,7 +212,7 @@ else {
     // tehdään pdf:n uusi sivu
     $firstpage = $pdf->new_page("a5");
 
-    if (class_exists("Image_Barcode")) {
+    if (false and class_exists("Image_Barcode")) {
       //luodaan viivakoodiolio kuljetusohjeelle = postino
       $nimi = "/tmp/".md5(uniqid(rand(), true)).".jpg";
 

--- a/tilauskasittely/osoitelappu_intrade_pdf.inc
+++ b/tilauskasittely/osoitelappu_intrade_pdf.inc
@@ -187,7 +187,7 @@ else {
       $kirjainlisa = " ".chr(64+$uniq_merkki);
     }
 
-    if (isset($uniq_pakkaukset_sscc[$tulostuskpl]) and $uniq_pakkaukset_sscc[$tulostuskpl] != "") {
+    if (false and isset($uniq_pakkaukset_sscc[$tulostuskpl]) and $uniq_pakkaukset_sscc[$tulostuskpl] != "") {
       $sscc = $uniq_pakkaukset_sscc[$tulostuskpl];
     }
     elseif ($kuljetusliike_sscc) {
@@ -330,14 +330,14 @@ else {
     $pdf->draw_text(mm_pt(22),  mm_pt(120), $laskurow['toim_postino']." ".$laskurow['toim_postitp'],  $firstpage, $iso);
 
     $pdf->draw_text(mm_pt(90), mm_pt(140), "Toimituspvm myym‰l‰‰n:",         $firstpage, $otsik);
-    
+
     if ((int) str_replace("-", "", $laskurow['toimaika']) < date("Ymd")) {
       $_toimaika = date("d.m.Y");
     }
     else {
       $_toimaika = tv1dateconv($laskurow['toimaika']);
     }
-    
+
     $pdf->draw_text(mm_pt(100), mm_pt(135), $_toimaika,                  $firstpage, $norm);
 
     // Kuljetusohjeet = viivakoodi tulee t‰h‰n

--- a/tilauskasittely/osoitelappu_intrade_pdf.inc
+++ b/tilauskasittely/osoitelappu_intrade_pdf.inc
@@ -84,7 +84,7 @@ else {
   require_once "pdflib/phppdflib.class.php";
 
   // jos php-gd on installoitu niin loidataab barcode library
-  if (false and in_array("gd", get_loaded_extensions())) {
+  if (in_array("gd", get_loaded_extensions())) {
     if (@include_once "viivakoodi/Barcode.php");
     else include_once "Barcode.php";
   }
@@ -212,7 +212,7 @@ else {
     // tehdään pdf:n uusi sivu
     $firstpage = $pdf->new_page("a5");
 
-    if (false and class_exists("Image_Barcode")) {
+    if (class_exists("Image_Barcode")) {
       //luodaan viivakoodiolio kuljetusohjeelle = postino
       $nimi = "/tmp/".md5(uniqid(rand(), true)).".jpg";
 


### PR DESCRIPTION
Intrade osoitelapun SSCC koodissa tuli ylimääräinen nolla yrityksen tunnuksen eteen, jos yrityksen tunnus on kuuden merkin mittainen. Korjattu niin, että ylimääräinen nolla tulee yrityksen tunnisteen loppuun. 