### PR TITLE
Ostoehdotusraportti: ei varastoitavat tuotteet

### DIFF
--- a/raportit/ostoehdotus_cs.php
+++ b/raportit/ostoehdotus_cs.php
@@ -657,6 +657,9 @@ if ($tee == "RAPORTOI" and isset($ehdotusnappi)) {
   // loopataan tuotteet läpi
   while ($row = mysql_fetch_assoc($res)) {
 
+    // Paljonko ehdotetaan ostettavaksi
+    $ostoehdotus = 0;
+
     $toimilisa = "";
     if ($toimittajaid != '') $toimilisa = " and tuotteen_toimittajat.liitostunnus = '$toimittajaid' ";
 
@@ -728,12 +731,6 @@ if ($tee == "RAPORTOI" and isset($ehdotusnappi)) {
           $ostoehdotus = $row["tpaikka_tilausmaara"] - $vapaasaldo;
           $ostoehdotus = floor($ostoehdotus / $osto_era) * $osto_era;
         }
-        else {
-          $ostoehdotus = 0;
-        }
-      }
-      else {
-        $ostoehdotus = 0;
       }
     }
     elseif ($toim == "BIO") {
@@ -767,12 +764,6 @@ if ($tee == "RAPORTOI" and isset($ehdotusnappi)) {
 
           $ostoehdotus = round($ostoehdotus, 2);
         }
-        else {
-          $ostoehdotus = 0;
-        }
-      }
-      else {
-        $ostoehdotus = 0;
       }
     }
 

--- a/raportit/ostoehdotus_cs.php
+++ b/raportit/ostoehdotus_cs.php
@@ -728,6 +728,9 @@ if ($tee == "RAPORTOI" and isset($ehdotusnappi)) {
           $ostoehdotus = $row["tpaikka_tilausmaara"] - $vapaasaldo;
           $ostoehdotus = floor($ostoehdotus / $osto_era) * $osto_era;
         }
+        else {
+          $ostoehdotus = 0;
+        }
       }
       else {
         $ostoehdotus = 0;
@@ -763,6 +766,9 @@ if ($tee == "RAPORTOI" and isset($ehdotusnappi)) {
           }
 
           $ostoehdotus = round($ostoehdotus, 2);
+        }
+        else {
+          $ostoehdotus = 0;
         }
       }
       else {


### PR DESCRIPTION
Ostoehdotusraportti toi tilaustuotteita ostoehdotukseen, vaikka näillä tuotteilla olisi ollut saldo + ostossa olevat määrät yhtä suuri kuin myyntitilauksilla oleva määrä. Korjattu nyt niin, että tälläisissä tilanteissa tilaustuotteet eivät ostoehdotusraportille tule.