### PR TITLE
Tarjous: toimitusaika

### DIFF
--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -3857,6 +3857,13 @@ if (isset($jatka)) {
     $ylatila = "";
   }
   else {
+    // Jos ollaan piilottamassa tarjouksen toimitusaikaa niin pitää nollata nämä tiedot myös tilausriveiltä
+    if ($naytetaanko_tarjouksella != 'on' and ($toim == 'TARJOUS' or $toim == 'EXTTARJOUS')) {
+      $toimvv = "0000";
+      $toimkk = "00";
+      $toimpp = "00";
+    }
+
     // Pidetään huolta tilausrivien toimituspäivistä ja kerayspaivasta
     $query = "UPDATE tilausrivi
               SET kerayspvm = '{$kervv}-{$kerkk}-{$kerpp}'


### PR DESCRIPTION
Tarjouksille voi valita näytetäänkö toimitusaikaa vai ei. Toimitusajan tarjoukselta piilottaminen saattoi välillä saada tilausriveille tallennettavan toimitusajan eroamaan tilauksen otsikon toimitusajasta. Tämä aiheutti sen ettei tilausrivien toimitusaikaa saanut enää muutettua. Nyt korjattun niin, ettei tälläistä eroa pääsee enää tapahtumaan.