### PR TITLE
Korjaus Postnordiin lähtevään keräyssanomaan

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -27623,14 +27623,8 @@ if (!function_exists('posten_outbounddelivery')) {
 
     $transport = $custpickinglist->addChild('Transport');
 
-    $toim_ta = t_avainsana('TOIM_TAPA_TA', '', '', '', '', 'selitetark');
-
-    if (empty($toim_ta)) {
-      $transport_account = substr($toimitustapa_chk_row['tunnus'], 0, 10);
-    }
-    else {
-      $transport_account = $toim_ta;
-    }
+    $toim_ta           = $looprow['ohjelma_moduli'] == 'MAGENTO' ? t_avainsana('TOIM_TAPA_TA', '', '', '', '', 'selitetark') : null;
+    $transport_account = $toim_ta ? $toim_ta : substr($toimitustapa_chk_row['tunnus'], 0, 10);
 
     $transport->addChild('TransportAccount', $transport_account);
 
@@ -32874,13 +32868,13 @@ if (!function_exists('tuoteperheen_lapsien_kertoimet')) {
 if (!function_exists('url_or_text')) {
   function url_or_text($str) {
     $array = array("http://", "https://");
-  
+
     foreach($array as $a) {
       if (stripos($str, $a) !== false) {
         return "<a href='{$str}' target='_blank'>".t("Linkki")."</a>";
       }
     }
-  
+
     return $str;
   }
 }


### PR DESCRIPTION
Laitetaan Postnordiin lähtevän keräyssanoman TransportAccount-kentän arvoksi avainsanoissa määritelty TOIM_TAPA_TA ainoastaan, jos tilauksen ohjelma_moduli on MAGENTO.