### PR TITLE
Toimittajapalautukset alv-laskelmalla

### DIFF
--- a/raportit/alv_laskelma_uusi.php
+++ b/raportit/alv_laskelma_uusi.php
@@ -792,6 +792,7 @@ function laskeveroja($taso, $tulos) {
                   and lasku.tapvm   >= '$startmonth'
                   and lasku.tapvm   <= '$endmonth'
                   and lasku.vienti  = 'E'
+                  and lasku.tilaustyyppi != '9'
                   {$kolmikantakauppa}
                   GROUP BY 1,2";
       }


### PR DESCRIPTION
Jos toimittajapalautus oli tehty myyntinä toimittajalle tilaustyypillä 'tehdaspalautus', laskettiin ko. lasku sekä myynteihin että ostojen oikaiuseriin.

Tämä korjattu niin, että toimittajapalautusta ei huomioida myynneissä