### PR TITLE
Jälkitoimitukset: jälkitoimitusten vapauttaminen myyntitilaukselle

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -2641,6 +2641,8 @@ if (($tee == "JT_TILAUKSELLE" and $tila == "jttilaukseen" and $muokkauslukko == 
     and (int) $kukarow['kesken'] > 0
     and $kaytiin_otsikolla == "NOJOO!"
     and $tee == ''
+    and $laskurow["tila"] == "N"
+    and in_array($laskurow["alatila"], array("", "A"))
   )
 ) {
 


### PR DESCRIPTION
Jälkitoimitusrivien vapauttamisessa suoraan myyntitilauksille ei huomioitu ollenkaan myyntitilauksen tilaa vaan jälkitoimitusrivejä vapautettiin myös esimerkiksi toimitettu-tilassa oleville tilauksille. Korjattu nyt niin, että jälkitoimitusrivejä vapautetaan vain kesken tai tulostujononssa oleville myyntitilauksille - eli tilauksille jota ei ole vielä käsitelty liian pitkälle eteenpäin.