### PR TITLE
Kalenterintapahtumatapa tallennetaan aina suomeksi

### DIFF
--- a/crm/asiakasmemo.php
+++ b/crm/asiakasmemo.php
@@ -183,6 +183,21 @@ if (strpos($_SERVER['SCRIPT_NAME'], "asiakasmemo.php") !== FALSE and $ytunnus !=
 
     if ($korjaus == '') {
       if ($viesti != '') {
+        
+        if ($kukarow["kieli"] != 'fi') {
+          $query = "SELECT selite from avainsana
+              where yhtio = '$kukarow[yhtio]'
+              and laji       = 'KALETAPA'
+              and selitetark = '$tapa'
+              and kieli      = '$kukarow[kieli]'";
+          $tapa_res = pupe_query($query);
+          $tapa_row = mysql_fetch_assoc($tapa_res);
+
+          $tapa_res = t_avainsana("KALETAPA","fi","and avainsana.selite = '{$tapa_row['selite']}'");
+          $tapa_row = mysql_fetch_assoc($tapa_res);
+    
+          if (!empty($tapa_row['selitetark'])) $tapa = $tapa_row['selitetark'];
+        }
         $kysely = "INSERT INTO kalenteri
                    SET tapa        = '$tapa',
                    asiakas         = '$ytunnus',

--- a/crm/kalenteri.php
+++ b/crm/kalenteri.php
@@ -215,6 +215,21 @@ if ($tee == 'LISAA') {
       $lkello = $lkello.":00";
     }
 
+    if ($kukarow["kieli"] != 'fi') {
+      $query = "SELECT selite from avainsana
+          where yhtio = '$kukarow[yhtio]'
+          and laji       = 'KALETAPA'
+          and selitetark = '$tapa'
+          and kieli      = '$kukarow[kieli]'";
+      $tapa_res = pupe_query($query);
+      $tapa_row = mysql_fetch_assoc($tapa_res);
+
+      $tapa_res = t_avainsana("KALETAPA","fi","and avainsana.selite = '{$tapa_row['selite']}'");
+      $tapa_row = mysql_fetch_assoc($tapa_res);
+    
+      if (!empty($tapa_row['selitetark'])) $tapa = $tapa_row['selitetark'];
+    }
+    
     $query = "INSERT INTO kalenteri
               SET
               yhtio        = '$kyhtio',


### PR DESCRIPTION
Esim. Edustajaraportti ei osaa hakea kuin suomenkieliset tapahtumat, joten tallennetaan tapahtumatapa aina suomeksi kantaan