### PR TITLE
Tarjous: keräyspäivämäärä ja toimitusaika

### DIFF
--- a/tilauskasittely/tilauksesta_myyntitilaus.inc
+++ b/tilauskasittely/tilauksesta_myyntitilaus.inc
@@ -471,8 +471,21 @@ if (!function_exists("tilauksesta_myyntitilaus")) {
       }
 
       $kommentti  = $coprivirow['kommentti'];
-      $kerayspvm  = $coprivirow['kerayspvm'];
-      $toimaika  = $coprivirow['toimaika'];
+
+      if ($coprivirow['kerayspvm'] >= date("Y-m-d")) {
+        $kerayspvm = $coprivirow['kerayspvm'];
+      }
+      else {
+        $kerayspvm = date("Y-m-d");
+      }
+
+      if ($coprivirow['toimaika'] >= date("Y-m-d")) {
+        $toimaika = $coprivirow['toimaika'];
+      }
+      else {
+        $toimaika = date("Y-m-d");
+      }
+
       $alv    = $coprivirow['alv'];
       $ytunnus  = $laskurow["ytunnus"];
       $rivinumero = $coprivirow['tilaajanrivinro'];


### PR DESCRIPTION
Mikäli tarjouksen päivämäärät olivat menneisyydessä muutettiin otsikon päivämäärät tälle päivälle, mutta rivien päivämäärät jäivät menneisyyteen. Ristiriita aiheutti sen, että rivien päivämäärät eivät olleet enää päivitettävissä myyntitilauksella.

Korjattu nyt niin, että myös rivien päivämäärät päivitetään tälle päivälle mikäli ne ovat olleet menneisyydessä tarjouksen hyväksymishetkellä.