### PR TITLE
Mobiili: vie varastoon

### DIFF
--- a/mobiili/vahvista_kerayspaikka.php
+++ b/mobiili/vahvista_kerayspaikka.php
@@ -79,6 +79,14 @@ $alkuperainen_saapuminen = $saapuminen;
 
 // Tullaan nappulasta
 if (isset($submit_button) and trim($submit_button) != '') {
+  // Vaan yks varastoonvienti kerrallaan voi olla käynnissä per firma
+  $lock_params = array(
+  "locktime"    => 600,
+  "lockfile"    => "$kukarow[yhtio]-keikka.lock",
+  "filecontent" => "$otunnus;{$kukarow['kuka']};".date("Y-m-d H:i:s")
+  );
+
+  pupesoft_flock($lock_params);
 
   // Virheet
   $errors = array();


### PR DESCRIPTION
Mobiilin varastoonviennissä oli erittäin pieni mahdollisuus, että laitteen jumittuessa saattoi olla mahdollista viedä sama rivi kahteen kertaan varastoon. Nyt mobiilin varastonvietiin-ohjelmaan on lisätty lukkoja, jotka estävät tämän tuplavarastoonviennin mahdollisuuden.