### PR TITLE
Korjaus koontiosoitelappuun

### DIFF
--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -1092,7 +1092,8 @@ if ($tee == 'tulosta') {
           if ($toitarow['osoitelappu'] == 'intrade') {
             require 'tilauskasittely/osoitelappu_intrade_pdf.inc';
           }
-          elseif ($toitarow['osoitelappu'] == 'hornbach') {
+          // Hornbach-tyyppisiä osoitelappuja ei tulosteta, kun ollaan tulostamassa koontirahtikirjaa.
+          elseif ($toitarow['osoitelappu'] == 'hornbach' && !in_array($toitarow['tulostustapa'], array('K', 'L'))) {
             require 'tilauskasittely/osoitelappu_hornbach_pdf.inc';
           }
           elseif ($toimitustaparow['osoitelappu'] == 'oslap_mg' and $yhtiorow['kerayserat'] == 'K') {

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -677,6 +677,9 @@ if ($tee == 'tulosta') {
         $lavatyht   += $pak["lavametri"];
       }
 
+      // $kolliyht yliajetaan jossain requiressa, joten otetaan tässä kohtaa arvo talteen ainakin osoitelappujen tulostusta varten
+      $_kolliyht = $kollityht;
+
       // Kuljetusohjeet
       $query = "SELECT trim(group_concat(DISTINCT viesti SEPARATOR ' ')) viesti
                 FROM rahtikirjat
@@ -1061,6 +1064,9 @@ if ($tee == 'tulosta') {
         $params_dgd["komento"] = $dgdkomento;
         print_pdf_dgd($params_dgd);
       }
+
+      // Palautetaan $kolliyht-muuttujalle arvo, jota ei ole yliajettu requireissa, jotta saadaan tulostettua osoitelaput.
+      $kollityht = $_kolliyht;
 
       // Tulostetaan osoitelappu
       if (strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-tulostus.php") !== FALSE or strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-kopio.php") !== FALSE) {

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -1068,6 +1068,9 @@ if ($tee == 'tulosta') {
       // Palautetaan $kolliyht-muuttujalle arvo, jota ei ole yliajettu requireissa, jotta saadaan tulostettua osoitelaput.
       $kollityht = $_kolliyht;
 
+      // Kun ollaan koontierätulostuksessa ja unifaun on käytössä, ei tulosteta osoitelappuja.
+      if ($_onko_unifaun && $toitarow['tulostustapa'] == 'L') $kollityht = 0;
+
       // Tulostetaan osoitelappu
       if (strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-tulostus.php") !== FALSE or strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-kopio.php") !== FALSE) {
         if ($valittu_rakiroslapp_tulostin != "" and $oslapp != '' and $kollityht > 0) {

--- a/tilauskasittely/rahtikirja_pdf.inc
+++ b/tilauskasittely/rahtikirja_pdf.inc
@@ -1,5 +1,7 @@
 <?php
 
+$koontirahtikirja = in_array($toitarow['tulostustapa'], array('K', 'L'));
+
 //  Jos tämä on osa "kokonaistoimitusta", merkataan alkuperäinen tilausnumero alkuun
 if ($rakir_row["tunnusnippu"]>0) {
   foreach ($lotsikot as &$o) {
@@ -326,15 +328,24 @@ else {
       $pdf->draw_text(65,  731,  $postirow["yhtio_postino"]."  ".$postirow["yhtio_postitp"]."  ".$postirow["yhtio_maa"]."    ".$yhtiorow["puhelin"],    $firstpage, $kirj);
 
       //vastaanottaja
+
+      $vastaanottaja = array(
+        'nimi'    => $koontirahtikirja ? $rakir_row['toim_nimi']    : $rakir_row['nimi'],
+        'osoite'  => $koontirahtikirja ? $rakir_row['toim_osoite']  : $rakir_row['osoite'],
+        'postino' => $koontirahtikirja ? $rakir_row['toim_postino'] : $rakir_row['postino'],
+        'postitp' => $koontirahtikirja ? $rakir_row['toim_postitp'] : $rakir_row['postitp'],
+        'maa'     => $koontirahtikirja ? $rakir_row['toim_maa']     : $rakir_row['maa'],
+      );
+
       $pdf->draw_rectangle(713, 60, 696, 300,                      $firstpage, $rectparam);
       $pdf->draw_text(62,  707,  t("Vastaanottaja Mottagare"),            $firstpage, $norm);
       $pdf->draw_text(240, 707,  t("Asiakasnro Kundnr"),                $firstpage, $norm);
-      $pdf->draw_text(65,  699,  $rakir_row["nimi"],                  $firstpage, $kirj);
+      $pdf->draw_text(65, 699, $vastaanottaja["nimi"], $firstpage, $kirj);
       $pdf->draw_text(240, 699,  $rakir_row['rahtisopimus'],              $firstpage, $kirj);
       $pdf->draw_rectangle(696, 60, 684, 300,                      $firstpage, $rectparam);
-      $pdf->draw_text(65,  687,  $rakir_row["osoite"],                $firstpage, $kirj);
+      $pdf->draw_text(65, 687, $vastaanottaja["osoite"], $firstpage, $kirj);
       $pdf->draw_rectangle(684, 60, 672, 300,                      $firstpage, $rectparam);
-      $pdf->draw_text(65,  675,  $rakir_row["postino"]."  ".$rakir_row["postitp"]."  ".$rakir_row["maa"]."    ".$rakir_row["puhelin"],  $firstpage, $kirj);
+      $pdf->draw_text(65, 675, $vastaanottaja["postino"] . "  " . $vastaanottaja["postitp"] . "  " . $vastaanottaja["maa"] . "    " . $rakir_row["puhelin"],  $firstpage, $kirj);
 
       //toimitusosoite
       $pdf->draw_rectangle(657, 60, 640, 300,                        $firstpage, $rectparam);

--- a/tilauskasittely/tulosta_dgd.inc
+++ b/tilauskasittely/tulosta_dgd.inc
@@ -56,7 +56,7 @@ if (!function_exists('alku_dgd')) {
 
     $pdf->pages[$sivu]->drawText($laskurow["rahtikirjanro"], mm_pt(110), mm_pt(263), 'LATIN1');
     // jos tulostustapa on koonti ja toimitustavan takana on annettu osoitetiedot, käytetään niitä
-    if ($toitarow['tulostustapa'] == 'K' and !empty($toitarow['toim_nimi']) and !empty($toitarow['toim_postitp'])) {
+    if (in_array($toitarow['tulostustapa'], array('K', 'L')) and !empty($toitarow['toim_nimi']) and !empty($toitarow['toim_postitp'])) {
       $pdf->pages[$sivu]->drawText($toitarow["toim_nimi"], mm_pt(15), mm_pt(242), 'LATIN1');
       $pdf->pages[$sivu]->drawText($toitarow["toim_osoite"], mm_pt(15), mm_pt(238), 'LATIN1');
       $pdf->pages[$sivu]->drawText($toitarow["toim_postino"]." ".$toitarow["toim_postitp"], mm_pt(15), mm_pt(234), 'LATIN1');


### PR DESCRIPTION
* Tulostetaan koontirahtikirjalle vastaanottajan tiedot toimitustavan takaa
* Käsitellään myös Koonti-erätulostus tulostustapa koontina DGD-lomakkeen tulostuksessa, jolloin consigneen tiedot haetaan toimitustavan takaa.
* Fixataan bugi, joka estää osoitelappujen tulostuksen koontirahtikirjan tulostuksen yhteydessä.
* Ei tulosteta Hornbach-tyyppisiä osoitelappuja, jos ollaan tulostamassa koontirahtikirjaa