### PR TITLE
Ostoehdotus CS: Tuotenro & ääkköset

### DIFF
--- a/inc/tilaa_ajax.inc
+++ b/inc/tilaa_ajax.inc
@@ -5,6 +5,8 @@ $maara = (float) str_replace(",", ".", $maara);
 // Lopetetaan jos tilattava m‰‰r‰ on nolla
 if ($maara > 0) {
 
+  $tuoteno = utf8_decode($tuoteno);
+
   //p‰ivitet‰‰n kukarow[kesken] kun k‰ytt‰j‰ tekee uutta tilausta
   $query = "UPDATE kuka
             SET kesken = 0


### PR DESCRIPTION
Korjattu tilanne jossa tilausriville meni virheellinen tuotenumero jos tuotenumerossa oli Ä tai Ö -kirjaimia