### PR TITLE
Myynninseuranta: tallennetun kyselyn ajaminen

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -8346,6 +8346,7 @@ if (!function_exists("aja_kysely")) {
           }
 
           ${$row["var"]} = $row["value"];
+          $_POST[$row["var"]] = $row["value"];
         }
       }
 


### PR DESCRIPTION
Myynninseurantaraportissa, jos teki tallennetun haun niin että oli laittanut rajauksen ytunnuksen mukaan. Kun tälläisen tallennetun raportin myöhemmin ajoi uudestaan niin ajo ei toiminut vaan rajaukset katosivat kesken ajon. Nyt tämä on korjattu ja jatkossa myös ytunnuksen mukaan tehtyjen hakujen rajaukset jäävät talteen ja toimivat tallennetun haun ajossa.