### PR TITLE
Korjaus Finvoicen sisäänlukuun

### DIFF
--- a/inc/verkkolasku-in-finvoice.inc
+++ b/inc/verkkolasku-in-finvoice.inc
@@ -152,7 +152,6 @@ if (count($tuotetiedot) > 0) {
     $tuote_elementit = array(
       xml_string($tuotetieto->ArticleIdentifier),
       xml_string($tuotetieto->ArticleName),
-      xml_string($tuotetieto->SubInvoiceRow->SubArticleName),
     );
 
     // Otetaan eka arvo, joka ei ole FALSE (null ja empty string on false)
@@ -173,14 +172,7 @@ if (count($tuotetiedot) > 0) {
       $rtuoteno[$i]["nimitys"] = xml_string($tuotetieto->ArticleName);
       $rtuoteno[$i]["riviinfo"] = preg_replace("/ {2,}/", " " , xml_string($tuotetieto->ArticleName));
 
-      // Lista elementeistä prioriteettijärjestyksessä, josta veroton rivihinta voi riviltä löytyä
-      $rivihinta_elementit = array(
-        round(xml_float($tuotetieto->RowVatExcludedAmount), 2),
-        round(xml_float($tuotetieto->SubInvoiceRow->SubRowAmount), 2),
-      );
-
-      // Otetaan eka arvo, joka ei ole FALSE (0, null ja empty string on false)
-      $rtuoteno[$i]["rivihinta"] = current(array_filter($rivihinta_elementit));
+      $rtuoteno[$i]["rivihinta"] = round(xml_float($tuotetieto->RowVatExcludedAmount), 2);
       $rtuoteno[$i]["rivihinta_verolli"] = round(xml_float($tuotetieto->RowAmount), 2);
 
       $rivien_summa_yhteensa += $rtuoteno[$i]["rivihinta_verolli"];


### PR DESCRIPTION
Ei lueta Finvoicen summarivejä mukaan loppusummaan.

http://www.finanssiala.fi/finvoice/dokumentit/Finvoice_2_1_soveltamisohje.pdf:

> 12 SubInvoiceRow
> SubInvoiceRow- kooste-elementti on tarkoitettu laskuriveistä muodostettujen yhteenvetorivien esittämiseen. Finvoice-sanomina välitettävistä laskuista ei muodosteta koontilaskuja. SubInvoice-Row:n avulla voidaan helpottaa laskun tarkastamiskäsittelyä laskun visualisoinnin yhteydessä.
> SubRowAmount-elementtiin tulee edeltävien RowAmount-elementtien yhteenlaskettu summa. Sanoman layoutissa (XSL) rivit tulostuvat tummennettuna tekstinä.
> Laskun loppusummien ja alv-yhteenvetojen laskemiseen käytetään InvoiceRow- kooste- elementin tietoja. SubRow-elementtien tietoja ei käytetä laskun loppusumman laskentaan, koska siitä saattaa aiheutua pyöristyseroja eikä se tue automaattista käsittelyä.
> SubInvoiceRow on InvoiceRow:n ala- kooste-elementti. InvoiceRow sisältää tällöin vain SubInvoice-Row:n.
> SubInvoiceRow:ta voidaan käyttää yksinkertaisimmillaan niin, että SubArticleName- elementtiin kirjoitetaan yhteenvetoa kuvaava teksti ja SubRowAmountiin edellä olevien rivien yhteismäärä.
> Yhteenvetorivin ja varsinaisten laskurivien välinen suhde voidaan ilmoittaa antamalla sama viitetieto yhteenvetorivin SubIdentifier-elementissä ja viiteriviin liittyvien laskurivien RowSubIdentifier-elementissä.
> Välisummarivejä voi olla useampi laskuriviä kohti.
> Laskussa ei voi olla pelkkiä SubInvoicerow:ta, koska esim. laskun loppusumma lasketaan InvoiceRow:n perusteella.