### PR TITLE
Myynnistä varastosiirto fix

### DIFF
--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -2513,7 +2513,7 @@ if ($toimittamatta > 0 or trim($var) != '' or $rivityyppi == 'O') {
       ($_tarjouksella or $_osto_myyntitilaukselta or $_extranetista) and
       !in_array($var, array('V', 'H', 'P'))
       and $kpl > 0
-      and in_array($laskurow['tila'], array('N', 'T')) and
+      and in_array($laskurow['tila'], array('N', 'T'))
       and in_array($laskurow['alatila'], array('', 'F'))) {
 
       if (!empty($laskurow['varasto'])) {

--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -2512,7 +2512,9 @@ if ($toimittamatta > 0 or trim($var) != '' or $rivityyppi == 'O') {
       $laskurow["tilaustyyppi"] != "U" and
       ($_tarjouksella or $_osto_myyntitilaukselta or $_extranetista) and
       !in_array($var, array('V', 'H', 'P'))
-      and $kpl > 0) {
+      and $kpl > 0
+      and in_array($laskurow['tila'], array('N', 'T')) and
+      and in_array($laskurow['alatila'], array('', 'F'))) {
 
       if (!empty($laskurow['varasto'])) {
         $kohde_varastot = array($laskurow['varasto']);

--- a/tilauskasittely/tarkistarivi.inc
+++ b/tilauskasittely/tarkistarivi.inc
@@ -1408,7 +1408,7 @@ if ($toim != "VALMISTAVARASTOON" and $row['tuoteno'] != '' and ($yhtiorow['vasta
                 $vastaavat_table .= "<font class='{$siirrettavissa_saldon_font}'>".sprintf("%.2f", $_siirrettavissa)."</font>";
 
                 if ($_eivoisiirtaa) {
-                  $vastaavat_table .= "<font class='error'>".sprintf("%.2f", 0)."</font> )";
+                  $vastaavat_table .= ") <font class='error'>".sprintf("%.2f", 0)."</font>";
                 }
               }
 

--- a/tilauskasittely/tarkistarivi.inc
+++ b/tilauskasittely/tarkistarivi.inc
@@ -1401,13 +1401,13 @@ if ($toim != "VALMISTAVARASTOON" and $row['tuoteno'] != '' and ($yhtiorow['vasta
                 $_siirrettavissa = $siirto_varastot[0]['tuote']['myytavissa'];
                 $siirrettavissa_saldon_font = $_siirrettavissa < 1 ? "error" : "ok";
 
-                if ($_eivoisiirtaa) {
+                if ($_eivoisiirtaa and $siirrettavissa_saldon_font == "ok") {
                   $vastaavat_table .= "(";
                 }
 
                 $vastaavat_table .= "<font class='{$siirrettavissa_saldon_font}'>".sprintf("%.2f", $_siirrettavissa)."</font>";
 
-                if ($_eivoisiirtaa) {
+                if ($_eivoisiirtaa and $siirrettavissa_saldon_font == "ok") {
                   $vastaavat_table .= ") <font class='error'>".sprintf("%.2f", 0)."</font>";
                 }
               }

--- a/tilauskasittely/tarkistarivi.inc
+++ b/tilauskasittely/tarkistarivi.inc
@@ -1395,10 +1395,21 @@ if ($toim != "VALMISTAVARASTOON" and $row['tuoteno'] != '' and ($yhtiorow['vasta
 
                 $siirto_varastot = hae_mahdolliset_siirto_varastot($kohde_varastot, $_tuote['tuoteno']);
 
+                $_eivoisiirtaa = false;
+                if (!in_array($laskurow['tila'], array('N', 'T')) and !in_array($laskurow['alatila'], array('', 'F'))) $_eivoisiirtaa = true;
+
                 $_siirrettavissa = $siirto_varastot[0]['tuote']['myytavissa'];
                 $siirrettavissa_saldon_font = $_siirrettavissa < 1 ? "error" : "ok";
 
+                if ($_eivoisiirtaa) {
+                  $vastaavat_table .= "<font class='error'>".sprintf("%.2f", 0)."</font> (siirtovarastossa ";
+                }
+
                 $vastaavat_table .= "<font class='{$siirrettavissa_saldon_font}'>".sprintf("%.2f", $_siirrettavissa)."</font>";
+
+                if ($_eivoisiirtaa) {
+                  $vastaavat_table .= ")";
+                }
               }
 
               $vastaavat_table .= "</td>";

--- a/tilauskasittely/tarkistarivi.inc
+++ b/tilauskasittely/tarkistarivi.inc
@@ -1402,13 +1402,13 @@ if ($toim != "VALMISTAVARASTOON" and $row['tuoteno'] != '' and ($yhtiorow['vasta
                 $siirrettavissa_saldon_font = $_siirrettavissa < 1 ? "error" : "ok";
 
                 if ($_eivoisiirtaa) {
-                  $vastaavat_table .= "<font class='error'>".sprintf("%.2f", 0)."</font> (siirtovarastossa ";
+                  $vastaavat_table .= "(";
                 }
 
                 $vastaavat_table .= "<font class='{$siirrettavissa_saldon_font}'>".sprintf("%.2f", $_siirrettavissa)."</font>";
 
                 if ($_eivoisiirtaa) {
-                  $vastaavat_table .= ")";
+                  $vastaavat_table .= "<font class='error'>".sprintf("%.2f", 0)."</font> )";
                 }
               }
 


### PR DESCRIPTION
Jos on vastaavat taulukko myynnissä auki ja automaattinen varastosiirto myynnistä päällä, saattoi aikaisemmin käydä niin että rivi meni varastosiirroksi automaattisesti kun vastaavat taulusta vaihdettiin tilauksen tuote, mikäli tilaus oli jo aikaisemmin laitettu valmiiksi. Enää näin ei tapahdu.