### PR TITLE
Käänteinen ALV

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -3558,11 +3558,28 @@ if (!function_exists("alv")) {
       $alv = 0; //ostotilaus --> ei alvia riveille
     }
     elseif ($alv >= 600) {
-      //Tässä keississä on käänteisen verotuksen
-      if ($laskurow["vienti"] == ""  and $laskurow["alv"] == 0) $alv = 600;              // Otsikolla on valittu veroton myynti, esim Ahvenanmaan myntiä
-      if (($laskurow["vienti"] == "" or $asrow["laji"] == "H") and $laskurow["alv"] != 0) $alv = $trow["alv"]+600; // Otsikolla on valittu verollinen kotimaan myynti
-      if ($laskurow["vienti"] == "E" and $asrow["laji"] != "H") $alv = 600;              // EU-vienti yritykselle --> alviton
-      if ($laskurow["vienti"] == "K") $alv = 600;              // Vienti EU:n ulkopuolelle on aina alviton
+      //Tässä keississä on käänteisen verotuksen alaista myyntiä
+      if ($laskurow["vienti"] == ""  and $laskurow["alv"] == 0) {
+        // Otsikolla on valittu veroton myynti, esim Ahvenanmaan myntiä
+        $alv = 600;
+      }
+      if (($laskurow["vienti"] == "" or $asrow["laji"] == "H") and $laskurow["alv"] != 0) {
+        // Otsikolla on valittu verollinen kotimaan myynti
+        if ($trow["alv"] >= 600) {
+         $alv = $trow["alv"];
+        }
+        else {
+          $alv = $trow["alv"]+600;
+        }
+      }
+      if ($laskurow["vienti"] == "E" and $asrow["laji"] != "H") {
+        // EU-vienti yritykselle --> alviton
+        $alv = 600;
+      }
+      if ($laskurow["vienti"] == "K") {
+        // Vienti EU:n ulkopuolelle on aina alviton
+        $alv = 600;
+      }
 
       $alv = (float) $alv;
     }

--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -353,13 +353,23 @@ $hinta  = str_replace(',', '.', $hinta);
 
 // lis‰t‰‰n alvit (jos hintamuunnos p‰‰ll‰)
 if (isset($tilausrivi_alvillisuus) and $tilausrivi_alvillisuus == "E" and $yhtiorow["alv_kasittely"] == '' and $yhtiorow["alv_kasittely_hintamuunnos"] == 'o' and !is_array($hyvityssaanto_hinta_array)) {
-  if (!isset($alv) or $alv == '') $alv = $trow['alv'];
-  $hinta = round($hinta * (1+$alv/100), $yhtiorow['hintapyoristys']);
+  if (!isset($alv) or $alv == '') {
+    $alv = $trow['alv'];
+  }
+
+  if ($alv < 500) {
+    $hinta = round($hinta * (1+$alv/100), $yhtiorow['hintapyoristys']);
+  }
 }
 // poistetaan alvit (jos hintamuunnos p‰‰ll‰)
 if (isset($tilausrivi_alvillisuus) and $tilausrivi_alvillisuus == "K" and $yhtiorow["alv_kasittely"] == 'o' and $yhtiorow["alv_kasittely_hintamuunnos"] == 'o' and !is_array($hyvityssaanto_hinta_array)) {
-  if (!isset($alv) or $alv == '') $alv = $trow['alv'];
-  $hinta = round($hinta / (1+$alv/100), $yhtiorow['hintapyoristys']);
+  if (!isset($alv) or $alv == '') {
+    $alv = $trow['alv'];
+  }
+
+  if ($alv < 500) {
+    $hinta = round($hinta / (1+$alv/100), $yhtiorow['hintapyoristys']);
+  }
 }
 
 if ($laskurow['tila'] == 'O' or $laskurow['tila'] == 'K') {

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -4673,11 +4673,11 @@ if ($tee == '') {
 
       if ($yhtiorow["alv_kasittely_hintamuunnos"] == 'o') {
         // valittu ei näytetä alveja vaikka hinnat alvillisina
-        if ($tilausrivi_alvillisuus == "E" and $yhtiorow["alv_kasittely"] == '') {
+        if ($tilausrivi_alvillisuus == "E" and $yhtiorow["alv_kasittely"] == '' and $alv < 500) {
           $hinta = round($hinta / (1+$alv/100), $yhtiorow['hintapyoristys']);
         }
         // valittu näytetään alvit vaikka hinnat alvittomia
-        if ($tilausrivi_alvillisuus == "K" and $yhtiorow["alv_kasittely"] == 'o') {
+        if ($tilausrivi_alvillisuus == "K" and $yhtiorow["alv_kasittely"] == 'o' and $alv < 500) {
           $hinta = round($hinta * (1+$alv/100), $yhtiorow['hintapyoristys']);
         }
       }
@@ -8203,7 +8203,7 @@ if ($tee == '') {
           if ($yhtiorow["alv_kasittely"] == "") {
 
             // Oletuksena verolliset hinnat ja ei käännettyä arvonlisäverovelvollisuutta
-            if ($tilausrivi_alvillisuus == "E" and $row["alv"] < 600) {
+            if ($tilausrivi_alvillisuus == "E" and $row["alv"] < 500) {
               $alvillisuus_jako = 1 + $row["alv"] / 100;
             }
             else {


### PR DESCRIPTION
Käänteiset ALVit meni solmuun jos tuotteella oli oletuksena ALV = K.V. 
Käänteiset ALVit meni solmuun myös kun käyttöliittymästä vaihtoi tilauksen alvioletusta ja muokkasi rivejä.