### PR TITLE
Tuotekysely: vastaanotettujen siirtolistojen näkyminen

### DIFF
--- a/tuote.php
+++ b/tuote.php
@@ -1242,7 +1242,7 @@ if (isset($ajax)) {
               WHERE tilausrivi.yhtio         = '$kukarow[yhtio]'
               and tilausrivi.tyyppi          in ('L','E','G','V','W','M','O')
               and tilausrivi.tuoteno         = '$tuoteno'
-              and tilausrivi.laskutettuaika  = '0000-00-00'
+              and ((tilausrivi.laskutettuaika = '0000-00-00' and tilausrivi.tyyppi != 'G') or (tilausrivi.toimitettuaika = '0000-00-00' and tilausrivi.tyyppi = 'G'))
               and (tilausrivi.var != 'P' or (tilausrivi.var = 'P' and lasku.tila != 'D' and lasku.alatila != 'X'))
               ORDER BY pvm, tunnus";
     $jtresult = pupe_query($query);

--- a/tuote.php
+++ b/tuote.php
@@ -1242,8 +1242,8 @@ if (isset($ajax)) {
               WHERE tilausrivi.yhtio         = '$kukarow[yhtio]'
               and tilausrivi.tyyppi          in ('L','E','G','V','W','M','O')
               and tilausrivi.tuoteno         = '$tuoteno'
-              and ((tilausrivi.laskutettuaika = '0000-00-00' and tilausrivi.tyyppi != 'G') or (tilausrivi.toimitettuaika = '0000-00-00' and tilausrivi.tyyppi = 'G'))
-              and (tilausrivi.var != 'P' or (tilausrivi.var = 'P' and lasku.tila != 'D' and lasku.alatila != 'X'))
+              and tilausrivi.laskutettuaika = '0000-00-00'
+              and ((tilausrivi.var != 'P' and tilausrivi.varattu + tilausrivi.jt != 0 ) or (tilausrivi.var = 'P' and lasku.tila != 'D' and lasku.alatila != 'X'))
               ORDER BY pvm, tunnus";
     $jtresult = pupe_query($query);
 

--- a/tuote.php
+++ b/tuote.php
@@ -1243,7 +1243,7 @@ if (isset($ajax)) {
               and tilausrivi.tyyppi          in ('L','E','G','V','W','M','O')
               and tilausrivi.tuoteno         = '$tuoteno'
               and tilausrivi.laskutettuaika = '0000-00-00'
-              and ((tilausrivi.var != 'P' and tilausrivi.varattu + tilausrivi.jt != 0 ) or (tilausrivi.var = 'P' and lasku.tila != 'D' and lasku.alatila != 'X'))
+              and ((tilausrivi.var != 'P' and tilausrivi.varattu + tilausrivi.jt != 0) or (tilausrivi.var = 'P' and lasku.tila != 'D' and lasku.alatila != 'X'))
               ORDER BY pvm, tunnus";
     $jtresult = pupe_query($query);
 


### PR DESCRIPTION
Tuotekyselyssä tuotteen tilaukset kohdassa tulivat näkyviin myös vastaanotetut siirtolista. Korjattu nyt niin, että vastaanotetut siirtolistat eivät tässä näkymässä näy.