### PR TITLE
Myyntitilaus: osatoimitukset

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -6600,7 +6600,7 @@ if ($tee == '') {
     }
     else {
       echo "<tr>$jarjlisa<td class='back' colspan='$sarakkeet' nowrap>";
-      echo "<font class='head'>".t("6586 Tilausrivit")."</font>";
+      echo "<font class='head'>".t("Tilausrivit")."</font>";
 
       $sele = array("K" => "", "E" => "");
 

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -784,10 +784,27 @@ if ((int) $valitsetoimitus_vaihdarivi > 0 and $tilausnumero == $kukarow["kesken"
   $result = pupe_query($query);
 
   if (mysql_num_rows($result) > 0) {
+    $aikalisa = "";
+
+    // Haetaan uuden otsikon kerayspvm ja toimaika siirrettäville tilausriveille
+    // mikäli EI ole käytössä näiden tietojen käsinsyöttö
+    if ($yhtiorow["splittauskielto"] != 'K') {
+      $ajat_query = "SELECT kerayspvm,
+                     toimaika
+                     FROM lasku
+                     WHERE yhtio = '$kukarow[yhtio]'
+                     AND tunnus = $valitsetoimitus_vaihdarivi";
+      $ajat = mysql_fetch_assoc(pupe_query($ajat_query));
+
+      $aikalisa = ", kerayspvm = '{$ajat["kerayspvm"]}', toimaika = '{$ajat["toimaika"]}'";
+    }
+
     while ($aburow = mysql_fetch_assoc($result)) {
       // Vaihdetaan rivin otunnus
       $query = "UPDATE tilausrivi
-                SET otunnus = '$valitsetoimitus_vaihdarivi'
+                SET
+                otunnus = '$valitsetoimitus_vaihdarivi'
+                $aikalisa
                 WHERE yhtio        = '$kukarow[yhtio]'
                 and otunnus        = '$edtilausnumero'
                 and tunnus         = '$aburow[tunnus]'
@@ -6583,7 +6600,7 @@ if ($tee == '') {
     }
     else {
       echo "<tr>$jarjlisa<td class='back' colspan='$sarakkeet' nowrap>";
-      echo "<font class='head'>".t("Tilausrivit")."</font>";
+      echo "<font class='head'>".t("6586 Tilausrivit")."</font>";
 
       $sele = array("K" => "", "E" => "");
 


### PR DESCRIPTION
Osatoimitusten tapauksessa, mikäli eri osatoimitusotsikoilla oli eri kerattypvm & toimajat saattoi käydä niin, että kun tilausrivejä siirrettiin otsikolta toiselle kävi niin ettei tilausrivi kerattypvm ja/tai toimaika enää otsikon tietoja vastannut. Tämä eroavaisuus aiheuttaa se ettei otsikkoon tehtävät muutokset vaikuta enää tämän rivin tietoihin. Korjattu nyt niin, että kerattypvm ja toimaika päivitetään siirrettäville tilausriveille siirron yhteydessä vastaamaan uuden otsikon tietoja.