### PR TITLE
SQL-hakugeneraattori: tuotteen lisätietojen korjaus

### DIFF
--- a/db_sql_query.php
+++ b/db_sql_query.php
@@ -199,7 +199,7 @@ else {
         $lresult = t_avainsana("LISATIETO");
 
         while ($lrow = mysql_fetch_assoc($lresult)) {
-          $selite = "lisatieto_$srow[selite]";
+          $selite = "lisatieto_$lrow[selite]";
           $chk = !empty($rajaus[$row[0]][$selite]) ? "CHECKED" : "";
 
           $rivi .= "<input type='checkbox' class='$class' name='rajaus[$row[0]][$selite]' value='$selite' $chk>".t("Tuotteen lisätieto").": $lrow[selitetark]<br>";


### PR DESCRIPTION
SQL-hakugeneraattorissa, jos valitsi tuote taulun ja haettavaksi myös tuotteen parametrejä. Sitten tuotteen parametreissä valitsi haettavaksi tuotteen lisätietoja. Tällöin ei exceliin kuitenkaan tullut valitttuja lisätietoja vaikka kyseisiä tietoja olisi tuotteelle ollutkin syötettynä. Lisäksi haun suorittamisen jälkeen valikoituivat kaikki tuotteen lisätiedot ruksatuiksi. Korjattu nyt niin, että tuotteen lisätiedot tulevat exceliin ja valikoituina pysyvät vain ne kohdat, jotka haussa oikeasti olivat valittuina.