### PR TITLE
Näytetään nimityksen loppu vain oikeassa paikassa

### DIFF
--- a/tilauskasittely/tilausvahvistus-email.inc
+++ b/tilauskasittely/tilausvahvistus-email.inc
@@ -284,6 +284,9 @@ if ($virexx == 0 and strpos($laskurow['tilausvahvistus'], 'P') === FALSE) {
         $nimitysloput = substr($tvtilausrivirow['nimitys'], 29);
         $tvtilausrivirow['nimitys'] = substr($tvtilausrivirow['nimitys'], 0, 29);
       }
+      else {
+        $nimitysloput = '';
+      }
 
       $ulos .= sprintf("%03.0f", $rivino)." ";
       $ulos .= sprintf("%-30.s", $tvtilausrivirow['nimitys']);


### PR DESCRIPTION
Teksti-tyypisessä sähköpostiin lähetettävässä tilausvahvistuksessa pitkä nimitys jaetaan kahdelle riville. 

Nimityksen loppuosa tulostui virheellisesti seuraavillekin riveille, jos niiden nimitystä ei tarvnnut jakaa kahdelle riville. Tämä on nyt korjattu.