### PR TITLE
Saapumiset: saapumiset joilla ei ole laskua

### DIFF
--- a/tilauskasittely/keikka.php
+++ b/tilauskasittely/keikka.php
@@ -829,10 +829,33 @@ if ($toiminto == "" and $ytunnus == "" and $keikka == "") {
             $laatijalisa
             {$kohdistuslisa}
             {$toimipaikkalisa}
-            GROUP BY lasku.liitostunnus
+            GROUP BY lasku.tunnus
             {$havinglisa}
-            ORDER BY lasku.nimi, lasku.nimitark, lasku.ytunnus";
+            ORDER BY lasku.liitostunnus, lasku.nimi, lasku.nimitark, lasku.ytunnus";
   $result = pupe_query($query);
+echo "836 Q $query <br><br>";
+  $rivit = array();
+  $lask;
+
+  while ($row = mysql_fetch_assoc($result)) {
+    if ($row["liitostunnus"] == $rivit[$lask]["liitostunnus"]) {
+      $rivit[$lask]["varastossaarvo"] = $rivit[$lask]["varastossaarvo"] + $row["varastossaarvo"];
+      $rivit[$lask]["varastoonvietyarvo"] = $rivit[$lask]["varastoonvietyarvo"] + $row["varastoonvietyarvo"];
+      $rivit[$lask]["kohdistettuarvo"] = $rivit[$lask]["kohdistettuarvo"] + $row["kohdistettuarvo"];
+
+
+
+    }
+    else {
+      $rivit[] = $row;
+    }
+
+
+    $lask = $lask + 1;
+
+
+
+  }
 
   if (mysql_num_rows($result) > 0) {
 
@@ -843,7 +866,7 @@ if ($toiminto == "" and $ytunnus == "" and $keikka == "") {
 
     $toimipaikka = isset($toimipaikka) ? $toimipaikka : 'kaikki';
 
-    while ($row = mysql_fetch_assoc($result)) {
+    foreach ($rivit as $row) {
 
       $query = "SELECT count(*) num,
                 sum(if(vienti in ('C','F','I','J','K','L'), 1, 0)) volasku,

--- a/tilauskasittely/keikka.php
+++ b/tilauskasittely/keikka.php
@@ -831,7 +831,7 @@ if ($toiminto == "" and $ytunnus == "" and $keikka == "") {
             {$toimipaikkalisa}
             GROUP BY lasku.tunnus
             {$havinglisa}
-            ORDER BY lasku.liitostunnus, lasku.nimi, lasku.nimitark, lasku.ytunnus";
+            ORDER BY lasku.nimi, lasku.nimitark, lasku.ytunnus";
   $result = pupe_query($query);
 
   $rivit = array();

--- a/tilauskasittely/keikka.php
+++ b/tilauskasittely/keikka.php
@@ -835,9 +835,10 @@ if ($toiminto == "" and $ytunnus == "" and $keikka == "") {
   $result = pupe_query($query);
 echo "836 Q $query <br><br>";
   $rivit = array();
-  $lask;
+  $lask = 0;
 
   while ($row = mysql_fetch_assoc($result)) {
+echo "841 lask $lask rowLiitostunnus {$row["liitostunnus"]} == rivitLaskLiitostunnus ",var_dump($rivit)," <br><br>";
     if ($row["liitostunnus"] == $rivit[$lask]["liitostunnus"]) {
       $rivit[$lask]["varastossaarvo"] = $rivit[$lask]["varastossaarvo"] + $row["varastossaarvo"];
       $rivit[$lask]["varastoonvietyarvo"] = $rivit[$lask]["varastoonvietyarvo"] + $row["varastoonvietyarvo"];
@@ -856,7 +857,7 @@ echo "836 Q $query <br><br>";
 
 
   }
-
+echo "<br><br> 859 ",var_dump($rivit[0]["liitostunnus"]),"<br><br><br>";
   if (mysql_num_rows($result) > 0) {
 
     echo "<br><font class='head'>".t("Keskeneräiset saapumiset")."</font><hr>";


### PR DESCRIPTION
Saapumiset ohjelmassa, kun haettiin saapumisia joille ei ole vielä liitetty laskua niin näkymässä ei tullut mukaan niitä toimittajia, joilla oli sekä saapumisia joilla on laskuja ja saapumisia joilla ei ole laskuja. Nyt tämä on korjattu niin, että mukaan tulevat myös ne toimittajat joilla on kaikenlaisia saapumisia haettaessa saapumisia joihin ei ole liitetty laskua.