### PR TITLE
Tilausvahvistus: toimitusaikakommentit oikealle kielelle

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -25137,7 +25137,7 @@ if (!function_exists('paivita_poikkeavat_tulliprosentit')) {
 }
 
 if (!function_exists('hae_tuotteen_saapumisaika')) {
-  function hae_tuotteen_saapumisaika($tuoteno, $tuote_status, $myytavissa, $loytyko=FALSE, $loytyko_normivarastosta=FALSE) {
+  function hae_tuotteen_saapumisaika($tuoteno, $tuote_status, $myytavissa, $loytyko = FALSE, $loytyko_normivarastosta = FALSE, $kieli = "") {
     global $kukarow, $yhtiorow, $verkkokauppa;
 
     $tulossalisa = array();
@@ -25157,8 +25157,8 @@ if (!function_exists('hae_tuotteen_saapumisaika')) {
         $tulossa_row = mysql_fetch_assoc($tulossa_result);
 
         if (mysql_num_rows($tulossa_result) > 0 and $tulossa_row["paivamaara"] != '') {
-          $tulossalisa[] = "<hr>".t("TULOSSA")."!°!";
-          $tulossalisa[] = t("Arvioitu saapumisp‰iv‰")."!°!".tv1dateconv($tulossa_row['paivamaara']);
+          $tulossalisa[] = "<hr>".t("TULOSSA", $kieli)."!°!";
+          $tulossalisa[] = t("Arvioitu saapumisp‰iv‰", $kieli)."!°!".tv1dateconv($tulossa_row['paivamaara']);
         }
         else {
           $tulossa_query = "SELECT DATE_ADD(curdate(), INTERVAL (if(tuotteen_toimittajat.toimitusaika > 0, tuotteen_toimittajat.toimitusaika, toimi.oletus_toimaika)+if(tuotteen_toimittajat.tilausvali > 0, tuotteen_toimittajat.tilausvali, toimi.oletus_tilausvali)) DAY) paivamaara,
@@ -25175,8 +25175,8 @@ if (!function_exists('hae_tuotteen_saapumisaika')) {
           $tulossa_row = mysql_fetch_assoc($tulossa_result);
 
           if (mysql_num_rows($tulossa_result) > 0 and $tulossa_row["paivamaara"] != '') {
-            $tulossalisa[] = "<hr>".t("TULOSSA")."!°!";
-            $tulossalisa[] = t("Arvioitu saapumisp‰iv‰")."!°!".tv1dateconv($tulossa_row['paivamaara']);
+            $tulossalisa[] = "<hr>".t("TULOSSA", $kieli)."!°!";
+            $tulossalisa[] = t("Arvioitu saapumisp‰iv‰", $kieli)."!°!".tv1dateconv($tulossa_row['paivamaara']);
           }
         }
       }
@@ -25193,8 +25193,8 @@ if (!function_exists('hae_tuotteen_saapumisaika')) {
         $tulossa_row = mysql_fetch_assoc($tulossa_result);
 
         if (mysql_num_rows($tulossa_result) > 0 and $tulossa_row["toimaika"] > 0) {
-          $tulossalisa[] = "<hr><font color='orange'>".t("TILAUSTUOTE")."</font>!°!";
-          $tulossalisa[] = t("Arvioitu toimitusaika")."!°!{$tulossa_row["toimaika"]} ".t("p‰iv‰‰");
+          $tulossalisa[] = "<hr><font color='orange'>".t("TILAUSTUOTE", $kieli)."</font>!°!";
+          $tulossalisa[] = t("Arvioitu toimitusaika", $kieli)."!°!{$tulossa_row["toimaika"]} ".t("p‰iv‰‰", $kieli);
         }
       }
       elseif ($verkkokauppa != "") {
@@ -25208,7 +25208,7 @@ if (!function_exists('hae_tuotteen_saapumisaika')) {
         $tulossa_row = mysql_fetch_assoc($tulossa_result);
 
         if (mysql_num_rows($tulossa_result) > 0 and $tulossa_row["paivamaara"] != '') {
-          $tulossalisa[] = t("Saapuu")."!°!".tv1dateconv($tulossa_row['paivamaara']);
+          $tulossalisa[] = t("Saapuu", $kieli)."!°!".tv1dateconv($tulossa_row['paivamaara']);
         }
         elseif ((float) $myytavissa <= 0) {
           $query = "SELECT toimitusaika
@@ -25221,7 +25221,7 @@ if (!function_exists('hae_tuotteen_saapumisaika')) {
           $tulossa_row = mysql_fetch_assoc($tulossa_result);
 
           if ($tulossa_row["toimitusaika"] > 0) {
-            $tulossalisa[] = t("Toimaika: %s pv.", "", $tulossa_row["toimitusaika"]);
+            $tulossalisa[] = t("Toimaika: %s pv.", $kieli, $tulossa_row["toimitusaika"]);
           }
         }
       }
@@ -25277,14 +25277,14 @@ if (!function_exists('hae_tuotteen_saapumisaika')) {
 
             if (isset($tulossa_row["nimi"]) and $tulossa_row["nimi"] != '') {
               if ($tulossa_row["suoraan_laskutukseen"] != "") {
-                $tulind = t("Suoratoimitus asiakkaalle").":<br>$tulossa_row[nimi]";
+                $tulind = t("Suoratoimitus asiakkaalle", $kieli).":<br>$tulossa_row[nimi]";
               }
               else {
-                $tulind = t("Tilattu asiakkaalle").":<br>$tulossa_row[nimi]";
+                $tulind = t("Tilattu asiakkaalle", $kieli).":<br>$tulossa_row[nimi]";
               }
             }
             else {
-              $tulind = t("TULOSSA");
+              $tulind = t("TULOSSA", $kieli);
             }
 
             $tulossalisa[] = "<hr>$tulind!°!<hr>$tulossa_row[tilattu]".t_avainsana("Y", "", " and avainsana.selite='$tulossa_row[yksikko]'", "", "", "selite");
@@ -25292,7 +25292,7 @@ if (!function_exists('hae_tuotteen_saapumisaika')) {
             if ($tulossa_row["jaksotettu"] == '1') $tarkkuus = "Vahvistettu";
             else $tarkkuus = "Arvioitu";
 
-            $tulossalisa[] = t("$tarkkuus saapumisp‰iv‰")."!°!".tv1dateconv($tulossa_row['paivamaara']);
+            $tulossalisa[] = t("$tarkkuus saapumisp‰iv‰", $kieli)."!°!".tv1dateconv($tulossa_row['paivamaara']);
           }
         }
 
@@ -25311,8 +25311,8 @@ if (!function_exists('hae_tuotteen_saapumisaika')) {
           $tulossa_row = mysql_fetch_assoc($tulossa_result);
 
           if (mysql_num_rows($tulossa_result) > 0) {
-            $tulossalisa[] = "<hr>".t("TULOSSA")."!°!"."<hr>";
-            $tulossalisa[] = t("Arvioitu saapumisp‰iv‰")."!°!".tv1dateconv($tulossa_row['paivamaara']);
+            $tulossalisa[] = "<hr>".t("TULOSSA", $kieli)."!°!"."<hr>";
+            $tulossalisa[] = t("Arvioitu saapumisp‰iv‰", $kieli)."!°!".tv1dateconv($tulossa_row['paivamaara']);
           }
         }
       }
@@ -25330,8 +25330,8 @@ if (!function_exists('hae_tuotteen_saapumisaika')) {
         $tulossa_row = mysql_fetch_assoc($tulossa_result);
 
         if (mysql_num_rows($tulossa_result) > 0 and $tulossa_row["toimaika"] > 0) {
-          $tulossalisa[] = "<hr><font color='orange'>".t("TILAUSTUOTE")."</font>!°!<hr>";
-          $tulossalisa[] = t("Arvioitu toimitusaika")."!°!{$tulossa_row["toimaika"]} ".t("p‰iv‰‰");
+          $tulossalisa[] = "<hr><font color='orange'>".t("TILAUSTUOTE", $kieli)."</font>!°!<hr>";
+          $tulossalisa[] = t("Arvioitu toimitusaika", $kieli)."!°!{$tulossa_row["toimaika"]} ".t("p‰iv‰‰", $kieli);
         }
       }
     }
@@ -25352,8 +25352,8 @@ if (!function_exists('hae_tuotteen_saapumisaika')) {
       $tehdassaldo_res = pupe_query($query);
 
       while ($tehdassaldo_row = mysql_fetch_assoc($tehdassaldo_res)) {
-        $tulossalisa[] = "<hr>".t("Tehtaalla")."!°!<hr>".sprintf("%.2f", $tehdassaldo_row['tehdas_saldo'])." ".t_avainsana("Y", "", " and avainsana.selite='$tehdassaldo_row[yksikko]'", "", "", "selite");
-        $tulossalisa[] = t("Arvioitu toimitusaika")."!°!{$tehdassaldo_row['toimaika']} ".t("p‰iv‰‰");
+        $tulossalisa[] = "<hr>".t("Tehtaalla", $kieli)."!°!<hr>".sprintf("%.2f", $tehdassaldo_row['tehdas_saldo'])." ".t_avainsana("Y", "", " and avainsana.selite='$tehdassaldo_row[yksikko]'", "", "", "selite");
+        $tulossalisa[] = t("Arvioitu toimitusaika", $kieli)."!°!{$tehdassaldo_row['toimaika']} ".t("p‰iv‰‰", $kieli);
       }
     }
 
@@ -31445,7 +31445,7 @@ if (!function_exists("mb_str_split")) {
 }
 
 if (!function_exists("jt_saapumisaika_tilausvahvistus")) {
-  function jt_saapumisaika_tilausvahvistus($tilausrivi, $status) {
+  function jt_saapumisaika_tilausvahvistus($tilausrivi, $status, $kieli = "") {
     global $yhtiorow;
 
     if ($yhtiorow["jt_rivien_saapumisajan_nayttaminen"] == "K" and
@@ -31454,7 +31454,7 @@ if (!function_exists("jt_saapumisaika_tilausvahvistus")) {
       $myytavissa = saldo_myytavissa($tilausrivi["tuoteno"]);
       $myytavissa = $myytavissa[2];
       $saapumisaika = hae_tuotteen_saapumisaika($tilausrivi["tuoteno"],
-        $status, $myytavissa);
+        $status, $myytavissa, false, false, $kieli);
       if (count($saapumisaika > 0)) {
         $saapumisaika = $saapumisaika[1];
 

--- a/tilauskasittely/tulosta_lahete.inc
+++ b/tilauskasittely/tulosta_lahete.inc
@@ -1703,7 +1703,7 @@ if (!function_exists('rivi_lahete')) {
     }
 
     // Lis‰t‰‰n mahdollinen saapumisaika tuoterivin alle, jos kyseess‰ on jt-rivi
-    $saapumisaika = jt_saapumisaika_tilausvahvistus($row, $asrow1["status"]);
+    $saapumisaika = jt_saapumisaika_tilausvahvistus($row, $asrow1["status"], $kieli);
 
     if (!empty($row["kommentti"]) and !empty($saapumisaika)) {
       $row["kommentti"] .= "\n{$saapumisaika}";


### PR DESCRIPTION
Tilausvahvistuksen tilaustuotteiden toimitusaikoja koskevat tiedot menivät aina oletuksena käyttäjän kielelle, jolloin nämä tekstit saattoivat olla eri kielellä kuin koko muu tilausvahvistus. Korjattu niin, että myös nämä tekstit menevät samalla kielellä kuin muu tilausvahvistus.