### PR TITLE
MySQL aliasten kautta määritellyt pakolliset tiedot 

### DIFF
--- a/aloita_synkronointi.php
+++ b/aloita_synkronointi.php
@@ -46,7 +46,7 @@ if ($tee == "SYNK") {
 
   require_once "inc/pakolliset_sarakkeet.inc";
 
-  list($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset) = pakolliset_sarakkeet($table);
+  list($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset, $eisaaollatyhja) = pakolliset_sarakkeet($table);
 
   if (count($wherelliset) == 0 and count($pakolliset) == 0) {
     echo "VIRHE: Pyydetty‰ taulua $table ei voida synkronoida, sit‰ ei ole m‰‰ritelty!<br>";

--- a/asiakasvalinta.inc
+++ b/asiakasvalinta.inc
@@ -12,9 +12,9 @@ function piirra_multiasiakkuusdropdown() {
   global $kukarow;
 
   // Haetaan käyttäjän asiakkuudet
-  $query = "SELECT asiakas.tunnus, asiakas.nimi 
-            FROM customers_users 
-            JOIN asiakas ON (customers_users.customer_id = asiakas.tunnus) 
+  $query = "SELECT asiakas.tunnus, asiakas.nimi
+            FROM customers_users
+            JOIN asiakas ON (customers_users.customer_id = asiakas.tunnus)
             WHERE user_id = '{$kukarow['tunnus']}'";
   $multiresult = pupe_query($query);
 
@@ -25,7 +25,7 @@ function piirra_multiasiakkuusdropdown() {
 
   // Haetaan oletusasiakkuus
   $query = "SELECT asiakas.*
-            FROM asiakas 
+            FROM asiakas
             WHERE asiakas.yhtio = '{$kukarow['yhtio']}'
             AND asiakas.tunnus = '{$kukarow['oletus_asiakas']}'";
   $result = pupe_query($query);

--- a/asiakasvalinta.inc
+++ b/asiakasvalinta.inc
@@ -27,7 +27,7 @@ function piirra_multiasiakkuusdropdown() {
   $query = "SELECT asiakas.*
             FROM asiakas
             WHERE asiakas.yhtio = '{$kukarow['yhtio']}'
-            AND asiakas.tunnus = '{$kukarow['oletus_asiakas']}'";
+            AND asiakas.tunnus  = '{$kukarow['oletus_asiakas']}'";
   $result = pupe_query($query);
   $row = mysql_fetch_assoc($result);
   echo "<form>";
@@ -57,7 +57,7 @@ function paivita_kayttajan_oletusasiakkuus($asiakasvalinta) {
   $query = "UPDATE kuka
             SET oletus_asiakas = '$asiakasvalinta'
             WHERE yhtio = '{$kukarow['yhtio']}'
-            AND tunnus = '{$kukarow['tunnus']}'";
+            AND tunnus  = '{$kukarow['tunnus']}'";
   pupe_query($query);
   $kukarow['oletus_asiakas'] = $asiakasvalinta;
 

--- a/budjetinyllapito_tat.php
+++ b/budjetinyllapito_tat.php
@@ -1519,9 +1519,9 @@ if ($tee == "AJA_RAPORTTI") {
               kuka.myyja
               FROM kuka
               JOIN asiakas ON (asiakas.yhtio = kuka.yhtio AND asiakas.myyjanro = kuka.myyja)
-              WHERE kuka.yhtio = '{$kukarow['yhtio']}'
-              AND kuka.extranet = ''
-              AND kuka.myyja > 0
+              WHERE kuka.yhtio     = '{$kukarow['yhtio']}'
+              AND kuka.extranet    = ''
+              AND kuka.myyja       > 0
               AND asiakas.myyjanro > 0
               {$lisa}";
   }

--- a/budjetinyllapito_tat.php
+++ b/budjetinyllapito_tat.php
@@ -1183,7 +1183,7 @@ if ($tee == "") {
     }
     elseif ($toim == "TOIMITTAJA") {
       $toim_selite = t("Toimittajan");
-    } 
+    }
     elseif ($toim == "ASIAKASMYYJA") {
       $toim_selite = t("Asiakasmyyjän");
     }

--- a/crm/asiakaslista.php
+++ b/crm/asiakaslista.php
@@ -179,18 +179,18 @@ if (isset($tee) and $tee == "lataa_tiedosto") {
             kuka.myyja
             FROM kalenteri
             JOIN asiakas ON (
-              asiakas.yhtio = kalenteri.yhtio AND
-              asiakas.laji != 'P'
+              asiakas.yhtio               = kalenteri.yhtio AND
+              asiakas.laji               != 'P'
               {$asiakaslisa}
             )
             LEFT JOIN yhteyshenkilo ON (
-              kalenteri.yhtio = yhteyshenkilo.yhtio AND
-              kalenteri.henkilo = yhteyshenkilo.tunnus
+              kalenteri.yhtio             = yhteyshenkilo.yhtio AND
+              kalenteri.henkilo           = yhteyshenkilo.tunnus
               {$yhteyshenkilo_rooli_lisa}
             )
             JOIN kuka ON (
-              kuka.yhtio = kalenteri.yhtio AND
-              kuka.kuka = kalenteri.kuka
+              kuka.yhtio                  = kalenteri.yhtio AND
+              kuka.kuka                   = kalenteri.kuka
             )
             WHERE kalenteri.liitostunnus  = asiakas.tunnus
             AND kalenteri.tyyppi          IN ('Memo','Muistutus','Kuittaus','Lead','Myyntireskontraviesti')

--- a/crm/asiakaslista.php
+++ b/crm/asiakaslista.php
@@ -205,8 +205,8 @@ if (isset($tee) and $tee == "lataa_tiedosto") {
   while ($row = mysql_fetch_assoc($res)) {
     fwrite($toot, substr($row['myyja'], 0, 10).";");
 
-    # Halutaan regexpillä numerot ja raput ensimmäiseksi
-    # Esim. Pursimiehenkatu 26 C -> 26 C Pursimiehenkatu
+    // Halutaan regexpillä numerot ja raput ensimmäiseksi
+    // Esim. Pursimiehenkatu 26 C -> 26 C Pursimiehenkatu
     preg_match('/\d.*/', $row['osoite'], $matches);
     $address1 = $matches[0];
 
@@ -227,8 +227,8 @@ if (isset($tee) and $tee == "lataa_tiedosto") {
     fwrite($toot, substr($row['postitp'], 0, 25).";");
     fwrite($toot, substr($address, 0, 60).";");
     fwrite($toot, substr($row['postino'], 0, 10).";");
-    fwrite($toot, ";"); # region
-    fwrite($toot, "{$row['maa']};"); # country
+    fwrite($toot, ";"); // region
+    fwrite($toot, "{$row['maa']};"); // country
     fwrite($toot, substr($row['puhelin'], 0, 30).";");
     fwrite($toot, substr($row['email'], 0, 241).";");
     fwrite($toot, substr($row['luontiaika'], 0, 10));
@@ -608,7 +608,7 @@ if ($crm_haas_check) {
   echo "</font></td></tr>";
 
   echo "<tr>";
-  echo "<th>",t("Valitse CRM Haas -kentät"),"</th>";
+  echo "<th>", t("Valitse CRM Haas -kentät"), "</th>";
   echo "<td>";
   echo "<input type='checkbox' name='crm_haas[call_type]' checked /> CALL_TYPE<br>";
   echo "<input type='checkbox' name='crm_haas[opportunity]' /> OPPORTUNITY<br>";
@@ -618,18 +618,18 @@ if ($crm_haas_check) {
   echo "</tr>";
 
   echo "<tr>";
-  echo "<th>",t("Aikarajaus"),"</th>";
+  echo "<th>", t("Aikarajaus"), "</th>";
   echo "<td>";
-  echo "<input type='text' name='crm_haas_date_alku[]' value='",date('d', mktime(0, 0, 0, date('m'), date('d'), date('Y')-1)),"' size='3' maxlength='2' /> ";
-  echo "<input type='text' name='crm_haas_date_alku[]' value='",date("m", mktime(0, 0, 0, date('m'), date('d'), date('Y')-1)),"' size='3' maxlength='2' /> ";
-  echo "<input type='text' name='crm_haas_date_alku[]' value='",date("Y", mktime(0, 0, 0, date('m'), date('d'), date('Y')-1)),"' size='5' maxlength='4' /> ";
+  echo "<input type='text' name='crm_haas_date_alku[]' value='", date('d', mktime(0, 0, 0, date('m'), date('d'), date('Y')-1)), "' size='3' maxlength='2' /> ";
+  echo "<input type='text' name='crm_haas_date_alku[]' value='", date("m", mktime(0, 0, 0, date('m'), date('d'), date('Y')-1)), "' size='3' maxlength='2' /> ";
+  echo "<input type='text' name='crm_haas_date_alku[]' value='", date("Y", mktime(0, 0, 0, date('m'), date('d'), date('Y')-1)), "' size='5' maxlength='4' /> ";
   echo " - ";
-  echo "<input type='text' name='crm_haas_date_loppu[]' value='",date("d"),"' size='3' maxlength='2' /> ";
-  echo "<input type='text' name='crm_haas_date_loppu[]' value='",date("m"),"' size='3' maxlength='2' /> ";
-  echo "<input type='text' name='crm_haas_date_loppu[]' value='",date("Y"),"' size='5' maxlength='4' /> ";
+  echo "<input type='text' name='crm_haas_date_loppu[]' value='", date("d"), "' size='3' maxlength='2' /> ";
+  echo "<input type='text' name='crm_haas_date_loppu[]' value='", date("m"), "' size='3' maxlength='2' /> ";
+  echo "<input type='text' name='crm_haas_date_loppu[]' value='", date("Y"), "' size='5' maxlength='4' /> ";
   echo "</td>";
   echo "</tr>";
-  echo "<tr><td colspan='2' class='back'><input type='submit' value='",t("Tallenna CSV"),"' /></td></tr>";
+  echo "<tr><td colspan='2' class='back'><input type='submit' value='", t("Tallenna CSV"), "' /></td></tr>";
   echo "</td>";
   echo "</tr>";
   echo "</table>";

--- a/crm/asiakasmemo.php
+++ b/crm/asiakasmemo.php
@@ -276,10 +276,10 @@ if (strpos($_SERVER['SCRIPT_NAME'], "asiakasmemo.php") !== FALSE and $ytunnus !=
 
         if ($kukarow["kieli"] != 'fi') {
           $query = "SELECT selite from avainsana
-              where yhtio = '$kukarow[yhtio]'
-              and laji       = 'KALETAPA'
-              and selitetark = '$tapa'
-              and kieli      = '$kukarow[kieli]'";
+                    where yhtio    = '$kukarow[yhtio]'
+                    and laji       = 'KALETAPA'
+                    and selitetark = '$tapa'
+                    and kieli      = '$kukarow[kieli]'";
           $tapa_res = pupe_query($query);
           $tapa_row = mysql_fetch_assoc($tapa_res);
 

--- a/crm/asiakasmemo.php
+++ b/crm/asiakasmemo.php
@@ -209,45 +209,45 @@ if (strpos($_SERVER['SCRIPT_NAME'], "asiakasmemo.php") !== FALSE and $ytunnus !=
 
     if (!empty($haas_call_type) and $haas_call_type != 'Prospecting Call') {
       if (empty($haas_opportunity)) {
-        echo "<font class='error'>",t("%s on pakollinen.", '', 'OPPORTUNITY'),"</font><br>";
+        echo "<font class='error'>", t("%s on pakollinen.", '', 'OPPORTUNITY'), "</font><br>";
         $tee = '';
       }
 
       if (empty($haas_qty)) {
-        echo "<font class='error'>",t("%s on pakollinen.", '', 'QTY'),"</font><br>";
+        echo "<font class='error'>", t("%s on pakollinen.", '', 'QTY'), "</font><br>";
         $tee = '';
       }
 
       if (empty($_dd) or empty($_mm) or empty($_yy)) {
-        echo "<font class='error'>",t("%s on pakollinen.", '', 'OPP_PROJ_DATE'),"</font><br>";
+        echo "<font class='error'>", t("%s on pakollinen.", '', 'OPP_PROJ_DATE'), "</font><br>";
         $tee = '';
       }
 
       if (in_array($haas_call_type, array('Won Call', 'Lost Call', 'Dead Call')) and empty($haas_end_reason)) {
-        echo "<font class='error'>",t("%s on pakollinen.", '', 'END_REASON'),"</font><br>";
+        echo "<font class='error'>", t("%s on pakollinen.", '', 'END_REASON'), "</font><br>";
         $tee = '';
       }
 
       if (!empty($haas_qty)) {
 
         if (!is_numeric($haas_qty)) {
-          echo "<font class='error'>",t("Kappalem‰‰r‰n t‰ytyy olla numero."),"</font><br>";
+          echo "<font class='error'>", t("Kappalem‰‰r‰n t‰ytyy olla numero."), "</font><br>";
           $tee = '';
         }
 
         if (strlen($haas_qty) > 2) {
-          echo "<font class='error'>",t("Liian suuri kappalem‰‰r‰. M‰‰r‰n maksimipituus on 2."),"</font><br>";
+          echo "<font class='error'>", t("Liian suuri kappalem‰‰r‰. M‰‰r‰n maksimipituus on 2."), "</font><br>";
           $tee = '';
         }
       }
 
       if ((!empty($_dd) or !empty($_mm) or !empty($_yy))) {
         if (!checkdate($_mm, $_dd, $_yy)) {
-          echo "<font class='error'>",t("Virheellinen p‰iv‰m‰‰r‰."),"</font><br>";
+          echo "<font class='error'>", t("Virheellinen p‰iv‰m‰‰r‰."), "</font><br>";
           $tee = '';
         }
         if (checkdate($_mm, $_dd, $_yy) and mktime(0, 0, 0, $_mm, $_dd, $_yy) < mktime(0, 0, 0, date("m"), date("d"), date("Y"))) {
-          echo "<font class='error'>",t("P‰iv‰m‰‰r‰ ei saa olla menneisyydess‰."),"</font><br>";
+          echo "<font class='error'>", t("P‰iv‰m‰‰r‰ ei saa olla menneisyydess‰."), "</font><br>";
           $tee = '';
         }
       }
@@ -283,7 +283,7 @@ if (strpos($_SERVER['SCRIPT_NAME'], "asiakasmemo.php") !== FALSE and $ytunnus !=
           $tapa_res = pupe_query($query);
           $tapa_row = mysql_fetch_assoc($tapa_res);
 
-          $tapa_res = t_avainsana("KALETAPA","fi","and avainsana.selite = '{$tapa_row['selite']}'");
+          $tapa_res = t_avainsana("KALETAPA", "fi", "and avainsana.selite = '{$tapa_row['selite']}'");
           $tapa_row = mysql_fetch_assoc($tapa_res);
 
           if (!empty($tapa_row['selitetark'])) $tapa = $tapa_row['selitetark'];
@@ -775,7 +775,7 @@ if ($ytunnus != '' and $tee == '') {
       echo "<th>CALL_TYPE</th>";
       echo "<td>";
       echo "<select name='haas_call_type' onchange='submit();'>";
-      echo "<option value=''>",t("Valitse"),"</option>";
+      echo "<option value=''>", t("Valitse"), "</option>";
 
       foreach ($call_types as $key => $value) {
         echo "<option value='{$key}' {$call_type_sel[$key]}>{$key}</th>";
@@ -816,7 +816,7 @@ if ($ytunnus != '' and $tee == '') {
         echo "<th>OPPORTUNITY</th>";
         echo "<td>";
         echo "<select name='haas_opportunity'>";
-        echo "<option value=''>",t("Valitse"),"</option>";
+        echo "<option value=''>", t("Valitse"), "</option>";
 
         foreach ($opportunities as $key => $value) {
           echo "<option value='{$key}' {$opportunity_sel[$key]}>{$key}</th>";
@@ -862,7 +862,7 @@ if ($ytunnus != '' and $tee == '') {
           echo "<th>END_REASON</th>";
           echo "<td>";
           echo "<select name='haas_end_reason'>";
-          echo "<option value=''>",t("Valitse"),"</option>";
+          echo "<option value=''>", t("Valitse"), "</option>";
 
           foreach ($end_reasons as $key => $value) {
             echo "<option value='{$key}' {$end_reason_sel[$key]}>{$key}</th>";

--- a/crm/kalenteri.php
+++ b/crm/kalenteri.php
@@ -224,7 +224,7 @@ if ($tee == 'LISAA') {
       $tapa_res = pupe_query($query);
       $tapa_row = mysql_fetch_assoc($tapa_res);
 
-      $tapa_res = t_avainsana("KALETAPA","fi","and avainsana.selite = '{$tapa_row['selite']}'");
+      $tapa_res = t_avainsana("KALETAPA", "fi", "and avainsana.selite = '{$tapa_row['selite']}'");
       $tapa_row = mysql_fetch_assoc($tapa_res);
 
       if (!empty($tapa_row['selitetark'])) $tapa = $tapa_row['selitetark'];

--- a/crm/kalenteri.php
+++ b/crm/kalenteri.php
@@ -226,10 +226,10 @@ if ($tee == 'LISAA') {
 
       $tapa_res = t_avainsana("KALETAPA","fi","and avainsana.selite = '{$tapa_row['selite']}'");
       $tapa_row = mysql_fetch_assoc($tapa_res);
-    
+
       if (!empty($tapa_row['selitetark'])) $tapa = $tapa_row['selitetark'];
     }
-    
+
     $query = "INSERT INTO kalenteri
               SET
               yhtio        = '$kyhtio',

--- a/crm/kalenteri.php
+++ b/crm/kalenteri.php
@@ -217,10 +217,10 @@ if ($tee == 'LISAA') {
 
     if ($kukarow["kieli"] != 'fi') {
       $query = "SELECT selite from avainsana
-          where yhtio = '$kukarow[yhtio]'
-          and laji       = 'KALETAPA'
-          and selitetark = '$tapa'
-          and kieli      = '$kukarow[kieli]'";
+                where yhtio    = '$kukarow[yhtio]'
+                and laji       = 'KALETAPA'
+                and selitetark = '$tapa'
+                and kieli      = '$kukarow[kieli]'";
       $tapa_res = pupe_query($query);
       $tapa_row = mysql_fetch_assoc($tapa_res);
 

--- a/data_import.php
+++ b/data_import.php
@@ -406,7 +406,10 @@ if (empty($_taulu)) {
   $_taulu = array_shift($taulut);
 }
 
-list($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset) = pakolliset_sarakkeet($_taulu);
+list($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset, $eisaaollatyhja) = pakolliset_sarakkeet($_taulu);
+
+$pakolliset = array_merge($pakolliset, $eisaaollatyhja);
+$pakolliset = array_unique($pakolliset);
 
 echo "  <tr><td class='tumma'>".t("Tietokantataulun pakolliset tiedot").":</td>";
 echo "  <td>".strtolower(implode(", ", $pakolliset))."</td></tr>";

--- a/db_sql_query.php
+++ b/db_sql_query.php
@@ -250,7 +250,7 @@ else {
   if ($rtee == "AJA" and isset($ruks_pakolliset)) {
     require "inc/pakolliset_sarakkeet.inc";
 
-    list($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset) = pakolliset_sarakkeet($table);
+    list($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset, $eisaaollatyhja) = pakolliset_sarakkeet($table);
 
     if (!is_array($wherelliset)) {
       $ruksaa = $pakolliset;

--- a/db_sql_query.php
+++ b/db_sql_query.php
@@ -533,12 +533,12 @@ else {
         }
 
         if ($table == "tuote" and in_array("tuote.vienti", $kentat)) {
-          $maaryhmaquery = " SELECT *
-                             FROM avainsana
-                             WHERE yhtio = '{$kukarow['yhtio']}'
-                             and laji    = 'maaryhma'
-                             and selite != ''
-                             ORDER BY jarjestys";
+          $maaryhmaquery = "SELECT *
+                            FROM avainsana
+                            WHERE yhtio  = '{$kukarow['yhtio']}'
+                            and laji     = 'maaryhma'
+                            and selite  != ''
+                            ORDER BY jarjestys";
           $maaryhmares = pupe_query($maaryhmaquery);
           $maaryhma_kaytossa = mysql_num_rows($maaryhmares) > 0 ? true : false;
 

--- a/db_sql_query.php
+++ b/db_sql_query.php
@@ -73,7 +73,7 @@ else {
   $oper_array = array('on' => '=', 'not' => '!=', 'in' => 'in', 'like' => 'like', 'gt' => '>', 'lt' => '<', 'gte' => '>=', 'lte' => '<=');
 
   function db_piirra_otsikot($dbtaulu) {
-    GLOBAL $table;
+    global $table;
 
     echo "<tr><th>".t("Kenttä")."</th><th>".t("Valitse")."</th><th>".t("Operaattori")."</th><th>".t("Rajaus")."</th>";
 
@@ -85,7 +85,7 @@ else {
   }
 
   function db_piirra_rivi($fields) {
-    GLOBAL $kukarow, $kentat, $ruksaa, $operaattori, $rajaus, $jarjestys, $table, $sanakirja_kielet;
+    global $kukarow, $kentat, $ruksaa, $operaattori, $rajaus, $jarjestys, $table, $sanakirja_kielet;
     $kala = array();
 
     foreach ($fields as $row) {
@@ -166,7 +166,7 @@ else {
         $avainsanatyypit["varastopalautus"] = t("Palautus sallittuihin varastoihin");
         $avainsanatyypit["hinnastoryhmittely"] = t("hinnastoryhmittely");
 
-        foreach($avainsanatyypit as $laji => $nimitys) {
+        foreach ($avainsanatyypit as $laji => $nimitys) {
           $chk = !empty($rajaus[$row[0]][$laji]) ? "CHECKED" : "";
 
           $rivi .= "<input type='checkbox' class='$class' name='rajaus[$row[0]][$laji]' value='$laji' $chk>$nimitys<br>";
@@ -492,7 +492,7 @@ else {
                 $order";
     $result = pupe_query($sqlhaku);
 
-    echo "<font class='message'>",query_dump($sqlhaku)."<br>".t("Haun tulos")." ".mysql_num_rows($result)." ".t("riviä").".</font><br><br>";
+    echo "<font class='message'>", query_dump($sqlhaku)."<br>".t("Haun tulos")." ".mysql_num_rows($result)." ".t("riviä").".</font><br><br>";
 
     if (mysql_num_rows($result) > 0) {
       if (include 'inc/pupeExcel.inc') {

--- a/extranet_laiterekisteri.php
+++ b/extranet_laiterekisteri.php
@@ -49,7 +49,7 @@ function piirra_kayttajan_laitteet() {
   }
   else {
     echo "<br><font class='error'>".t('Laiterekisteristä ei löydy yhtään laitetta tai niillä ei ole sopimuksia')."!</font><br/>";
-  } 
+  }
 }
 
 function hae_kayttajan_laitteet() {
@@ -79,7 +79,7 @@ function hae_kayttajan_laitteet() {
             AND avainsana.laji = 'TRY'
             AND avainsana.selite = tuote.try)
             JOIN laitteen_sopimukset ON (laitteen_sopimukset.laitteen_tunnus = laite.tunnus)
-            JOIN tilausrivi ON (laitteen_sopimukset.yhtio = tilausrivi.yhtio 
+            JOIN tilausrivi ON (laitteen_sopimukset.yhtio = tilausrivi.yhtio
             AND laitteen_sopimukset.sopimusrivin_tunnus = tilausrivi.tunnus)
             JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio AND lasku.tunnus = tilausrivi.otunnus)
             WHERE laite.yhtio = '{$kukarow['yhtio']}'

--- a/extranet_laiterekisteri.php
+++ b/extranet_laiterekisteri.php
@@ -74,15 +74,15 @@ function hae_kayttajan_laitteet() {
             tuote.tuotemerkki malli
             FROM laite
             LEFT JOIN tuote ON (tuote.yhtio = laite.yhtio
-            AND tuote.tuoteno = laite.tuoteno)
+            AND tuote.tuoteno                           = laite.tuoteno)
             LEFT JOIN avainsana ON (avainsana.yhtio = tuote.yhtio
-            AND avainsana.laji = 'TRY'
-            AND avainsana.selite = tuote.try)
+            AND avainsana.laji                          = 'TRY'
+            AND avainsana.selite                        = tuote.try)
             JOIN laitteen_sopimukset ON (laitteen_sopimukset.laitteen_tunnus = laite.tunnus)
             JOIN tilausrivi ON (laitteen_sopimukset.yhtio = tilausrivi.yhtio
             AND laitteen_sopimukset.sopimusrivin_tunnus = tilausrivi.tunnus)
             JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio AND lasku.tunnus = tilausrivi.otunnus)
-            WHERE laite.yhtio = '{$kukarow['yhtio']}'
+            WHERE laite.yhtio                           = '{$kukarow['yhtio']}'
             {$toimipistelisa}
             GROUP BY laite.sarjanro,laite.tuoteno";
   $result = pupe_query($query);

--- a/extranet_tyomaaraykset.php
+++ b/extranet_tyomaaraykset.php
@@ -62,7 +62,7 @@ if (isset($livesearch_tee) and $livesearch_tee == "LAITEHAKU") {
 <script>
 
 $(function() {
-  
+
   function confirmation(question) {
       var defer = $.Deferred();
       $('<div></div>')
@@ -90,7 +90,7 @@ $(function() {
     var onkoviesti2 = $('#viesti2').val();
     $('#tarkistusmuuttuja').val('JOO');
     if (onkoviesti1.length > 0) {
-        var question = "<?php 
+        var question = "<?php
           echo t("Laitetta ei löydy laiterekisteristä");
           echo "<br>";
           echo t("Haluatko silti avata huoltopyynnön?");
@@ -102,7 +102,7 @@ $(function() {
         });
     }
     else if (onkoviesti2.length > 0) {
-      var question = "<?php 
+      var question = "<?php
         echo t("Laitetta ei löydy sopimukselta");
         echo "<br>";
         echo t("Haluatko silti avata huoltopyynnön?");
@@ -408,7 +408,7 @@ function piirra_edit_tyomaaraysrivi($request, $piilota = false) {
   echo "<td>";
   echo livesearch_kentta("tyomaarays_form", "LAITEHAKU", "valmnro", 140, $request['tyom_parametrit']['valmnro'], '', '', '', 'ei_break_all');
   echo "</td>";
-  
+
   if (!$piilota) echo "<td></td>";
   echo "<td><textarea cols='40' rows='5' name='komm1'>{$request['tyom_parametrit']['komm1']}</textarea></td>";
   if (!$piilota) echo "<td></td>";
@@ -536,7 +536,7 @@ function hae_laitteen_parametrit($laite_tunnus) {
             AND avainsana.laji = 'TRY'
             AND avainsana.selite = tuote.try)
             LEFT JOIN laitteen_sopimukset ON (laitteen_sopimukset.laitteen_tunnus = laite.tunnus)
-            LEFT JOIN tilausrivi ON (laitteen_sopimukset.yhtio = tilausrivi.yhtio 
+            LEFT JOIN tilausrivi ON (laitteen_sopimukset.yhtio = tilausrivi.yhtio
             AND laitteen_sopimukset.sopimusrivin_tunnus = tilausrivi.tunnus)
             LEFT JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio AND lasku.tunnus = tilausrivi.otunnus)
             WHERE laite.yhtio = '{$kukarow['yhtio']}'

--- a/extranet_tyomaaraykset.php
+++ b/extranet_tyomaaraykset.php
@@ -130,7 +130,7 @@ if (isset($valmnro) and !empty($valmnro)) {
   // Jos on valittu sarjanumero niin yritet‰‰n t‰ytt‰‰ muut laitekent‰t
   $query = "SELECT *
             FROM laite
-            WHERE yhtio = '{$kukarow['yhtio']}'
+            WHERE yhtio  = '{$kukarow['yhtio']}'
             AND sarjanro = '{$valmnro}'
             LIMIT 1";
   $result = pupe_query($query);
@@ -266,8 +266,8 @@ function hae_kayttajan_tyomaaraykset() {
             LEFT JOIN laite ON (laite.yhtio = lasku.yhtio and laite.sarjanro = tyomaarays.valmnro)
             LEFT JOIN tuote ON (tuote.yhtio = laite.yhtio and tuote.tuoteno = laite.tuoteno)
             LEFT JOIN avainsana a6 ON (a6.yhtio = tuote.yhtio and a6.laji = 'TRY' and a6.selite = tuote.try)
-            WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-            AND lasku.tila     in ('A','L','N','S','C')
+            WHERE lasku.yhtio      = '{$kukarow['yhtio']}'
+            AND lasku.tila         in ('A','L','N','S','C')
             {$alatila}
             AND lasku.liitostunnus = '{$kukarow['oletus_asiakas']}'
             GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22
@@ -277,7 +277,7 @@ function hae_kayttajan_tyomaaraykset() {
   while ($row = mysql_fetch_assoc($result)) {
     $historiaquery = "SELECT count(*) tapahtumahistoria_count
                       FROM tyomaarayksen_tapahtumat
-                      WHERE yhtio = '{$kukarow['yhtio']}'
+                      WHERE yhtio           = '{$kukarow['yhtio']}'
                       AND tyomaarays_tunnus = '{$row['tunnus']}'";
     $historiaresult = pupe_query($historiaquery);
     $historiarow = mysql_fetch_assoc($historiaresult);
@@ -464,24 +464,24 @@ function tallenna_tyomaarays($request) {
   // Luodaan uusi lasku
   $query  = "INSERT INTO lasku
              SET yhtio = '{$kukarow['yhtio']}',
-             luontiaika = now(),
-             laatija = '{$kukarow['kuka']}',
-             nimi = '{$asiakastiedot['nimi']}',
-             nimitark = '{$asiakastiedot['nimitark']}',
-             osoite = '{$asiakastiedot['osoite']}',
-             postino = '{$asiakastiedot['postino']}',
-             postitp = '{$asiakastiedot['postitp']}',
-             maa = '{$asiakastiedot['maa']}',
-             toim_nimi     = '{$request['osoite_parametrit']['toim_nimi']}',
-             toim_nimitark = '{$request['osoite_parametrit']['toim_nimitark']}',
-             toim_osoite   = '{$request['osoite_parametrit']['toim_osoite']}',
-             toim_postino  = '{$request['osoite_parametrit']['toim_postino']}',
-             toim_postitp  = '{$request['osoite_parametrit']['toim_postitp']}',
-             toim_maa      = '{$request['osoite_parametrit']['toim_maa']}',
-             ytunnus = '{$asiakastiedot['ytunnus']}',
-             liitostunnus = '{$kukarow['oletus_asiakas']}',
-             tilaustyyppi = 'A',
-             tila = 'A',
+             luontiaika          = now(),
+             laatija             = '{$kukarow['kuka']}',
+             nimi                = '{$asiakastiedot['nimi']}',
+             nimitark            = '{$asiakastiedot['nimitark']}',
+             osoite              = '{$asiakastiedot['osoite']}',
+             postino             = '{$asiakastiedot['postino']}',
+             postitp             = '{$asiakastiedot['postitp']}',
+             maa                 = '{$asiakastiedot['maa']}',
+             toim_nimi           = '{$request['osoite_parametrit']['toim_nimi']}',
+             toim_nimitark       = '{$request['osoite_parametrit']['toim_nimitark']}',
+             toim_osoite         = '{$request['osoite_parametrit']['toim_osoite']}',
+             toim_postino        = '{$request['osoite_parametrit']['toim_postino']}',
+             toim_postitp        = '{$request['osoite_parametrit']['toim_postitp']}',
+             toim_maa            = '{$request['osoite_parametrit']['toim_maa']}',
+             ytunnus             = '{$asiakastiedot['ytunnus']}',
+             liitostunnus        = '{$kukarow['oletus_asiakas']}',
+             tilaustyyppi        = 'A',
+             tila                = 'A',
              tilausyhteyshenkilo = '{$request['osoite_parametrit']['tilausyhteyshenkilo']}'";
   $result = pupe_query($query);
   $utunnus = mysql_insert_id($GLOBALS["masterlink"]);
@@ -502,18 +502,18 @@ function tallenna_tyomaarays($request) {
   // Luodaan uusi tyˆm‰‰r‰ys
   $query  = "INSERT INTO tyomaarays
              SET yhtio = '{$kukarow['yhtio']}',
-             luontiaika = now(),
-             otunnus = '{$utunnus}',
-             laatija = '{$kukarow['kuka']}',
-             tyojono = '1',
-             tyostatus = 'O',
+             luontiaika   = now(),
+             otunnus      = '{$utunnus}',
+             laatija      = '{$kukarow['kuka']}',
+             tyojono      = '1',
+             tyostatus    = 'O',
              prioriteetti = '3',
-             hyvaksy = 'Kyll‰',
-             komm1 = '{$request['tyom_parametrit']['komm1']}',
-             sla = '{$request['tyom_parametrit']['sla']}',
-             mallivari = '{$request['tyom_parametrit']['tuotenro']}',
-             valmnro = '{$request['tyom_parametrit']['valmnro']}',
-             merkki = '{$request['tyom_parametrit']['valmistaja']}'";
+             hyvaksy      = 'Kyll‰',
+             komm1        = '{$request['tyom_parametrit']['komm1']}',
+             sla          = '{$request['tyom_parametrit']['sla']}',
+             mallivari    = '{$request['tyom_parametrit']['tuotenro']}',
+             valmnro      = '{$request['tyom_parametrit']['valmnro']}',
+             merkki       = '{$request['tyom_parametrit']['valmistaja']}'";
   $result  = pupe_query($query);
 
   $request['tyom_tunnus'] = $utunnus;
@@ -531,16 +531,16 @@ function hae_laitteen_parametrit($laite_tunnus) {
             tuote.tuotemerkki malli
             FROM laite
             LEFT JOIN tuote ON (tuote.yhtio = laite.yhtio
-            AND tuote.tuoteno = laite.tuoteno)
+            AND tuote.tuoteno                           = laite.tuoteno)
             LEFT JOIN avainsana ON (avainsana.yhtio = tuote.yhtio
-            AND avainsana.laji = 'TRY'
-            AND avainsana.selite = tuote.try)
+            AND avainsana.laji                          = 'TRY'
+            AND avainsana.selite                        = tuote.try)
             LEFT JOIN laitteen_sopimukset ON (laitteen_sopimukset.laitteen_tunnus = laite.tunnus)
             LEFT JOIN tilausrivi ON (laitteen_sopimukset.yhtio = tilausrivi.yhtio
             AND laitteen_sopimukset.sopimusrivin_tunnus = tilausrivi.tunnus)
             LEFT JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio AND lasku.tunnus = tilausrivi.otunnus)
-            WHERE laite.yhtio = '{$kukarow['yhtio']}'
-            AND laite.tunnus = '{$laite_tunnus}'";
+            WHERE laite.yhtio                           = '{$kukarow['yhtio']}'
+            AND laite.tunnus                            = '{$laite_tunnus}'";
 
   $result = pupe_query($query);
   $row = mysql_fetch_assoc($result);
@@ -571,7 +571,7 @@ function hae_asiakasdata() {
             IF(toim_maa = '', maa, toim_maa) toim_maa
             FROM asiakas
             WHERE asiakas.yhtio = '{$kukarow['yhtio']}'
-            AND asiakas.tunnus = '{$kukarow['oletus_asiakas']}'";
+            AND asiakas.tunnus  = '{$kukarow['oletus_asiakas']}'";
   $result = pupe_query($query);
   $asiakasdata = mysql_fetch_assoc($result);
   return $asiakasdata;
@@ -618,8 +618,8 @@ function puuttuuko_laite_jarjestelmasta($sarjanumero, $tuotenumero) {
   $puuttuu = true;
   $query = "SELECT *
             FROM laite
-            WHERE yhtio = '{$kukarow['yhtio']}'
-            AND tuoteno = '{$tuotenumero}'
+            WHERE yhtio  = '{$kukarow['yhtio']}'
+            AND tuoteno  = '{$tuotenumero}'
             AND sarjanro = '{$sarjanumero}'";
   $result = pupe_query($query);
   if (mysql_num_rows($result) != 0) {
@@ -636,8 +636,8 @@ function puuttuuko_laitteelta_sopimus($sarjanumero, $tuotenumero) {
             FROM laite
             JOIN laitteen_sopimukset ON laite.yhtio = laitteen_sopimukset.yhtio
               AND laite.tunnus = laitteen_sopimukset.laitteen_tunnus
-            WHERE laite.yhtio = '{$kukarow['yhtio']}'
-            AND laite.tuoteno = '{$tuotenumero}'
+            WHERE laite.yhtio  = '{$kukarow['yhtio']}'
+            AND laite.tuoteno  = '{$tuotenumero}'
             AND laite.sarjanro = '{$sarjanumero}'";
   $result = pupe_query($query);
   if (mysql_num_rows($result) != 0) {

--- a/extranet_tyomaaraykset.php
+++ b/extranet_tyomaaraykset.php
@@ -91,10 +91,10 @@ $(function() {
     $('#tarkistusmuuttuja').val('JOO');
     if (onkoviesti1.length > 0) {
         var question = "<?php
-          echo t("Laitetta ei löydy laiterekisteristä");
-          echo "<br>";
-          echo t("Haluatko silti avata huoltopyynnön?");
-        ?>";
+echo t("Laitetta ei löydy laiterekisteristä");
+echo "<br>";
+echo t("Haluatko silti avata huoltopyynnön?");
+?>";
         confirmation(question).then(function (answer) {
             if(answer){
               $('#tyomaarays_form').submit();
@@ -103,10 +103,10 @@ $(function() {
     }
     else if (onkoviesti2.length > 0) {
       var question = "<?php
-        echo t("Laitetta ei löydy sopimukselta");
-        echo "<br>";
-        echo t("Haluatko silti avata huoltopyynnön?");
-      ?>";
+echo t("Laitetta ei löydy sopimukselta");
+echo "<br>";
+echo t("Haluatko silti avata huoltopyynnön?");
+?>";
       confirmation(question).then(function (answer) {
           if(answer){
             $('#tyomaarays_form').submit();

--- a/generoi_tuotepaikkoja.php
+++ b/generoi_tuotepaikkoja.php
@@ -28,7 +28,7 @@ require "inc/functions.inc";
 // Generoidaan jokaiselle yhtiön tuotteelle tuotepaikka jokaiseen yhtiön varastoon
 $query = "SELECT *
           FROM varastopaikat
-          WHERE yhtio = '$yhtio'
+          WHERE yhtio        = '$yhtio'
           AND alkuhyllyalue != '!!M'";
 $varastoresult = pupe_query($query);
 

--- a/huoltopyynto_pdf.inc
+++ b/huoltopyynto_pdf.inc
@@ -101,7 +101,7 @@ $pdf->draw_text(50, 87, $tulostettavat_tiedot['lasku']['toim_maa'],    $firstpag
 //keksit‰‰n uudelle failille joku varmasti uniikki nimi:
 list($usec, $sec) = explode(' ', microtime());
 mt_srand((float) $sec + ((float) $usec * 100000));
-$asiakasnimi = str_replace(" ","", $tulostettavat_tiedot['asiakas']['nimi']);
+$asiakasnimi = str_replace(" ", "", $tulostettavat_tiedot['asiakas']['nimi']);
 $pdffilenimi = "/tmp/huoltopyynto-{$tulostettavat_tiedot['huoltopyynto']}-{$asiakasnimi}.pdf";
 
 //kirjoitetaan pdf faili levylle..

--- a/huoltopyynto_pdf.inc
+++ b/huoltopyynto_pdf.inc
@@ -97,7 +97,7 @@ $pdf->draw_text(50, 120, $tulostettavat_tiedot['lasku']['toim_nimi'],    $firstp
 $pdf->draw_text(50, 109, $tulostettavat_tiedot['lasku']['toim_osoite'],  $firstpage, $pieni);
 $pdf->draw_text(50, 98, $tulostettavat_tiedot['lasku']['toim_postino']."  ".$tulostettavat_tiedot['lasku']['toim_postitp'],  $firstpage, $pieni);
 $pdf->draw_text(50, 87, $tulostettavat_tiedot['lasku']['toim_maa'],    $firstpage, $pieni);
-                                                                                                   
+
 //keksit‰‰n uudelle failille joku varmasti uniikki nimi:
 list($usec, $sec) = explode(' ', microtime());
 mt_srand((float) $sec + ((float) $usec * 100000));
@@ -118,7 +118,7 @@ function hae_tiedot($tyomaaraystunnus) {
 
   // Haetaan asiakastiedot
   $asiakasquery = "SELECT asiakas.*
-                   FROM asiakas 
+                   FROM asiakas
                    WHERE asiakas.yhtio = '{$kukarow['yhtio']}'
                    AND asiakas.tunnus = '{$kukarow['oletus_asiakas']}'";
   $asiakasresult = pupe_query($asiakasquery);
@@ -137,8 +137,8 @@ function hae_tiedot($tyomaaraystunnus) {
   // Haetaan lasku ja laskun lis‰tiedot
   $laskuquery = "SELECT lasku.*
                  FROM lasku
-                 JOIN laskun_lisatiedot ON (lasku.yhtio = laskun_lisatiedot.yhtio 
-                   AND lasku.tunnus = laskun_lisatiedot.otunnus) 
+                 JOIN laskun_lisatiedot ON (lasku.yhtio = laskun_lisatiedot.yhtio
+                   AND lasku.tunnus = laskun_lisatiedot.otunnus)
                  WHERE lasku.yhtio = '{$kukarow['yhtio']}'
                  AND lasku.tunnus = '{$tyomaaraystunnus}'";
   $laskuresult = pupe_query($laskuquery);
@@ -146,7 +146,7 @@ function hae_tiedot($tyomaaraystunnus) {
   $tiedot['lasku'] = $laskurivi;
 
   // Haetaan laitetiedot
-  $laitequery = "SELECT * 
+  $laitequery = "SELECT *
                  FROM laite
                  WHERE yhtio = '{$kukarow['yhtio']}'
                  AND sarjanro = '{$tyomaaraysrivi['valmnro']}'

--- a/huoltopyynto_pdf.inc
+++ b/huoltopyynto_pdf.inc
@@ -120,7 +120,7 @@ function hae_tiedot($tyomaaraystunnus) {
   $asiakasquery = "SELECT asiakas.*
                    FROM asiakas
                    WHERE asiakas.yhtio = '{$kukarow['yhtio']}'
-                   AND asiakas.tunnus = '{$kukarow['oletus_asiakas']}'";
+                   AND asiakas.tunnus  = '{$kukarow['oletus_asiakas']}'";
   $asiakasresult = pupe_query($asiakasquery);
   $asiakasrivi = mysql_fetch_assoc($asiakasresult);
   $tiedot['asiakas'] = $asiakasrivi;
@@ -139,8 +139,8 @@ function hae_tiedot($tyomaaraystunnus) {
                  FROM lasku
                  JOIN laskun_lisatiedot ON (lasku.yhtio = laskun_lisatiedot.yhtio
                    AND lasku.tunnus = laskun_lisatiedot.otunnus)
-                 WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-                 AND lasku.tunnus = '{$tyomaaraystunnus}'";
+                 WHERE lasku.yhtio  = '{$kukarow['yhtio']}'
+                 AND lasku.tunnus   = '{$tyomaaraystunnus}'";
   $laskuresult = pupe_query($laskuquery);
   $laskurivi = mysql_fetch_assoc($laskuresult);
   $tiedot['lasku'] = $laskurivi;
@@ -148,9 +148,9 @@ function hae_tiedot($tyomaaraystunnus) {
   // Haetaan laitetiedot
   $laitequery = "SELECT *
                  FROM laite
-                 WHERE yhtio = '{$kukarow['yhtio']}'
+                 WHERE yhtio  = '{$kukarow['yhtio']}'
                  AND sarjanro = '{$tyomaaraysrivi['valmnro']}'
-                 AND tuoteno = '{$tyomaaraysrivi['mallivari']}'";
+                 AND tuoteno  = '{$tyomaaraysrivi['mallivari']}'";
   $laiteresult = pupe_query($laitequery);
   $laiterivi = mysql_fetch_assoc($laiteresult);
   $tiedot['laite'] = $laiterivi;

--- a/hyvak.php
+++ b/hyvak.php
@@ -1036,7 +1036,7 @@ if (strlen($tunnus) != 0) {
     }
   }
 
-  # Halutaan n‰hd‰ laskun kuva oikealla puolella joten tehd‰‰n table
+  // Halutaan n‰hd‰ laskun kuva oikealla puolella joten tehd‰‰n table
   echo "<table><tr><td class='back'>";
 
   echo "<table>";
@@ -1499,7 +1499,7 @@ if (strlen($tunnus) != 0) {
     echo "</tr></table><br>";
   }
 
-  # Laskun kuva oikealle puolelle
+  // Laskun kuva oikealle puolelle
   echo "</td><td class='back ptop'>";
 
   echo "<table><tr>";

--- a/inc/asiakashaku.inc
+++ b/inc/asiakashaku.inc
@@ -603,7 +603,7 @@ if ($monta > 1 and $monta <= $limit) {
         $brnim .= "<br><font class='error'>".t("HUOM: Tämä on korjaamo-asiakas")."</font>";
       }
 
-      echo "<td>",tarkistahetu($asiakas['ytunnus']),"</td>";
+      echo "<td>", tarkistahetu($asiakas['ytunnus']), "</td>";
       echo "<td>{$asiakas['asiakasnro']}</td>";
       echo "<td>{$asiakas['nimi']} {$asiakas['nimitark']} {$brnim}</td>";
       echo "<td>{$asiakas['osoite']} {$bros}</td>";

--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -1140,9 +1140,9 @@ if ($avain_sel['TYOM_TYOJONO'] == "SELECTED" and $_selitetark_4) {
   $ulos .= "<option value=''>".t('Ei oletusvastuuhenkilöä')."</option>";
   $query = "SELECT *
             FROM kuka
-            WHERE yhtio = '{$kukarow['yhtio']}'
+            WHERE yhtio    = '{$kukarow['yhtio']}'
             AND aktiivinen = 1
-            AND extranet = ''
+            AND extranet   = ''
             ORDER BY nimi";
   $vastuuresult = pupe_query($query);
 

--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -330,8 +330,8 @@ if (mysql_field_name($result, $i) == "laji") {
 
 if (mysql_field_name($result, $i) == "nakyvyys") {
   if (in_array("SELECTED", array($avain_sel["TRY"],
-                                 $avain_sel["OSASTO"],
-                                 $avain_sel["PS_ALA_TRY"]))) {
+        $avain_sel["OSASTO"],
+        $avain_sel["PS_ALA_TRY"]))) {
     $sel = array();
     $sel[$trow[$i]] = "SELECTED";
 

--- a/inc/avainsanatarkista.inc
+++ b/inc/avainsanatarkista.inc
@@ -275,9 +275,9 @@ if (!function_exists("avainsanatarkista")) {
 
       if (empty($virhe) and $tem_laji == 'MAARYHMA' and $tem_selite != $trow['selite'] and $trow['selite'] != '') {
         $query = "UPDATE tuote SET
-                  vienti = '{$tem_selite}'
+                  vienti      = '{$tem_selite}'
                   WHERE yhtio = '{$kukarow['yhtio']}'
-                  AND vienti = '{$trow['selite']}'";
+                  AND vienti  = '{$trow['selite']}'";
         $updres = pupe_query($query);
       }
     }

--- a/inc/connect.inc
+++ b/inc/connect.inc
@@ -3,7 +3,7 @@
 // Tsekataan ajetaanko Pupea Latin1- vai UTF-8-moodissa
 // (Ohjataan mssql.charset-muuttujalla php.ini-tiedostossa)
 if (!defined("PUPE_UNICODE")) {
-  if (get_cfg_var('mssql.charset') == "UTF-8" or @include_once(".PUPE_UNICODE")) {
+  if (get_cfg_var('mssql.charset') == "UTF-8" or @include_once ".PUPE_UNICODE") {
     define("PUPE_UNICODE", TRUE);
   }
   else {

--- a/inc/ftp-send.inc
+++ b/inc/ftp-send.inc
@@ -214,26 +214,26 @@ else {
   // jos siirto epäonnistuu
   if ($palautus != 0) {
     switch ($palautus) {
-      case  1:
-        $syy = "Could not connect to remote host. ($ftphost)";
-        break;
-      case  2:
-        $syy = "Could not login to remote host ($ftpuser, $ftppass)";
-        break;
-      case  3:
-        $syy = "Transfer failed ($ftppath, ".realpath($ftpfile).")";
-        break;
-      case  4:
-        $syy = "Rename failed ($ftppath, {$ftppath}{$ftpfile_tmp} --> {$ftppath}{$filenimi})";
-        break;
-      case  5:
-        $syy = "Rename failed ($ftppath, {$ftppath}{$filenimi} --> {$ftppath}{$renameftpfile})";
-        break;
-      case  6:
-        $syy = "Delete failed ({$ftppath}{$ftpfile_tmp})";
-        break;
-      default:
-        $syy = t("Tuntematon errorkoodi")." ($palautus)!!";
+    case  1:
+      $syy = "Could not connect to remote host. ($ftphost)";
+      break;
+    case  2:
+      $syy = "Could not login to remote host ($ftpuser, $ftppass)";
+      break;
+    case  3:
+      $syy = "Transfer failed ($ftppath, ".realpath($ftpfile).")";
+      break;
+    case  4:
+      $syy = "Rename failed ($ftppath, {$ftppath}{$ftpfile_tmp} --> {$ftppath}{$filenimi})";
+      break;
+    case  5:
+      $syy = "Rename failed ($ftppath, {$ftppath}{$filenimi} --> {$ftppath}{$renameftpfile})";
+      break;
+    case  6:
+      $syy = "Delete failed ({$ftppath}{$ftpfile_tmp})";
+      break;
+    default:
+      $syy = t("Tuntematon errorkoodi")." ($palautus)!!";
     }
 
     pupesoft_log('ftp_send', "Tiedoston '{$ftpfile}' lähetys palvelimelle '{$ftphost}' epäonnistui: {$syy}");

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -3582,7 +3582,7 @@ if (!function_exists("alv")) {
       if (($laskurow["vienti"] == "" or $asrow["laji"] == "H") and $laskurow["alv"] != 0) {
         // Otsikolla on valittu verollinen kotimaan myynti
         if ($trow["alv"] >= 600) {
-         $alv = $trow["alv"];
+          $alv = $trow["alv"];
         }
         else {
           $alv = $trow["alv"]+600;
@@ -7618,7 +7618,7 @@ if (!function_exists("js_openFormInNewWindow")) {
   function js_openFormInNewWindow() {
     static $js_openFormInNewWindowCalled = FALSE;
 
-    # Ekotetaan vain kerran.
+    // Ekotetaan vain kerran.
     if (!$js_openFormInNewWindowCalled) {
       $js_openFormInNewWindowCalled = TRUE;
 ?>
@@ -25508,7 +25508,7 @@ if (!function_exists("saako_myyda_private_label")) {
     //$tarkistakaikkituotteet muuttujalla voidaan funktio pakottaa tutkimaan onko asiakashintoja/alennuksia olemassa, vaikka tuote olisikin normaali hinnasto-tuote (eli tarkistetaan kaikki tuotteet)
     global $kukarow, $yhtiorow;
 
-    # Jos param on "vain extranet" ja jos ei ole extranet niin saa myydä
+    // Jos param on "vain extranet" ja jos ei ole extranet niin saa myydä
     if ($yhtiorow['extranet_private_label'] == 'E' and $kukarow['extranet'] == '') return true;
 
     //haetaan ensin tutkittavan tuotteen tiedot
@@ -27723,7 +27723,7 @@ if (!function_exists('posten_outbounddelivery')) {
     $filename = $pupe_root_polku."/dataout/{$_name}.xml";
 
     if (file_put_contents($filename, $xml->asXML())) {
-      # Lähetetään UTF-8 muodossa jos PUPE_UNICODE on true
+      // Lähetetään UTF-8 muodossa jos PUPE_UNICODE on true
       $ftputf8 = PUPE_UNICODE;
 
       echo "<br /><font class='message'>", t("Tiedoston luonti onnistui"), "</font><br />";
@@ -32639,14 +32639,14 @@ if (!function_exists("loppulaskuta")) {
     $stresult = pupe_query($query);
 
     if (mysql_num_rows($stresult) == 0) {
-      echo "<font class='error'>",t("Otsikkoa '%d' ei löytynyt, tai se on väärässä tilassa.", "", $tunnus),"</font><br><br>";
+      echo "<font class='error'>", t("Otsikkoa '%d' ei löytynyt, tai se on väärässä tilassa.", "", $tunnus), "</font><br><br>";
       return 0;
     }
     else {
       $row = mysql_fetch_assoc($stresult);
 
       if ($row["kaikki"] - ($row["toimitus_valmis"] + $row["rojekti"]) <> 0) {
-        echo "<font class='error'>",t("Laskutussopimuksella on kaikki tilaukset oltava toimitettuna ennen loppulaskutusta."),"</font><br><br>";
+        echo "<font class='error'>", t("Laskutussopimuksella on kaikki tilaukset oltava toimitettuna ennen loppulaskutusta."), "</font><br><br>";
         return 0;
       }
     }
@@ -32772,8 +32772,8 @@ if (!function_exists("loppulaskuta")) {
       $rivikommentti .= "\n ".$posrow["lisatiedot"];
     }
 
-    # Tarkistetaan että ennakkolaskun hyvitysrivi menee kunnolliselle otsikolle
-    # (Voi olla case jossa ennakon kaikki rivit ovat olleet JT-rivejä ja otsikko on mitätöitynyt)
+    // Tarkistetaan että ennakkolaskun hyvitysrivi menee kunnolliselle otsikolle
+    // (Voi olla case jossa ennakon kaikki rivit ovat olleet JT-rivejä ja otsikko on mitätöitynyt)
     $query = "SELECT tunnus, if(lasku.vienti_kurssi = 0, 1, lasku.vienti_kurssi) vienti_kurssi
               FROM lasku
               WHERE yhtio     = '{$kukarow['yhtio']}'
@@ -32991,7 +32991,7 @@ if (!function_exists('url_or_text')) {
   function url_or_text($str) {
     $array = array("http://", "https://");
 
-    foreach($array as $a) {
+    foreach ($array as $a) {
       if (stripos($str, $a) !== false) {
         return "<a href='{$str}' target='_blank'>".t("Linkki")."</a>";
       }
@@ -33064,7 +33064,7 @@ if (!function_exists('tuoteperheiden_hintojen_paivitys')) {
       return;
     }
 
-    foreach($isatunnukset as $isa => $perhe) {
+    foreach ($isatunnukset as $isa => $perhe) {
 
       $tunnukset = implode(", ", $perhe);
 

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -2590,7 +2590,7 @@ if (!function_exists("synkronoi")) {
 
     require_once "inc/pakolliset_sarakkeet.inc";
 
-    list($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset) = pakolliset_sarakkeet($table, '', 'ALA_YHDISTA_MYSQLALIAKSIA');
+    list($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset, $eisaaollatyhja) = pakolliset_sarakkeet($table);
 
     if (count($wherelliset) == 0 and count($pakolliset) == 0) {
       $synclog.= "VIRHE: Pyydetty‰ taulua $table ei voida synkronoida, sit‰ ei ole m‰‰ritelty!\n";

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -1304,9 +1304,9 @@ if (!function_exists("vapauta_sarjanumerot")) {
         if ($srow["tyyppi"] == "W") {
           // Poistetaan valmistusrivin sarjanumero poiston yhteydessä
           $query = "DELETE FROM sarjanumeroseuranta
-                    WHERE yhtio        = '$kukarow[yhtio]'
-                    AND tuoteno        = '$srow[tuoteno]'
-                    AND ostorivitunnus = '$srow[tunnus]'
+                    WHERE yhtio          = '$kukarow[yhtio]'
+                    AND tuoteno          = '$srow[tuoteno]'
+                    AND ostorivitunnus   = '$srow[tunnus]'
                     AND myyntirivitunnus = 0";
           pupe_query($query);
         }
@@ -3376,17 +3376,17 @@ if (!function_exists("tuotteen_myyntihinta")) {
 
       $query = "SELECT *
                 FROM hinnasto
-                WHERE yhtio   = '$kukarow[yhtio]'
-                and tuoteno   = '$trow[tuoteno]'
-                and tuoteno  != ''
-                and laji      in ('N', 'E')
-                and valkoodi  = '$laskurow[valkoodi]'
-                and maa       in ('$laskurow[maa]','')
+                WHERE yhtio                 = '$kukarow[yhtio]'
+                and tuoteno                 = '$trow[tuoteno]'
+                and tuoteno                != ''
+                and laji                    in ('N', 'E')
+                and valkoodi                = '$laskurow[valkoodi]'
+                and maa                     in ('$laskurow[maa]','')
                 and ((alkupvm <= current_date and if (loppupvm = '0000-00-00','9999-12-31',loppupvm) >= current_date) or (alkupvm='0000-00-00' and loppupvm='0000-00-00'))
                 and ((minkpl <= '$kpl' and maxkpl >= '$kpl') or (minkpl = 0 and maxkpl = 0))
                 AND (yhtion_toimipaikka_id IS NULL
-                  OR yhtion_toimipaikka_id = 0
-                  OR yhtion_toimipaikka_id = '{$laskurow["yhtio_toimipaikka"]}')
+                  OR yhtion_toimipaikka_id  = 0
+                  OR yhtion_toimipaikka_id  = '{$laskurow["yhtio_toimipaikka"]}')
                 ORDER BY yhtion_toimipaikka_id DESC,
                          IFNULL(TO_DAYS(current_date)-TO_DAYS(alkupvm),9999999999999),
                          maa DESC
@@ -3406,17 +3406,17 @@ if (!function_exists("tuotteen_myyntihinta")) {
 
       $query = "SELECT *
                 FROM hinnasto
-                WHERE yhtio   = '$kukarow[yhtio]'
-                and tuoteno   = '$trow[tuoteno]'
-                and tuoteno  != ''
-                and laji      in ('N', 'E')
-                and valkoodi  in ('$yhtiorow[valkoodi]','')
-                and maa       in ('$laskurow[maa]','')
+                WHERE yhtio                 = '$kukarow[yhtio]'
+                and tuoteno                 = '$trow[tuoteno]'
+                and tuoteno                != ''
+                and laji                    in ('N', 'E')
+                and valkoodi                in ('$yhtiorow[valkoodi]','')
+                and maa                     in ('$laskurow[maa]','')
                 and ((alkupvm <= current_date and if (loppupvm = '0000-00-00','9999-12-31',loppupvm) >= current_date) or (alkupvm='0000-00-00' and loppupvm='0000-00-00'))
                 and ((minkpl <= '$kpl' and maxkpl >= '$kpl') or (minkpl = 0 and maxkpl = 0))
                 AND (yhtion_toimipaikka_id IS NULL
-                  OR yhtion_toimipaikka_id = 0
-                  OR yhtion_toimipaikka_id = '{$laskurow["yhtio_toimipaikka"]}')
+                  OR yhtion_toimipaikka_id  = 0
+                  OR yhtion_toimipaikka_id  = '{$laskurow["yhtio_toimipaikka"]}')
                 ORDER BY yhtion_toimipaikka_id DESC,
                          IFNULL(TO_DAYS(current_date)-TO_DAYS(alkupvm),9999999999999),
                          valkoodi DESC
@@ -3443,17 +3443,17 @@ if (!function_exists("tuotteen_myyntihinta")) {
 
       $query = "SELECT *
                 FROM hinnasto
-                WHERE yhtio   = '$kukarow[yhtio]'
-                and tuoteno   = '$trow[tuoteno]'
-                and tuoteno  != ''
-                and laji      = ''
-                and valkoodi  = '$laskurow[valkoodi]'
-                and maa       in ('$laskurow[maa]','')
+                WHERE yhtio                 = '$kukarow[yhtio]'
+                and tuoteno                 = '$trow[tuoteno]'
+                and tuoteno                != ''
+                and laji                    = ''
+                and valkoodi                = '$laskurow[valkoodi]'
+                and maa                     in ('$laskurow[maa]','')
                 and ((alkupvm <= current_date and if (loppupvm = '0000-00-00','9999-12-31',loppupvm) >= current_date) or (alkupvm='0000-00-00' and loppupvm='0000-00-00'))
                 and ((minkpl <= '$kpl' and maxkpl >= '$kpl') or (minkpl = 0 and maxkpl = 0))
                 AND (yhtion_toimipaikka_id IS NULL
-                  OR yhtion_toimipaikka_id = 0
-                  OR yhtion_toimipaikka_id = '{$laskurow["yhtio_toimipaikka"]}')
+                  OR yhtion_toimipaikka_id  = 0
+                  OR yhtion_toimipaikka_id  = '{$laskurow["yhtio_toimipaikka"]}')
                 ORDER BY yhtion_toimipaikka_id DESC,
                          IFNULL(TO_DAYS(current_date)-TO_DAYS(alkupvm),9999999999999),
                          maa DESC
@@ -3473,17 +3473,17 @@ if (!function_exists("tuotteen_myyntihinta")) {
 
       $query = "SELECT *
                 FROM hinnasto
-                WHERE yhtio   = '$kukarow[yhtio]'
-                and tuoteno   = '$trow[tuoteno]'
-                and tuoteno  != ''
-                and laji      = ''
-                and valkoodi  in ('$yhtiorow[valkoodi]','')
-                and maa       in ('$laskurow[maa]','')
+                WHERE yhtio                 = '$kukarow[yhtio]'
+                and tuoteno                 = '$trow[tuoteno]'
+                and tuoteno                != ''
+                and laji                    = ''
+                and valkoodi                in ('$yhtiorow[valkoodi]','')
+                and maa                     in ('$laskurow[maa]','')
                 and ((alkupvm <= current_date and if (loppupvm = '0000-00-00','9999-12-31',loppupvm) >= current_date) or (alkupvm='0000-00-00' and loppupvm='0000-00-00'))
                 and ((minkpl <= '$kpl' and maxkpl >= '$kpl') or (minkpl = 0 and maxkpl = 0))
                 AND (yhtion_toimipaikka_id IS NULL
-                  OR yhtion_toimipaikka_id = 0
-                  OR yhtion_toimipaikka_id = '{$laskurow["yhtio_toimipaikka"]}')
+                  OR yhtion_toimipaikka_id  = 0
+                  OR yhtion_toimipaikka_id  = '{$laskurow["yhtio_toimipaikka"]}')
                 ORDER BY yhtion_toimipaikka_id DESC,
                          IFNULL(TO_DAYS(current_date)-TO_DAYS(alkupvm),9999999999999),
                          valkoodi DESC
@@ -5470,17 +5470,17 @@ if (!function_exists("alehinta")) {
 
         $query = "SELECT hinta, laji
                   FROM hinnasto
-                  WHERE yhtio   = '$kukarow[yhtio]'
-                  and tuoteno   = '$trow[tuoteno]'
-                  and tuoteno  != ''
-                  and laji      in ('N', 'E')
-                  and valkoodi  = '$laskurow[valkoodi]'
-                  and maa       in ('$laskurow[maa]','')
+                  WHERE yhtio                 = '$kukarow[yhtio]'
+                  and tuoteno                 = '$trow[tuoteno]'
+                  and tuoteno                != ''
+                  and laji                    in ('N', 'E')
+                  and valkoodi                = '$laskurow[valkoodi]'
+                  and maa                     in ('$laskurow[maa]','')
                   and ((alkupvm <= current_date and if (loppupvm = '0000-00-00','9999-12-31',loppupvm) >= current_date) or (alkupvm='0000-00-00' and loppupvm='0000-00-00'))
                   and ((minkpl <= $kpl and maxkpl >= $kpl) or (minkpl = 0 and maxkpl = 0))
                   AND (yhtion_toimipaikka_id IS NULL
-                    OR yhtion_toimipaikka_id = 0
-                    OR yhtion_toimipaikka_id = '{$laskurow["yhtio_toimipaikka"]}')
+                    OR yhtion_toimipaikka_id  = 0
+                    OR yhtion_toimipaikka_id  = '{$laskurow["yhtio_toimipaikka"]}')
                   ORDER BY yhtion_toimipaikka_id DESC,
                            IFNULL(TO_DAYS(current_date)-TO_DAYS(alkupvm),9999999999999),
                            maa DESC,
@@ -5503,17 +5503,17 @@ if (!function_exists("alehinta")) {
 
         $query = "SELECT hinta, laji
                   FROM hinnasto
-                  WHERE yhtio   = '$kukarow[yhtio]'
-                  and tuoteno   = '$trow[tuoteno]'
-                  and tuoteno  != ''
-                  and laji      in ('N', 'E')
-                  and valkoodi  in ('$yhtiorow[valkoodi]','')
-                  and maa       in ('$laskurow[maa]','')
+                  WHERE yhtio                 = '$kukarow[yhtio]'
+                  and tuoteno                 = '$trow[tuoteno]'
+                  and tuoteno                != ''
+                  and laji                    in ('N', 'E')
+                  and valkoodi                in ('$yhtiorow[valkoodi]','')
+                  and maa                     in ('$laskurow[maa]','')
                   and ((alkupvm <= current_date and if (loppupvm = '0000-00-00','9999-12-31',loppupvm) >= current_date) or (alkupvm='0000-00-00' and loppupvm='0000-00-00'))
                   and ((minkpl <= $kpl and maxkpl >= $kpl) or (minkpl = 0 and maxkpl = 0))
                   AND (yhtion_toimipaikka_id IS NULL
-                    OR yhtion_toimipaikka_id = 0
-                    OR yhtion_toimipaikka_id = '{$laskurow["yhtio_toimipaikka"]}')
+                    OR yhtion_toimipaikka_id  = 0
+                    OR yhtion_toimipaikka_id  = '{$laskurow["yhtio_toimipaikka"]}')
                   ORDER BY yhtion_toimipaikka_id DESC,
                            IFNULL(TO_DAYS(current_date)-TO_DAYS(alkupvm),9999999999999),
                            valkoodi DESC,
@@ -5547,17 +5547,17 @@ if (!function_exists("alehinta")) {
 
         $query = "SELECT hinta, laji
                   FROM hinnasto
-                  WHERE yhtio   = '$kukarow[yhtio]'
-                  and tuoteno   = '$trow[tuoteno]'
-                  and tuoteno  != ''
-                  and laji      = ''
-                  and valkoodi  = '$laskurow[valkoodi]'
-                  and maa       in ('$laskurow[maa]','')
+                  WHERE yhtio                 = '$kukarow[yhtio]'
+                  and tuoteno                 = '$trow[tuoteno]'
+                  and tuoteno                != ''
+                  and laji                    = ''
+                  and valkoodi                = '$laskurow[valkoodi]'
+                  and maa                     in ('$laskurow[maa]','')
                   and ((alkupvm <= current_date and if (loppupvm = '0000-00-00','9999-12-31',loppupvm) >= current_date) or (alkupvm='0000-00-00' and loppupvm='0000-00-00'))
                   and ((minkpl <= $kpl and maxkpl >= $kpl) or (minkpl = 0 and maxkpl = 0))
                   AND (yhtion_toimipaikka_id IS NULL
-                    OR yhtion_toimipaikka_id = 0
-                    OR yhtion_toimipaikka_id = '{$laskurow["yhtio_toimipaikka"]}')
+                    OR yhtion_toimipaikka_id  = 0
+                    OR yhtion_toimipaikka_id  = '{$laskurow["yhtio_toimipaikka"]}')
                   ORDER BY yhtion_toimipaikka_id DESC,
                            IFNULL(TO_DAYS(current_date)-TO_DAYS(alkupvm),9999999999999),
                            maa DESC,
@@ -5580,17 +5580,17 @@ if (!function_exists("alehinta")) {
 
         $query = "SELECT hinta, laji
                   FROM hinnasto
-                  WHERE yhtio   = '$kukarow[yhtio]'
-                  and tuoteno   = '$trow[tuoteno]'
-                  and tuoteno  != ''
-                  and laji      = ''
-                  and valkoodi  in ('$yhtiorow[valkoodi]','')
-                  and maa       in ('$laskurow[maa]','')
+                  WHERE yhtio                 = '$kukarow[yhtio]'
+                  and tuoteno                 = '$trow[tuoteno]'
+                  and tuoteno                != ''
+                  and laji                    = ''
+                  and valkoodi                in ('$yhtiorow[valkoodi]','')
+                  and maa                     in ('$laskurow[maa]','')
                   and ((alkupvm <= current_date and if (loppupvm = '0000-00-00','9999-12-31',loppupvm) >= current_date) or (alkupvm='0000-00-00' and loppupvm='0000-00-00'))
                   and ((minkpl <= $kpl and maxkpl >= $kpl) or (minkpl = 0 and maxkpl = 0))
                   AND (yhtion_toimipaikka_id IS NULL
-                    OR yhtion_toimipaikka_id = 0
-                    OR yhtion_toimipaikka_id = '{$laskurow["yhtio_toimipaikka"]}')
+                    OR yhtion_toimipaikka_id  = 0
+                    OR yhtion_toimipaikka_id  = '{$laskurow["yhtio_toimipaikka"]}')
                   ORDER BY yhtion_toimipaikka_id DESC,
                            IFNULL(TO_DAYS(current_date)-TO_DAYS(alkupvm),9999999999999),
                            valkoodi DESC,
@@ -10350,7 +10350,7 @@ if (!function_exists("livesearch_laitehaku")) {
 
       $query = "SELECT DISTINCT sarjanro
                 FROM laite
-                WHERE yhtio     = '{$kukarow['yhtio']}'
+                WHERE yhtio  = '{$kukarow['yhtio']}'
                 {$toimipistelisa}
                 AND sarjanro LIKE '%{$haku}%'";
       $result = pupe_query($query);
@@ -10430,8 +10430,8 @@ if (!function_exists("livesearch_tullinimikehaku")) {
 
       $query = "SELECT cn, dm
                 FROM tullinimike
-                WHERE kieli = '{$yhtiorow['kieli']}'
-                AND cn != ''";
+                WHERE kieli  = '{$yhtiorow['kieli']}'
+                AND cn      != ''";
       $result = pupe_query($query);
 
       $limit = 0;
@@ -25524,12 +25524,12 @@ if (!function_exists("saako_myyda_private_label")) {
 
       //haetaan asiakkaan tiedot
       $query = "SELECT tunnus liitostunnus,
-                       ytunnus,
-                       valkoodi,
-                       maa,
-                       ryhma,
-                       piiri,
-                       toimipaikka AS yhtio_toimipaikka
+                ytunnus,
+                valkoodi,
+                maa,
+                ryhma,
+                piiri,
+                toimipaikka AS yhtio_toimipaikka
                 FROM asiakas
                 WHERE yhtio = '$kukarow[yhtio]'
                 AND tunnus  = '$asiakastunnus'";
@@ -26461,29 +26461,29 @@ if (!function_exists('paivita_rahtikirjat_tulostetuksi_ja_toimitetuksi')) {
 
     // kotimaan myynti menee alatilaan D
     $query = "UPDATE lasku SET
-              alatila = 'D'
-              WHERE tunnus IN ({$otunnukset})
-              AND vienti = ''
-              AND yhtio = '{$kukarow['yhtio']}'
-              AND alatila != 'X'";
+              alatila       = 'D'
+              WHERE tunnus  IN ({$otunnukset})
+              AND vienti    = ''
+              AND yhtio     = '{$kukarow['yhtio']}'
+              AND alatila  != 'X'";
     $ures  = pupe_query($query);
 
     // vientilaskut menee alatilaan B
     $query = "UPDATE lasku SET
-              alatila = 'B'
-              WHERE tunnus IN ({$otunnukset})
-              AND vienti != ''
-              AND yhtio = '{$kukarow['yhtio']}'
-              AND alatila != 'X'";
+              alatila       = 'B'
+              WHERE tunnus  IN ({$otunnukset})
+              AND vienti   != ''
+              AND yhtio     = '{$kukarow['yhtio']}'
+              AND alatila  != 'X'";
     $ures  = pupe_query($query);
 
     // jos laskulla on maksupositioita, menee ne alatilaan J
     $query = "UPDATE lasku SET
-              alatila = 'J'
-              WHERE tunnus IN ({$otunnukset})
+              alatila         = 'J'
+              WHERE tunnus    IN ({$otunnukset})
               AND jaksotettu != 0
-              AND yhtio = '{$kukarow['yhtio']}'
-              AND alatila != 'X'";
+              AND yhtio       = '{$kukarow['yhtio']}'
+              AND alatila    != 'X'";
     $ures  = pupe_query($query);
 
     // verkkolaskutettavat EU-viennit menee alatilaan D, jos niillä on tarpeeksi lisätietoja
@@ -26497,7 +26497,7 @@ if (!function_exists('paivita_rahtikirjat_tulostetuksi_ja_toimitetuksi')) {
               AND maa_maara               != ''
               AND kauppatapahtuman_luonne  > 0
               AND kuljetusmuoto           != ''
-              AND alatila != 'X'";
+              AND alatila                 != 'X'";
     $ures  = pupe_query($query);
 
     // Etukäteen maksetut tilaukset pitää muuttaa takaisin "maksettu"-tilaan
@@ -27557,19 +27557,19 @@ if (!function_exists('posten_outbounddelivery')) {
               FROM lasku
               LEFT JOIN asiakas ON (asiakas.yhtio = lasku.yhtio AND asiakas.tunnus = lasku.liitostunnus)
               JOIN tilausrivi ON (
-                tilausrivi.yhtio = lasku.yhtio AND
-                tilausrivi.otunnus = lasku.tunnus AND
+                tilausrivi.yhtio    = lasku.yhtio AND
+                tilausrivi.otunnus  = lasku.tunnus AND
                 (tilausrivi.varattu + tilausrivi.kpl) > 0 AND
-                tilausrivi.tyyppi IN ('L', 'G') AND
-                tilausrivi.var != 'J'
+                tilausrivi.tyyppi   IN ('L', 'G') AND
+                tilausrivi.var     != 'J'
               )
               JOIN tuote ON (
-                tuote.yhtio = tilausrivi.yhtio AND
-                tuote.tuoteno = tilausrivi.tuoteno AND
-                tuote.ei_saldoa = ''
+                tuote.yhtio         = tilausrivi.yhtio AND
+                tuote.tuoteno       = tilausrivi.tuoteno AND
+                tuote.ei_saldoa     = ''
               )
-              WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-              AND lasku.tunnus  = '{$otunnus}'";
+              WHERE lasku.yhtio     = '{$kukarow['yhtio']}'
+              AND lasku.tunnus      = '{$otunnus}'";
     $loopres = pupe_query($query);
 
     if (mysql_num_rows($loopres) == 0) return;
@@ -31556,10 +31556,10 @@ if (!function_exists("vapauta_maksusopimus")) {
 
       $query = "SELECT *
                 FROM lasku
-                WHERE yhtio = '{$kukarow['yhtio']}'
+                WHERE yhtio    = '{$kukarow['yhtio']}'
                 AND jaksotettu = '{$maksusoppari}'
-                AND tila = 'N'
-                AND alatila = 'B'";
+                AND tila       = 'N'
+                AND alatila    = 'B'";
       $laskures = pupe_query($query);
 
       while ($laskurow = mysql_fetch_assoc($laskures)) {
@@ -32594,8 +32594,8 @@ if (!function_exists('generoi_hinnastot')) {
       $query = "SELECT hinta
                 FROM hinnasto
                 WHERE tuoteno = '{$tuote["tuoteno"]}'
-                AND yhtio = '{$kukarow["yhtio"]}'
-                AND valkoodi = '{$valuu["nimi"]}'
+                AND yhtio     = '{$kukarow["yhtio"]}'
+                AND valkoodi  = '{$valuu["nimi"]}'
                 AND ((alkupvm <= current_date AND if(loppupvm = '0000-00-00', '9999-12-31', loppupvm) >= current_date) OR (alkupvm = '0000-00-00' AND loppupvm = '0000-00-00'))
                 ORDER BY IFNULL(TO_DAYS(current_date) - TO_DAYS(alkupvm), 9999999999999), maa DESC
                 LIMIT 1";
@@ -32742,14 +32742,14 @@ if (!function_exists("loppulaskuta")) {
               tilausrivi.alv
               FROM lasku
               JOIN tilausrivi ON (
-                tilausrivi.yhtio = lasku.yhtio
-                AND tilausrivi.otunnus = lasku.tunnus
-                AND tilausrivi.kpl != 0
-                AND tilausrivi.uusiotunnus > 0
-                AND tilausrivi.tuoteno = '{$yhtiorow['ennakkomaksu_tuotenumero']}'
+                tilausrivi.yhtio            = lasku.yhtio
+                AND tilausrivi.otunnus      = lasku.tunnus
+                AND tilausrivi.kpl         != 0
+                AND tilausrivi.uusiotunnus  > 0
+                AND tilausrivi.tuoteno      = '{$yhtiorow['ennakkomaksu_tuotenumero']}'
               )
-              WHERE lasku.yhtio    = '{$kukarow['yhtio']}'
-              AND lasku.jaksotettu = '".($tunnus * -1)."'
+              WHERE lasku.yhtio             = '{$kukarow['yhtio']}'
+              AND lasku.jaksotettu          = '".($tunnus * -1)."'
               GROUP BY alv";
     $sresult = pupe_query($query);
 
@@ -32757,7 +32757,7 @@ if (!function_exists("loppulaskuta")) {
     $query = "SELECT kieli
               FROM asiakas
               WHERE yhtio = '{$kukarow['yhtio']}'
-              AND tunnus = '{$laskurow['liitostunnus']}'";
+              AND tunnus  = '{$laskurow['liitostunnus']}'";
     $kielires = pupe_query($query);
     $kielirow = mysql_fetch_assoc($kielires);
 
@@ -32776,11 +32776,11 @@ if (!function_exists("loppulaskuta")) {
     # (Voi olla case jossa ennakon kaikki rivit ovat olleet JT-rivejä ja otsikko on mitätöitynyt)
     $query = "SELECT tunnus, if(lasku.vienti_kurssi = 0, 1, lasku.vienti_kurssi) vienti_kurssi
               FROM lasku
-              WHERE yhtio = '{$kukarow['yhtio']}'
-              AND jaksotettu = '{$tunnus}'
-              AND tunnus != '{$tunnus}'
-              AND tila = 'L'
-              AND alatila != 'X'
+              WHERE yhtio     = '{$kukarow['yhtio']}'
+              AND jaksotettu  = '{$tunnus}'
+              AND tunnus     != '{$tunnus}'
+              AND tila        = 'L'
+              AND alatila    != 'X'
               ORDER BY tunnus DESC
               LIMIT 1";
     $tunnus_chk_res = pupe_query($query);
@@ -32804,15 +32804,15 @@ if (!function_exists("loppulaskuta")) {
       }
 
       $query  = "INSERT INTO tilausrivi (
-                  hinta, netto, varattu, tilkpl, otunnus, tuoteno, nimitys, yhtio, tyyppi, alv,
-                  kommentti, keratty, kerattyaika, toimitettu, toimitettuaika, laatija, laadittu
-                )
-                VALUES (
-                  '{$laskutettu}', 'N', '-1', '-1', '{$ennakkolaskun_hyvitys_otunnus}',
-                  '{$yhtiorow['ennakkomaksu_tuotenumero']}', '{$nimitys}', '{$kukarow['yhtio']}', 'L',
-                  '{$row['alv']}', '{$rivikommentti}', '{$kukarow['kuka']}', now(), '{$kukarow['kuka']}',
-                  now(), '{$kukarow['kuka']}', now()
-                )";
+                 hinta, netto, varattu, tilkpl, otunnus, tuoteno, nimitys, yhtio, tyyppi, alv,
+                 kommentti, keratty, kerattyaika, toimitettu, toimitettuaika, laatija, laadittu
+                 )
+                 VALUES (
+                 '{$laskutettu}', 'N', '-1', '-1', '{$ennakkolaskun_hyvitys_otunnus}',
+                 '{$yhtiorow['ennakkomaksu_tuotenumero']}', '{$nimitys}', '{$kukarow['yhtio']}', 'L',
+                 '{$row['alv']}', '{$rivikommentti}', '{$kukarow['kuka']}', now(), '{$kukarow['kuka']}',
+                 now(), '{$kukarow['kuka']}', now()
+                 )";
       $addtil = pupe_query($query);
 
       if ($debug == 1) {
@@ -32823,7 +32823,7 @@ if (!function_exists("loppulaskuta")) {
 
     // Päivitetään positiolle laskutustunnus
     $query = "UPDATE maksupositio SET
-              uusiotunnus = '{$ennakkolaskun_hyvitys_otunnus}'
+              uusiotunnus  = '{$ennakkolaskun_hyvitys_otunnus}'
               WHERE tunnus = '{$posrow['tunnus']}'";
     pupe_query($query);
 
@@ -32930,8 +32930,8 @@ if (!function_exists('tuoteperheen_lapsien_kertoimet')) {
               tuoteperhe.tuoteno
               FROM tuoteperhe
               JOIN tuote USING (yhtio, tuoteno)
-              WHERE tuoteperhe.yhtio = '{$kukarow['yhtio']}'
-              AND tuoteperhe.tyyppi = '{$tyyppi}'
+              WHERE tuoteperhe.yhtio    = '{$kukarow['yhtio']}'
+              AND tuoteperhe.tyyppi     = '{$tyyppi}'
               AND tuoteperhe.isatuoteno = '{$isa_tuoteno}'
               ORDER BY hintatyyppi DESC";
     $result = pupe_query($query);
@@ -33010,7 +33010,7 @@ if (!function_exists('ulkoinen_jarjestelma_varastot')) {
 
     $query = "SELECT DISTINCT varasto
               FROM tilausrivi
-              WHERE yhtio = '{$kukarow['yhtio']}'
+              WHERE yhtio     = '{$kukarow['yhtio']}'
               AND uusiotunnus = '{$otunnus}'";
     $varastocheckres = pupe_query($query);
 
@@ -33101,31 +33101,31 @@ if (!function_exists('tuoteperheiden_hintojen_paivitys')) {
 
         // päivitetään lapsituotteen hinta
         $query = "UPDATE tilausrivi SET
-                  ale1       = '{$row['ale1']}',
-                  ale2       = '{$row['ale2']}',
-                  ale3       = '{$row['ale3']}',
-                  erikoisale = '{$row['erikoisale']}',
-                  hinta      = '{$hinta}',
-                  netto      = '{$row['netto']}'
-                  WHERE yhtio = '{$kukarow['yhtio']}'
-                  AND tuoteno = '{$lapsituote['tuoteno']}'
-                  AND perheid = '{$row['perheid']}'
-                  AND tilkpl  = {$row['tilkpl']} * {$lapsituote['kerroin']}
-                  AND tunnus != perheid
-                  AND tunnus in ({$tunnukset})";
+                  ale1         = '{$row['ale1']}',
+                  ale2         = '{$row['ale2']}',
+                  ale3         = '{$row['ale3']}',
+                  erikoisale   = '{$row['erikoisale']}',
+                  hinta        = '{$hinta}',
+                  netto        = '{$row['netto']}'
+                  WHERE yhtio  = '{$kukarow['yhtio']}'
+                  AND tuoteno  = '{$lapsituote['tuoteno']}'
+                  AND perheid  = '{$row['perheid']}'
+                  AND tilkpl   = {$row['tilkpl']} * {$lapsituote['kerroin']}
+                  AND tunnus  != perheid
+                  AND tunnus   in ({$tunnukset})";
         pupe_query($query);
       }
 
       // päivitetään isätuote nollaksi
       $query = "UPDATE tilausrivi SET
-                ale1       = 0,
-                ale2       = 0,
-                ale3       = 0,
-                erikoisale = 0,
-                hinta      = 0,
-                netto      = ''
+                ale1        = 0,
+                ale2        = 0,
+                ale3        = 0,
+                erikoisale  = 0,
+                hinta       = 0,
+                netto       = ''
                 WHERE yhtio = '{$kukarow['yhtio']}'
-                AND tunnus = {$row['tunnus']}";
+                AND tunnus  = {$row['tunnus']}";
       pupe_query($query);
 
       // katsotaan pyöristysero
@@ -33137,7 +33137,7 @@ if (!function_exists('tuoteperheiden_hintojen_paivitys')) {
 
         // Lisätään pyöristys tämän perheen vikalle lapselle
         $query = "UPDATE tilausrivi SET
-                  hinta = round(hinta - ({$pyoristysero} / tilkpl), {$yhtiorow['hintapyoristys']})
+                  hinta       = round(hinta - ({$pyoristysero} / tilkpl), {$yhtiorow['hintapyoristys']})
                   WHERE yhtio = '{$kukarow['yhtio']}'
                   AND perheid = '{$row['perheid']}'
                   AND tunnus  = $vikalapsi";

--- a/inc/pakkauskooditrivi.inc
+++ b/inc/pakkauskooditrivi.inc
@@ -28,7 +28,7 @@ if (mysql_field_name($result, $i) == "pakkaus") {
 
   $ulos .= "</select></td>";
   $jatko = 0;
-  
+
 }
 
 if (mysql_field_name($result, $i) == "rahdinkuljettaja") {

--- a/inc/pakolliset_sarakkeet.inc
+++ b/inc/pakolliset_sarakkeet.inc
@@ -332,11 +332,11 @@ if (!function_exists("pakolliset_sarakkeet")) {
     case "asiakkaan_avainsanat" :
       if (is_array($otsikot) and in_array("YTUNNUS", $otsikot) and !in_array("LIITOSTUNNUS", $otsikot)) {
         $pakolliset  = array("LAJI", "AVAINSANA");
-        $wherelliset = array("LAJI", "AVAINSANA","KIELI");
+        $wherelliset = array("LAJI", "AVAINSANA", "KIELI");
       }
       else {
         $pakolliset  = array("LIITOSTUNNUS", "LAJI", "AVAINSANA");
-        $wherelliset = array("LIITOSTUNNUS", "LAJI", "AVAINSANA","KIELI");
+        $wherelliset = array("LIITOSTUNNUS", "LAJI", "AVAINSANA", "KIELI");
       }
 
       $joinattavat  = array("LIITOSTUNNUS" => "asiakas");

--- a/inc/pakolliset_sarakkeet.inc
+++ b/inc/pakolliset_sarakkeet.inc
@@ -3,21 +3,22 @@
 /*
   Yll‰pidet‰‰n taulujen pakollisia saraketietoja
 
-  list($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset) = pakolliset_sarakkeet($table);
+  list($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset, $eisaaollatyhja) = pakolliset_sarakkeet($table);
 */
 
 // m‰‰ritell‰‰n pakolliset sarakkeet
 if (!function_exists("pakolliset_sarakkeet")) {
-  function pakolliset_sarakkeet($table, $otsikot = "", $synkronointi = '') {
+  function pakolliset_sarakkeet($table, $otsikot = "") {
     global $kukarow, $yhtiorow;
 
-    $pakolliset   = array();
-    $kielletyt    = array();
-    $wherelliset  = array();
-    $eiyhtiota    = "";
-    $joinattavat  = array();
-    $saakopoistaa = FALSE;
-    $oletukset    = array();
+    $pakolliset     = array();
+    $kielletyt      = array();
+    $wherelliset    = array();
+    $eiyhtiota      = "";
+    $joinattavat    = array();
+    $saakopoistaa   = FALSE;
+    $oletukset      = array();
+    $eisaaollatyhja = array();
 
     switch ($table) {
     case "tuote" :
@@ -441,35 +442,33 @@ if (!function_exists("pakolliset_sarakkeet")) {
       $kielletyt    = array();
     }
 
-    if ($synkronointi != 'ALA_YHDISTA_MYSQLALIAKSIA') {
-      // Haetaan kenttien pakollisuudet sek‰ oletukset MySQL aliaksista. Selitetark_2 on profiilin nimi, joten haetaan vain "oletusprofiilista"
-      $query = "SELECT selite, selitetark_3, selitetark_4
-                FROM avainsana use index (yhtio_laji_selite)
-                WHERE yhtio      = '{$kukarow["yhtio"]}'
-                AND laji         = 'MYSQLALIAS'
-                AND selite       LIKE '$table.%'
-                AND selitetark_2 = 'Default'";
-      $result = pupe_query($query);
+    // Haetaan kenttien pakollisuudet sek‰ oletukset MySQL aliaksista. Selitetark_2 on profiilin nimi, joten haetaan vain "oletusprofiilista"
+    $query = "SELECT selite, selitetark_3, selitetark_4
+              FROM avainsana use index (yhtio_laji_selite)
+              WHERE yhtio      = '{$kukarow["yhtio"]}'
+              AND laji         = 'MYSQLALIAS'
+              AND selite       LIKE '$table.%'
+              AND selitetark_2 = 'Default'";
+    $result = pupe_query($query);
 
-      while ($row = mysql_fetch_assoc($result)) {
-        // Selitteess‰ on tietokannan sarakkeen nimi muodossa asiakas.luottoraja
-        if (strpos($row["selite"], ".") !== FALSE) {
-          list($taulu, $sarake) = explode(".", $row["selite"]);
-          $sarake = strtoupper(trim($sarake));
+    while ($row = mysql_fetch_assoc($result)) {
+      // Selitteess‰ on tietokannan sarakkeen nimi muodossa asiakas.luottoraja
+      if (strpos($row["selite"], ".") !== FALSE) {
+        list($taulu, $sarake) = explode(".", $row["selite"]);
+        $sarake = strtoupper(trim($sarake));
 
-          // Pakollisuus
-          if ($row["selitetark_3"] == "PAKOLLINEN" and !in_array($sarake, $pakolliset)) {
-            $pakolliset[] = $sarake;
-          }
+        // Pakollisuus
+        if ($row["selitetark_3"] == "PAKOLLINEN" and !in_array($sarake, $pakolliset)) {
+          $eisaaollatyhja[] = $sarake;
+        }
 
-          // Oletusarvo
-          if ($row["selitetark_4"] != "") {
-            $oletukset[$sarake] = $row["selitetark_4"];
-          }
+        // Oletusarvo
+        if ($row["selitetark_4"] != "") {
+          $oletukset[$sarake] = $row["selitetark_4"];
         }
       }
     }
 
-    return array($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset);
+    return array($pakolliset, $kielletyt, $wherelliset, $eiyhtiota, $joinattavat, $saakopoistaa, $oletukset, $eisaaollatyhja);
   }
 }

--- a/inc/pankkiyhteys_tilioteviite.inc
+++ b/inc/pankkiyhteys_tilioteviite.inc
@@ -8,9 +8,9 @@ if ($tee == "hae_aineistot") {
   $factoring_viite_references = isset($factoring_viite_references) ? $factoring_viite_references : array();
 
   if (count($tiliote_references) +
-      count($viite_references) +
-      count($factoring_tiliote_references) +
-      count($factoring_viite_references) == 0) {
+    count($viite_references) +
+    count($factoring_tiliote_references) +
+    count($factoring_viite_references) == 0) {
     virhe("Et valinnut yht‰‰n aineistoa");
     $tee = "valitse";
   }

--- a/inc/parametrit.inc
+++ b/inc/parametrit.inc
@@ -16,7 +16,7 @@ ini_set("log_errors", 1);
 // Tsekataan ajetaanko Pupea Latin1- vai UTF-8-moodissa
 // (Ohjataan mssql.charset-muuttujalla php.ini-tiedostossa)
 if (!defined("PUPE_UNICODE")) {
-  if (get_cfg_var('mssql.charset') == "UTF-8" or @include_once(".PUPE_UNICODE")) {
+  if (get_cfg_var('mssql.charset') == "UTF-8" or @include_once ".PUPE_UNICODE") {
     define("PUPE_UNICODE", TRUE);
   }
   else {

--- a/inc/teemaksutosite.inc
+++ b/inc/teemaksutosite.inc
@@ -202,20 +202,20 @@ if ($teemaksutosite) {
 
   // Rahatili
   $query = "INSERT into tiliointi set
-            yhtio    = '$yritirow[yhtio]',
-            ltunnus  = '$trow[tunnus]',
-            tilino   = '$yritirow[oletus_rahatili]',
-            kustp    = '{$kustp_ins}',
-            kohde    = '{$kohde_ins}',
-            projekti = '{$projekti_ins}',
-            tapvm    = '$tpv-$tpk-$tpp',
-            summa    = '$maara',
+            yhtio            = '$yritirow[yhtio]',
+            ltunnus          = '$trow[tunnus]',
+            tilino           = '$yritirow[oletus_rahatili]',
+            kustp            = '{$kustp_ins}',
+            kohde            = '{$kohde_ins}',
+            projekti         = '{$projekti_ins}',
+            tapvm            = '$tpv-$tpk-$tpp',
+            summa            = '$maara',
             summa_valuutassa = '{$summavaluutassa}',
-            valkoodi = '{$summavaluuttakoodi}',
-            vero     = 0,
-            lukko    = '',
-            laatija  = 'tiliote',
-            laadittu = now()";
+            valkoodi         = '{$summavaluuttakoodi}',
+            vero             = 0,
+            lukko            = '',
+            laatija          = 'tiliote',
+            laadittu         = now()";
   $result = pupe_query($query);
 
   // Tarkenteet kopsataan alkuperäiseltä tiliöinniltä, mutta jos alkuperäinen tiliöinti on ilman tarkenteita, niin mennään tilin defaulteilla
@@ -223,20 +223,20 @@ if ($teemaksutosite) {
 
   // Ostovelat, tarkenteet kopsataan alkuperäisesltä tiliöinniltä
   $query = "INSERT into tiliointi set
-            yhtio    = '$yritirow[yhtio]',
-            ltunnus  = '$trow[tunnus]',
-            tilino   = '$ostovelkarow[tilino]',
-            kustp    = '{$kustp_ins}',
-            kohde    = '{$kohde_ins}',
-            projekti = '{$projekti_ins}',
-            tapvm    = '$tpv-$tpk-$tpp',
-            summa    = '$trow[vietysumma]',
+            yhtio            = '$yritirow[yhtio]',
+            ltunnus          = '$trow[tunnus]',
+            tilino           = '$ostovelkarow[tilino]',
+            kustp            = '{$kustp_ins}',
+            kohde            = '{$kohde_ins}',
+            projekti         = '{$projekti_ins}',
+            tapvm            = '$tpv-$tpk-$tpp',
+            summa            = '$trow[vietysumma]',
             summa_valuutassa = '{$summavaluutassa}',
-            valkoodi = '{$summavaluuttakoodi}',
-            vero     = 0,
-            lukko    = '',
-            laatija  = 'tiliote',
-            laadittu = now()";
+            valkoodi         = '{$summavaluuttakoodi}',
+            vero             = 0,
+            lukko            = '',
+            laatija          = 'tiliote',
+            laadittu         = now()";
   $result = pupe_query($query);
   $_tiliointi_id = mysql_insert_id($GLOBALS["masterlink"]);
 

--- a/inc/tilaus_in_multi.inc
+++ b/inc/tilaus_in_multi.inc
@@ -137,9 +137,9 @@ while ($rivi = fgets($fd)) {
       // Jos ei haluta tilausvahvistusta
       if (!empty($tilaus_novahvistus)) {
         $query = "UPDATE lasku
-            SET tilausvahvistus = ''
-            WHERE tunnus = '$id'
-            AND yhtio    = '$kukarow[yhtio]'";
+                  SET tilausvahvistus = ''
+                  WHERE tunnus = '$id'
+                  AND yhtio    = '$kukarow[yhtio]'";
         pupe_query($query);
       }
 

--- a/inc/tuoterivi.inc
+++ b/inc/tuoterivi.inc
@@ -188,11 +188,11 @@ if (mysql_field_name($result, $i) == "kehahin" and $yhtiorow["kehahinarvio_ennen
 
 if ($laji != "V" and
   (mysql_field_name($result, $i) == "try"
-  or mysql_field_name($result, $i) == "osasto"
-  or mysql_field_name($result, $i) == "tuotemerkki"
-  or mysql_field_name($result, $i) == "malli"
-  or mysql_field_name($result, $i) == "mallitarkenne"
-  or mysql_field_name($result, $i) == "valmistuslinja")) {
+    or mysql_field_name($result, $i) == "osasto"
+    or mysql_field_name($result, $i) == "tuotemerkki"
+    or mysql_field_name($result, $i) == "malli"
+    or mysql_field_name($result, $i) == "mallitarkenne"
+    or mysql_field_name($result, $i) == "valmistuslinja")) {
 
   $sresult = t_avainsana(mysql_field_name($result, $i));
   $sarnimi = mysql_field_name($result, $i);

--- a/inc/tuotetarkista.inc
+++ b/inc/tuotetarkista.inc
@@ -474,9 +474,9 @@ if (!function_exists("tuotetarkista")) {
            $tem_try        != $tem_try_vanha)) {
 
         $query = "UPDATE tuotteen_avainsanat SET
-                  selite = ''
+                  selite      = ''
                   WHERE yhtio = '{$kukarow['yhtio']}'
-                  AND laji = 'synkronointi'
+                  AND laji    = 'synkronointi'
                   AND tuoteno = '{$tem_tuoteno}'";
         $updres = pupe_query($query);
       }

--- a/inc/tuotetarkista.inc
+++ b/inc/tuotetarkista.inc
@@ -78,10 +78,10 @@ if (!function_exists("tuotetarkista")) {
 
     if ($laji != "V" and
       ($fieldname == "osasto"
-      or $fieldname == "try"
-      or $fieldname == "tuotemerkki"
-      or $fieldname == "malli"
-      or $fieldname == "mallitarkenne")) {
+        or $fieldname == "try"
+        or $fieldname == "tuotemerkki"
+        or $fieldname == "malli"
+        or $fieldname == "mallitarkenne")) {
 
       // Ei tehdä tarkistuksia jos tietoa ei oo syötetty
       if (empty($t[$i])) {
@@ -465,13 +465,13 @@ if (!function_exists("tuotetarkista")) {
       }
 
       if (count($virhe) == 0 and
-          ($onkologmaster or $onkoposten) and
-          ($tem_status     != $trow['status']     or
-           $tem_eankoodi   != $trow['eankoodi']   or
-           $tem_yksikko    != $trow['yksikko']    or
-           $tem_nimitys    != $trow['nimitys']    or
-           $tem_tuotemassa != $trow['tuotemassa'] or
-           $tem_try        != $tem_try_vanha)) {
+        ($onkologmaster or $onkoposten) and
+        ($tem_status     != $trow['status']     or
+          $tem_eankoodi   != $trow['eankoodi']   or
+          $tem_yksikko    != $trow['yksikko']    or
+          $tem_nimitys    != $trow['nimitys']    or
+          $tem_tuotemassa != $trow['tuotemassa'] or
+          $tem_try        != $tem_try_vanha)) {
 
         $query = "UPDATE tuotteen_avainsanat SET
                   selite      = ''

--- a/inc/unifaun_send.inc
+++ b/inc/unifaun_send.inc
@@ -156,7 +156,7 @@ class Unifaun {
 
       $ftpfile = realpath($filenimi);
 
-      # Lähetetään UTF-8 muodossa jos PUPE_UNICODE on true
+      // Lähetetään UTF-8 muodossa jos PUPE_UNICODE on true
       $ftputf8 = PUPE_UNICODE;
 
       require "inc/ftp-send.inc";
@@ -579,7 +579,7 @@ class Unifaun {
 
     if (!empty($this->postirow["noutopisteen_tunnus"])) {
       //<val n="agentto">1234</val> # definaa noutopisteen tunnuksen
-      $agentto_noutopiste = $uni_shipment->addChild('val', utf8_encode($this->postirow["noutopisteen_tunnus"])); # Defines the agent's ID for recipient in shipment. Used by DBSchenker PrivPak to store the agent's details, address etc. For Bring it's used to store address details to MyQuickBox machine.
+      $agentto_noutopiste = $uni_shipment->addChild('val', utf8_encode($this->postirow["noutopisteen_tunnus"])); // Defines the agent's ID for recipient in shipment. Used by DBSchenker PrivPak to store the agent's details, address etc. For Bring it's used to store address details to MyQuickBox machine.
       $agentto_noutopiste->addAttribute('n', "agentto");
     }
 

--- a/inc/unifaun_send.inc
+++ b/inc/unifaun_send.inc
@@ -107,8 +107,8 @@ class Unifaun {
     // haetaan laskun_lisatiedot, käytetään noutopisteen_tunnus jos se on != ''
     $ll_query = "SELECT noutopisteen_tunnus
                  FROM laskun_lisatiedot
-                 WHERE yhtio  = '{$this->kukarow['yhtio']}'
-                 AND otunnus   = '{$this->postirow['tunnus']}'
+                 WHERE yhtio              = '{$this->kukarow['yhtio']}'
+                 AND otunnus              = '{$this->postirow['tunnus']}'
                  AND noutopisteen_tunnus != ''";
     $ll_res = pupe_query($ll_query);
 

--- a/indexvas.php
+++ b/indexvas.php
@@ -241,7 +241,7 @@ while ($orow = mysql_fetch_array($result)) {
 
     $goclass = "";
 
-    if (isset($go) and $go == $mrow["nimi"] or $go == "$mrow[nimi]?toim=$mrow[alanimi]") {
+    if (isset($go) and ($go == $mrow["nimi"] or $go == "$mrow[nimi]?toim=$mrow[alanimi]")) {
       $goclass = " menu_aktivoitu";
       unset($go);
     }

--- a/katelaskenta/controller.katelaskenta.php
+++ b/katelaskenta/controller.katelaskenta.php
@@ -260,40 +260,40 @@ if ($submit_button != '' and ($lisa != '' or $lisa_parametri != '')) {
 
   // Hakukysely tuotehakuun.
   $query = "SELECT
-              if (tuote.tuoteno = '$tuotenumero', 1, if(left(tuote.tuoteno, length('$tuotenumero')) = '$tuotenumero', 2, 3)) jarjestys,
-              tuote.tuoteno,
-              tuote.nimitys,
-              tuote.osasto,
-              tuote.try,
-              tuote.myyntihinta,
-              tuote.myymalahinta,
-              tuote.nettohinta,
-              tuote.aleryhma,
-              tuote.status,
-              tuote.ei_saldoa,
-              tuote.yksikko,
-              tuote.tunnus,
-              tuote.epakurantti25pvm,
-              tuote.epakurantti50pvm,
-              tuote.epakurantti75pvm,
-              tuote.epakurantti100pvm,
-              tuote.kehahin,
-              tuote.myyntikate,
-              tuote.myymalakate,
-              tuote.nettokate,
-              (SELECT group_concat(distinct tuotteen_toimittajat.toim_tuoteno order by tuotteen_toimittajat.tunnus separator '<br>') FROM tuotteen_toimittajat use index (yhtio_tuoteno) WHERE tuote.yhtio = tuotteen_toimittajat.yhtio and tuote.tuoteno = tuotteen_toimittajat.tuoteno) toim_tuoteno,
-              tuote.sarjanumeroseuranta,
-              tuote.status
-              FROM tuote use index (tuoteno, nimitys)
-              $lisa_parametri
-              WHERE tuote.yhtio     = '$kukarow[yhtio]'
-              and tuote.tuotetyyppi NOT IN ('A', 'B')
-              $kieltolisa
-              $lisa
-              $extra_poislisa
-              $poislisa
-              ORDER BY jarjestys, $jarjestys
-              LIMIT 500";
+            if (tuote.tuoteno = '$tuotenumero', 1, if(left(tuote.tuoteno, length('$tuotenumero')) = '$tuotenumero', 2, 3)) jarjestys,
+            tuote.tuoteno,
+            tuote.nimitys,
+            tuote.osasto,
+            tuote.try,
+            tuote.myyntihinta,
+            tuote.myymalahinta,
+            tuote.nettohinta,
+            tuote.aleryhma,
+            tuote.status,
+            tuote.ei_saldoa,
+            tuote.yksikko,
+            tuote.tunnus,
+            tuote.epakurantti25pvm,
+            tuote.epakurantti50pvm,
+            tuote.epakurantti75pvm,
+            tuote.epakurantti100pvm,
+            tuote.kehahin,
+            tuote.myyntikate,
+            tuote.myymalakate,
+            tuote.nettokate,
+            (SELECT group_concat(distinct tuotteen_toimittajat.toim_tuoteno order by tuotteen_toimittajat.tunnus separator '<br>') FROM tuotteen_toimittajat use index (yhtio_tuoteno) WHERE tuote.yhtio = tuotteen_toimittajat.yhtio and tuote.tuoteno = tuotteen_toimittajat.tuoteno) toim_tuoteno,
+            tuote.sarjanumeroseuranta,
+            tuote.status
+            FROM tuote use index (tuoteno, nimitys)
+            $lisa_parametri
+            WHERE tuote.yhtio     = '$kukarow[yhtio]'
+            and tuote.tuotetyyppi NOT IN ('A', 'B')
+            $kieltolisa
+            $lisa
+            $extra_poislisa
+            $poislisa
+            ORDER BY jarjestys, $jarjestys
+            LIMIT 500";
   $result = pupe_query($query);
 
   // T‰ytet‰‰n template muuttuja tiedoilla, jotka halutaan

--- a/katelaskenta/functions.katelaskenta.php
+++ b/katelaskenta/functions.katelaskenta.php
@@ -23,6 +23,7 @@ function lisaa_hintaan_kate($keskihankintahinta, $kateprosentti) {
   return $keskihankintahinta / ( 1 - ( $kateprosentti / 100 ) );
 }
 
+
 /**
  * Funktio tarkistaa, että kateprosentti on sallitulla välillä.
  *

--- a/katelaskenta/katelaskenta_functions.php
+++ b/katelaskenta/katelaskenta_functions.php
@@ -18,6 +18,8 @@
  *
  * @param type    $tuotteet
  */
+
+
 function valmistele_hakutulokset($tuotteet) {
   foreach ($tuotteet as $avain => $arvo) { // $rows muuttuja tulee templaten ulkopuolelta
     // Merkit‰‰n nimitykseen "poistuva"

--- a/kerayksen_kuittaus_ulkoisesta_jarjestelmasta_cron.php
+++ b/kerayksen_kuittaus_ulkoisesta_jarjestelmasta_cron.php
@@ -168,12 +168,12 @@ while (false !== ($file = readdir($handle))) {
       $query = "SELECT tilausrivi.*
                 FROM tilausrivi
                 JOIN tuote ON (tuote.yhtio = tilausrivi.yhtio {$tuotelisa} AND tuote.tuoteno = tilausrivi.tuoteno)
-                WHERE tilausrivi.yhtio = '{$kukarow['yhtio']}'
-                AND tilausrivi.tunnus  = '{$tilausrivin_tunnus}'
-                AND tilausrivi.tunnus != 0
-                AND tilausrivi.otunnus = '{$laskurow['tunnus']}'
-                AND tilausrivi.keratty = ''
-                AND tilausrivi.toimitettu = ''";
+                WHERE tilausrivi.yhtio     = '{$kukarow['yhtio']}'
+                AND tilausrivi.tunnus      = '{$tilausrivin_tunnus}'
+                AND tilausrivi.tunnus     != 0
+                AND tilausrivi.otunnus     = '{$laskurow['tunnus']}'
+                AND tilausrivi.keratty     = ''
+                AND tilausrivi.toimitettu  = ''";
       $tilausrivi_res = pupe_query($query);
 
       if (mysql_num_rows($tilausrivi_res) != 1) {
@@ -235,16 +235,16 @@ while (false !== ($file = readdir($handle))) {
     # Päivitetään saldottomat tuotteet myös toimitetuksi
     $query = "UPDATE tilausrivi
               JOIN tuote ON (
-                tuote.yhtio = tilausrivi.yhtio AND
-                tuote.tuoteno = tilausrivi.tuoteno AND
-                tuote.ei_saldoa != ''
+                tuote.yhtio              = tilausrivi.yhtio AND
+                tuote.tuoteno            = tilausrivi.tuoteno AND
+                tuote.ei_saldoa         != ''
               )
               SET tilausrivi.keratty = '{$kukarow['kuka']}',
-              tilausrivi.kerattyaika = '{$toimaika}',
-              tilausrivi.toimitettu = '{$kukarow['kuka']}',
-              tilausrivi.toimitettuaika = '{$toimaika}'
-              WHERE tilausrivi.yhtio = '{$kukarow['yhtio']}'
-              AND tilausrivi.otunnus  = '{$otunnus}'";
+              tilausrivi.kerattyaika     = '{$toimaika}',
+              tilausrivi.toimitettu      = '{$kukarow['kuka']}',
+              tilausrivi.toimitettuaika  = '{$toimaika}'
+              WHERE tilausrivi.yhtio     = '{$kukarow['yhtio']}'
+              AND tilausrivi.otunnus     = '{$otunnus}'";
     pupe_query($query);
 
     $query  = "INSERT INTO rahtikirjat SET

--- a/kerayksen_kuittaus_ulkoisesta_jarjestelmasta_cron.php
+++ b/kerayksen_kuittaus_ulkoisesta_jarjestelmasta_cron.php
@@ -100,13 +100,13 @@ while (false !== ($file = readdir($handle))) {
   }
 
   if (isset($xml->CustPackingSlip->DeliveryDate)) {
-    #<DeliveryDate>20-04-2016</DeliveryDate>
+    //<DeliveryDate>20-04-2016</DeliveryDate>
     $delivery_date = $xml->CustPackingSlip->DeliveryDate;
     $toimaika = date("Y-m-d 00:00:00", strtotime($delivery_date));
   }
   elseif (isset($xml->CustPackingSlip->Deliverydate)) {
-    #HHV-case
-    #<Deliverydate>2016-04-20T12:34:56</Deliverydate>
+    //HHV-case
+    //<Deliverydate>2016-04-20T12:34:56</Deliverydate>
     $delivery_date = $xml->CustPackingSlip->Deliverydate;
     $toimaika = date("Y-m-d H:i:s", strtotime($delivery_date));
   }
@@ -232,7 +232,7 @@ while (false !== ($file = readdir($handle))) {
       $tuotteiden_paino += $painorow['paino'];
     }
 
-    # Päivitetään saldottomat tuotteet myös toimitetuksi
+    // Päivitetään saldottomat tuotteet myös toimitetuksi
     $query = "UPDATE tilausrivi
               JOIN tuote ON (
                 tuote.yhtio              = tilausrivi.yhtio AND

--- a/laiterekisteri.php
+++ b/laiterekisteri.php
@@ -239,7 +239,7 @@ if ($toiminto == "LINKKAA" or $vanhatoiminto == "LINKKAA") {
             LEFT JOIN avainsana on avainsana.yhtio = tuote.yhtio
               AND avainsana.laji                          = 'TRY'
               AND avainsana.selite                        = tuote.try
-            LEFT JOIN asiakas ON laite.yhtio = asiakas.yhtio 
+            LEFT JOIN asiakas ON laite.yhtio = asiakas.yhtio
               AND laite.toimipiste = asiakas.tunnus
             JOIN laitteen_sopimukset on laitteen_sopimukset.laitteen_tunnus = laite.tunnus
               AND laitteen_sopimukset.sopimusrivin_tunnus = '{$tilausrivin_tunnus}'
@@ -311,7 +311,7 @@ if (empty($toiminto) or $toiminto == 'LINKKAA' or $toiminto == 'NAYTALAITTEET') 
   }
   echo "</tr>";
   echo "<input type='hidden' name='tilausrivin_tunnus' value='$tilausrivin_tunnus'>";
-  
+
   echo "<input type='hidden' name='vanhatoiminto' value='$vanhatoiminto'>";
   echo "<input type='hidden' name='lopetus' value='$lopetus' />";
 }
@@ -324,13 +324,13 @@ if (empty($toiminto) or $toiminto == 'LINKKAA' or $vanhatoiminto == 'LINKKAA') {
 
 if ($toiminto == 'NAYTALAITTEET') {
   if (!empty($valmistajahaku)) {
-    $valmistajajoini = " JOIN avainsana on avainsana.yhtio = tuote.yhtio 
+    $valmistajajoini = " JOIN avainsana on avainsana.yhtio = tuote.yhtio
                          AND avainsana.laji = 'TRY'
                          AND avainsana.selite = tuote.try
                          AND avainsana.selitetark like '$valmistajahaku%' ";
   }
   else {
-    $valmistajajoini = " LEFT JOIN avainsana on avainsana.yhtio = tuote.yhtio 
+    $valmistajajoini = " LEFT JOIN avainsana on avainsana.yhtio = tuote.yhtio
                          AND avainsana.laji = 'TRY'
                          AND avainsana.selite = tuote.try ";
   }
@@ -355,7 +355,7 @@ if ($toiminto == 'NAYTALAITTEET') {
   if (!empty($sopimusasiakashaku)) {
     // Sopimusasiakashakua varten tarvitaan myös laitteen_sopimukset
     $sopimusjoinilisa = '';
-    $sopimusasiakasjoini = " JOIN tilausrivi ON (tilausrivi.yhtio = laite.yhtio and tilausrivi.tunnus = laitteen_sopimukset.sopimusrivin_tunnus)	
+    $sopimusasiakasjoini = " JOIN tilausrivi ON (tilausrivi.yhtio = laite.yhtio and tilausrivi.tunnus = laitteen_sopimukset.sopimusrivin_tunnus)
                              JOIN lasku ON (lasku.yhtio = laite.yhtio AND lasku.tunnus = tilausrivi.otunnus AND lasku.toim_nimi like '%{$sopimusasiakashaku}%') ";
   }
   elseif (!empty($sarjanumeroseurantahaku)) {
@@ -364,11 +364,11 @@ if ($toiminto == 'NAYTALAITTEET') {
                                   JOIN lasku ON (lasku.yhtio = sarjanumeroseuranta.yhtio AND lasku.tunnus = tilausrivi.otunnus AND lasku.toim_nimi like '%{$sarjanumeroseurantahaku}%') ";
   }
 
-  $asiakasjoinilisa = " LEFT JOIN asiakas ON laite.yhtio = asiakas.yhtio 
+  $asiakasjoinilisa = " LEFT JOIN asiakas ON laite.yhtio = asiakas.yhtio
     AND laite.toimipiste = asiakas.tunnus ";
   if (!empty($toimipistehaku)) {
-    $asiakasjoinilisa = " JOIN asiakas ON laite.yhtio = asiakas.yhtio 
-      AND laite.toimipiste = asiakas.tunnus AND asiakas.tunnus = '{$toimipistehaku}' ";  
+    $asiakasjoinilisa = " JOIN asiakas ON laite.yhtio = asiakas.yhtio
+      AND laite.toimipiste = asiakas.tunnus AND asiakas.tunnus = '{$toimipistehaku}' ";
   }
 
   // Haetaan kaikkien laiterekisterin laitteiden tuotteiden ja sopimusten tiedot
@@ -409,10 +409,10 @@ if ($toiminto == 'MUOKKAA' and !empty($laiterajaus)) {
             FROM laite
             LEFT JOIN tuote on tuote.yhtio = laite.yhtio
               AND tuote.tuoteno    = laite.tuoteno
-            LEFT JOIN avainsana on avainsana.yhtio = tuote.yhtio 
+            LEFT JOIN avainsana on avainsana.yhtio = tuote.yhtio
               AND avainsana.laji = 'TRY'
               AND avainsana.selite = tuote.try
-            LEFT JOIN asiakas ON laite.yhtio = asiakas.yhtio 
+            LEFT JOIN asiakas ON laite.yhtio = asiakas.yhtio
               AND laite.toimipiste = asiakas.tunnus
             LEFT JOIN laitteen_sopimukset ON laitteen_sopimukset.laitteen_tunnus = laite.tunnus
             WHERE laite.yhtio      = '{$kukarow['yhtio']}'
@@ -431,13 +431,13 @@ if ($toiminto == 'MUOKKAA' and !empty($laiterajaus)) {
   echo "<td nowrap>{$rowi['sarjanro']}</td>";
   echo "<td nowrap>{$rowi['tuoteno']}</td>";
   echo "<td></td>";
-  
+
   $toimipistetunnus = $rowi['toimipistetunnus'];
   // Toimipistevalinta
   echo "<td>";
   echo livesearch_kentta("laiterekisteriformi", "ASIAKASHAKU", "toimipistetunnus", 140, $toimipistetunnus, 'EISUBMIT', '', '', 'ei_break_all');
   echo "</td>";
-  
+
   echo "<td></td>";
   echo "<td><input type='text' name='sla' value='{$rowi['sla']}'/></td>";
   echo "<td><input type='text' name='sd_sla' value='{$rowi['sd_sla']}'/></td>";
@@ -668,7 +668,7 @@ else {
   echo "<th>".t("Malli")."</th>";
   echo "<td><input type='text' name='mallihaku'></td>";
   echo "</tr>";
-  
+
   echo "<tr>";
   echo "<th>".t("Sarjanumero")."</th>";
   echo "<td><input type='text' name='sarjanumerohaku'></td>";
@@ -692,14 +692,14 @@ else {
   echo livesearch_kentta("laiterekisteriformi", "ASIAKASHAKU", "toimipistehaku", 140, $toimipistehaku, '', '', '', 'ei_break_all');
   echo "</td>";
   echo "</tr>";
-  
+
   echo "<tr>";
   echo "<th>".t("Vain laitteet joilla on sopimus")."</th>";
   echo "<td><input type='checkbox' name='sopimushaku' value='joo'></td>";
   echo "</tr>";
-  
+
   echo "</table>";
   echo "<br>";
   echo "<input type='submit' name='hae_laitteet' value=".t('Hae laitteet')."/>";
-  echo "</form>"; 
+  echo "</form>";
 }

--- a/laiterekisteri.php
+++ b/laiterekisteri.php
@@ -240,7 +240,7 @@ if ($toiminto == "LINKKAA" or $vanhatoiminto == "LINKKAA") {
               AND avainsana.laji                          = 'TRY'
               AND avainsana.selite                        = tuote.try
             LEFT JOIN asiakas ON laite.yhtio = asiakas.yhtio
-              AND laite.toimipiste = asiakas.tunnus
+              AND laite.toimipiste                        = asiakas.tunnus
             JOIN laitteen_sopimukset on laitteen_sopimukset.laitteen_tunnus = laite.tunnus
               AND laitteen_sopimukset.sopimusrivin_tunnus = '{$tilausrivin_tunnus}'
             WHERE laite.yhtio                             = '{$kukarow['yhtio']}'
@@ -382,13 +382,13 @@ if ($toiminto == 'NAYTALAITTEET') {
             group_concat(laitteen_sopimukset.sopimusrivin_tunnus) sopimusrivin_tunnukset
             FROM laite
             LEFT JOIN tuote on tuote.yhtio = laite.yhtio
-              AND tuote.tuoteno    = laite.tuoteno
+              AND tuote.tuoteno = laite.tuoteno
             {$valmistajajoini}
             {$asiakasjoinilisa}
             {$sopimusjoinilisa} JOIN laitteen_sopimukset ON laitteen_sopimukset.laitteen_tunnus = laite.tunnus
             {$sopimusasiakasjoini}
             {$sarjanumeroseurantajoini}
-            WHERE laite.yhtio      = '{$kukarow['yhtio']}'
+            WHERE laite.yhtio   = '{$kukarow['yhtio']}'
             {$mallihakulisa}
             {$sarjanumerohakulisa}
             {$laiterajaus}
@@ -410,7 +410,7 @@ if ($toiminto == 'MUOKKAA' and !empty($laiterajaus)) {
             LEFT JOIN tuote on tuote.yhtio = laite.yhtio
               AND tuote.tuoteno    = laite.tuoteno
             LEFT JOIN avainsana on avainsana.yhtio = tuote.yhtio
-              AND avainsana.laji = 'TRY'
+              AND avainsana.laji   = 'TRY'
               AND avainsana.selite = tuote.try
             LEFT JOIN asiakas ON laite.yhtio = asiakas.yhtio
               AND laite.toimipiste = asiakas.tunnus

--- a/loppulaskuta_maksusopimukset_cron.php
+++ b/loppulaskuta_maksusopimukset_cron.php
@@ -71,18 +71,18 @@ while ($row = mysql_fetch_assoc($result)) {
             count(*) toimituksia
             FROM lasku
             JOIN tilausrivi ON (tilausrivi.yhtio = lasku.yhtio
-              AND tilausrivi.otunnus = lasku.tunnus
+              AND tilausrivi.otunnus     = lasku.tunnus
               AND tilausrivi.jaksotettu=lasku.jaksotettu
-              AND tilausrivi.tyyppi != 'D'
-              AND tilausrivi.var != 'P'
+              AND tilausrivi.tyyppi     != 'D'
+              AND tilausrivi.var        != 'P'
               AND tilausrivi.toimitettu != '')
-            WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-            AND lasku.jaksotettu = '{$row['jaksotettu']}'
-            AND lasku.tila = 'L'
-            AND lasku.alatila IN ('J', 'X')
+            WHERE lasku.yhtio            = '{$kukarow['yhtio']}'
+            AND lasku.jaksotettu         = '{$row['jaksotettu']}'
+            AND lasku.tila               = 'L'
+            AND lasku.alatila            IN ('J', 'X')
             GROUP BY lasku.jaksotettu
             HAVING tilaok = toimituksia
-            AND toimittamatta = 0";
+            AND toimittamatta            = 0";
   $toimitettu = pupe_query($query);
   if (mysql_affected_rows() > 0) {
     echo "\nLoppulaskutetaan maksusopimus: {$row['jaksotettu']}\n";

--- a/loppulaskuta_maksusopimukset_cron.php
+++ b/loppulaskuta_maksusopimukset_cron.php
@@ -73,11 +73,11 @@ while ($row = mysql_fetch_assoc($result)) {
             JOIN tilausrivi ON (tilausrivi.yhtio = lasku.yhtio
               AND tilausrivi.otunnus = lasku.tunnus
               AND tilausrivi.jaksotettu=lasku.jaksotettu
-              AND tilausrivi.tyyppi != 'D' 
-              AND tilausrivi.var != 'P' 
+              AND tilausrivi.tyyppi != 'D'
+              AND tilausrivi.var != 'P'
               AND tilausrivi.toimitettu != '')
             WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-            AND lasku.jaksotettu = '{$row['jaksotettu']}' 
+            AND lasku.jaksotettu = '{$row['jaksotettu']}'
             AND lasku.tila = 'L'
             AND lasku.alatila IN ('J', 'X')
             GROUP BY lasku.jaksotettu
@@ -87,5 +87,5 @@ while ($row = mysql_fetch_assoc($result)) {
   if (mysql_affected_rows() > 0) {
     echo "\nLoppulaskutetaan maksusopimus: {$row['jaksotettu']}\n";
     loppulaskuta($row['jaksotettu']);
-  }  
+  }
 }

--- a/lue_data.php
+++ b/lue_data.php
@@ -442,7 +442,7 @@ if ($kasitellaan_tiedosto) {
         $query = "SELECT tt.tunnus
                   FROM tuotteen_toimittajat AS tt
                   JOIN toimi ON (toimi.yhtio = tt.yhtio AND toimi.{$toimikentta} = '{$chk_tunnus_val}')
-                  WHERE tt.yhtio = '{$kukarow['yhtio']}'
+                  WHERE tt.yhtio      = '{$kukarow['yhtio']}'
                   AND tt.{$tuotenokentta} = '{$chk_tuoteno_val}'
                   AND tt.liitostunnus = toimi.tunnus";
         $chk_tunnus_res = pupe_query($query);
@@ -527,7 +527,7 @@ if ($kasitellaan_tiedosto) {
         $query = "SELECT tt.tunnus
                   FROM tuotteen_toimittajat AS tt
                   JOIN toimi ON (toimi.yhtio = tt.yhtio AND toimi.{$toimikentta} = '{$chk_tunnus_val}')
-                  WHERE tt.yhtio = '{$kukarow['yhtio']}'
+                  WHERE tt.yhtio      = '{$kukarow['yhtio']}'
                   AND tt.{$tuotenokentta} = '{$chk_tuoteno_val}'
                   AND tt.liitostunnus = toimi.tunnus";
         $chk_tunnus_res = pupe_query($query);
@@ -587,11 +587,11 @@ if ($kasitellaan_tiedosto) {
   // Tarkistetaan k‰ytet‰‰nkˆ maaryhmi‰
   if (in_array("tuote", $taulut)) {
     $maaryhmaquery = "SELECT *
-                       FROM avainsana
-                       WHERE yhtio = '{$kukarow['yhtio']}'
-                       and laji = 'maaryhma'
-                       and selite != ''
-                       ORDER BY jarjestys";
+                      FROM avainsana
+                      WHERE yhtio  = '{$kukarow['yhtio']}'
+                      and laji     = 'maaryhma'
+                      and selite  != ''
+                      ORDER BY jarjestys";
     $maaryhmares = pupe_query($maaryhmaquery);
 
     $maaryhma_kaytossa = mysql_num_rows($maaryhmares) > 0 ? true : false;
@@ -1021,9 +1021,9 @@ if ($kasitellaan_tiedosto) {
         elseif ($table_mysql == 'extranet_kayttajan_lisatiedot' and strtoupper($taulunotsikot[$taulu][$j]) == "LIITOSTUNNUS" and $liitostunnusvalinta == 2) {
           $query = "SELECT tunnus
                     FROM kuka
-                    WHERE yhtio = '$kukarow[yhtio]'
+                    WHERE yhtio   = '$kukarow[yhtio]'
                     and extranet != ''
-                    and kuka = '{$taulunrivit[$taulu][$eriviindex][$j]}'";
+                    and kuka      = '{$taulunrivit[$taulu][$eriviindex][$j]}'";
           $apures = pupe_query($query);
 
           if (mysql_num_rows($apures) == 1) {
@@ -1078,7 +1078,7 @@ if ($kasitellaan_tiedosto) {
           $apusql = "SELECT tunnus
                      FROM {$yhteensopivuus_taulun_nimi}
                      WHERE yhtio = '$kukarow[yhtio]'
-                     and tyyppi = '{$_tyyppi}'
+                     and tyyppi  = '{$_tyyppi}'
                      and atunnus = '{$_atunnus}'
                      and tuoteno = '{$_tuoteno}'
                      {$_wherelisa}";
@@ -1107,8 +1107,8 @@ if ($kasitellaan_tiedosto) {
               $query_x = "SELECT tunnus
                           FROM dynaaminen_puu
                           WHERE yhtio = '{$kukarow['yhtio']}'
-                          AND laji = '{$table_tarkenne}'
-                          AND koodi = '{$taulunrivit[$taulu][$eriviindex][$j]}'";
+                          AND laji    = '{$table_tarkenne}'
+                          AND koodi   = '{$taulunrivit[$taulu][$eriviindex][$j]}'";
               $koodi_tunnus_res = pupe_query($query_x);
 
               // jos tunnusta ei lˆydy, ohitetaan kyseinen rivi
@@ -1129,7 +1129,7 @@ if ($kasitellaan_tiedosto) {
 
               $query = "SELECT tunnus
                         FROM asiakas
-                        WHERE yhtio = '{$kukarow['yhtio']}'
+                        WHERE yhtio  = '{$kukarow['yhtio']}'
                         AND laji    != 'P'
                         AND $dynaamisen_taulun_liitos = '{$taulunrivit[$taulu][$eriviindex][$j]}'";
               $asiakkaan_haku_res = pupe_query($query);
@@ -1251,8 +1251,8 @@ if ($kasitellaan_tiedosto) {
           if (isset($toimittajavalinta) and $toimittajavalinta == 3) {
             $tpque = "SELECT tunnus
                       FROM toimi
-                      WHERE yhtio = '{$kukarow['yhtio']}'
-                      AND toimittajanro = '{$taulunrivit[$taulu][$eriviindex][$j]}'
+                      WHERE yhtio        = '{$kukarow['yhtio']}'
+                      AND toimittajanro  = '{$taulunrivit[$taulu][$eriviindex][$j]}'
                       AND toimittajanro != ''
                       AND tyyppi        != 'P'";
             $tpres = pupe_query($tpque);
@@ -1260,8 +1260,8 @@ if ($kasitellaan_tiedosto) {
           elseif (isset($toimittajavalinta) and $toimittajavalinta == 2) {
             $tpque = "SELECT tunnus
                       FROM toimi
-                      WHERE yhtio = '{$kukarow['yhtio']}'
-                      AND ytunnus = '{$taulunrivit[$taulu][$eriviindex][$j]}'
+                      WHERE yhtio  = '{$kukarow['yhtio']}'
+                      AND ytunnus  = '{$taulunrivit[$taulu][$eriviindex][$j]}'
                       AND ytunnus != ''
                       AND tyyppi  != 'P'";
             $tpres = pupe_query($tpque);
@@ -1269,8 +1269,8 @@ if ($kasitellaan_tiedosto) {
           else {
             $tpque = "SELECT tunnus
                       FROM toimi
-                      WHERE yhtio = '{$kukarow['yhtio']}'
-                      AND tunnus = '{$taulunrivit[$taulu][$eriviindex][$j]}'
+                      WHERE yhtio  = '{$kukarow['yhtio']}'
+                      AND tunnus   = '{$taulunrivit[$taulu][$eriviindex][$j]}'
                       AND tyyppi  != 'P'";
             $tpres = pupe_query($tpque);
           }
@@ -1324,8 +1324,8 @@ if ($kasitellaan_tiedosto) {
             if ($taulunrivit[$taulu][$eriviindex][array_search("TYYPPI", $taulunotsikot[$taulu])] == "T" and $table_mysql == "yhteyshenkilo") {
               $tpque = "SELECT tunnus
                         from toimi
-                        where yhtio = '$kukarow[yhtio]'
-                        and ytunnus = '".$taulunrivit[$taulu][$eriviindex][array_search("YTUNNUS", $taulunotsikot[$taulu])]."'
+                        where yhtio  = '$kukarow[yhtio]'
+                        and ytunnus  = '".$taulunrivit[$taulu][$eriviindex][array_search("YTUNNUS", $taulunotsikot[$taulu])]."'
                         and tyyppi  != 'P'";
               $tpres = pupe_query($tpque);
             }
@@ -1419,8 +1419,8 @@ if ($kasitellaan_tiedosto) {
           if ($taulunrivit[$taulu][$eriviindex][array_search("TYYPPI", $taulunotsikot[$taulu])] == "T" and $table_mysql == "yhteyshenkilo") {
             $tpque = "SELECT tunnus
                       from toimi
-                      where yhtio = '$kukarow[yhtio]'
-                      and tunnus = '".$taulunrivit[$taulu][$eriviindex][array_search("LIITOSTUNNUS", $taulunotsikot[$taulu])]."'
+                      where yhtio  = '$kukarow[yhtio]'
+                      and tunnus   = '".$taulunrivit[$taulu][$eriviindex][array_search("LIITOSTUNNUS", $taulunotsikot[$taulu])]."'
                       and tyyppi  != 'P'";
             $tpres = pupe_query($tpque);
           }
@@ -1428,7 +1428,7 @@ if ($kasitellaan_tiedosto) {
             $tpque = "SELECT tunnus
                       from asiakas
                       where yhtio = '$kukarow[yhtio]'
-                      and tunnus = '".$taulunrivit[$taulu][$eriviindex][array_search("LIITOSTUNNUS", $taulunotsikot[$taulu])]."'";
+                      and tunnus  = '".$taulunrivit[$taulu][$eriviindex][array_search("LIITOSTUNNUS", $taulunotsikot[$taulu])]."'";
             $tpres = pupe_query($tpque);
           }
 
@@ -1634,12 +1634,12 @@ if ($kasitellaan_tiedosto) {
               $_selitetark = mysql_real_escape_string($taulunrivit[$taulu][$eriviindex][$r]);
 
               $maaryhmaquery = "SELECT *
-                                 FROM avainsana
-                                 WHERE yhtio = '{$kukarow['yhtio']}'
-                                 and laji = 'maaryhma'
-                                 and selite != ''
-                                 and selitetark = '{$_selitetark}'
-                                 ORDER BY jarjestys";
+                                FROM avainsana
+                                WHERE yhtio     = '{$kukarow['yhtio']}'
+                                and laji        = 'maaryhma'
+                                and selite     != ''
+                                and selitetark  = '{$_selitetark}'
+                                ORDER BY jarjestys";
               $maaryhmares = pupe_query($maaryhmaquery);
 
               if (mysql_num_rows($maaryhmares) > 0) {
@@ -1699,10 +1699,10 @@ if ($kasitellaan_tiedosto) {
               if ($ikustp_tsk != "") {
                 $ikustpq = "SELECT tunnus
                             FROM kustannuspaikka
-                            WHERE yhtio = '$kukarow[yhtio]'
-                            and tyyppi = '$kptyyppi'
+                            WHERE yhtio   = '$kukarow[yhtio]'
+                            and tyyppi    = '$kptyyppi'
                             and kaytossa != 'E'
-                            and nimi = '$ikustp_tsk'";
+                            and nimi      = '$ikustp_tsk'";
                 $ikustpres = pupe_query($ikustpq);
 
                 if (mysql_num_rows($ikustpres) == 1) {
@@ -1714,10 +1714,10 @@ if ($kasitellaan_tiedosto) {
               if ($ikustp_tsk != "" and $ikustp_ok == 0) {
                 $ikustpq = "SELECT tunnus
                             FROM kustannuspaikka
-                            WHERE yhtio = '$kukarow[yhtio]'
-                            and tyyppi = '$kptyyppi'
+                            WHERE yhtio   = '$kukarow[yhtio]'
+                            and tyyppi    = '$kptyyppi'
                             and kaytossa != 'E'
-                            and koodi = '$ikustp_tsk'";
+                            and koodi     = '$ikustp_tsk'";
                 $ikustpres = pupe_query($ikustpq);
 
                 if (mysql_num_rows($ikustpres) == 1) {
@@ -1732,10 +1732,10 @@ if ($kasitellaan_tiedosto) {
 
                 $ikustpq = "SELECT tunnus
                             FROM kustannuspaikka
-                            WHERE yhtio = '$kukarow[yhtio]'
-                            and tyyppi = '$kptyyppi'
+                            WHERE yhtio   = '$kukarow[yhtio]'
+                            and tyyppi    = '$kptyyppi'
                             and kaytossa != 'E'
-                            and tunnus = '$ikustp_tsk'";
+                            and tunnus    = '$ikustp_tsk'";
                 $ikustpres = pupe_query($ikustpq);
 
                 if (mysql_num_rows($ikustpres) == 1) {
@@ -1769,11 +1769,11 @@ if ($kasitellaan_tiedosto) {
               elseif ($otsikko == 'ASIAKAS' and $asiakkaanvalinta == 2 and $taulunrivit[$taulu][$eriviindex][$r] != "") {
                 $etsitunnus = "SELECT tunnus
                                FROM asiakas USE INDEX (toim_ovttunnus_index)
-                               WHERE yhtio = '$kukarow[yhtio]'
-                               AND toim_ovttunnus = '{$taulunrivit[$taulu][$eriviindex][$r]}'
+                               WHERE yhtio         = '$kukarow[yhtio]'
+                               AND toim_ovttunnus  = '{$taulunrivit[$taulu][$eriviindex][$r]}'
                                AND toim_ovttunnus != ''
                                AND ytunnus        != ''
-                               AND ytunnus = '".$taulunrivit[$taulu][$eriviindex][array_search("YTUNNUS", $taulunotsikot[$taulu])]."'";
+                               AND ytunnus         = '".$taulunrivit[$taulu][$eriviindex][array_search("YTUNNUS", $taulunotsikot[$taulu])]."'";
                 $etsiresult = pupe_query($etsitunnus);
 
                 if (mysql_num_rows($etsiresult) == 1) {
@@ -1793,8 +1793,8 @@ if ($kasitellaan_tiedosto) {
               elseif ($otsikko == 'ASIAKAS' and $asiakkaanvalinta == 3 and $taulunrivit[$taulu][$eriviindex][$r] != "") {
                 $etsitunnus = "SELECT tunnus
                                FROM asiakas USE INDEX (asno_index)
-                               WHERE yhtio = '$kukarow[yhtio]'
-                               AND asiakasnro = '{$taulunrivit[$taulu][$eriviindex][$r]}'
+                               WHERE yhtio     = '$kukarow[yhtio]'
+                               AND asiakasnro  = '{$taulunrivit[$taulu][$eriviindex][$r]}'
                                AND asiakasnro != ''";
                 $etsiresult = pupe_query($etsitunnus);
 
@@ -1841,8 +1841,8 @@ if ($kasitellaan_tiedosto) {
                 $etsitunnus = "SELECT tunnus
                                FROM dynaaminen_puu
                                WHERE yhtio = '$kukarow[yhtio]'
-                               AND laji = 'asiakas'
-                               AND koodi = '{$taulunrivit[$taulu][$eriviindex][$r]}'";
+                               AND laji    = 'asiakas'
+                               AND koodi   = '{$taulunrivit[$taulu][$eriviindex][$r]}'";
                 $etsiresult = pupe_query($etsitunnus);
                 $etsirow = mysql_fetch_assoc($etsiresult);
 
@@ -1885,7 +1885,7 @@ if ($kasitellaan_tiedosto) {
                 $xquery = "SELECT tunnus
                            FROM asiakas
                            WHERE yhtio = '$kukarow[yhtio]'
-                           and tunnus = '{$taulunrivit[$taulu][$eriviindex][$r]}'";
+                           and tunnus  = '{$taulunrivit[$taulu][$eriviindex][$r]}'";
                 $xresult = pupe_query($xquery);
 
                 if (mysql_num_rows($xresult) == 0) {
@@ -1899,7 +1899,7 @@ if ($kasitellaan_tiedosto) {
                 if (mysql_num_rows($xresult) == 0) {
                   $xquery = "SELECT tunnus
                              FROM asiakas
-                             WHERE yhtio = '$kukarow[yhtio]'
+                             WHERE yhtio    = '$kukarow[yhtio]'
                              and asiakasnro = '{$taulunrivit[$taulu][$eriviindex][$r]}'";
                   $xresult = pupe_query($xquery);
                 }
@@ -1944,8 +1944,8 @@ if ($kasitellaan_tiedosto) {
                 //  Selvitet‰‰n vanha oletuspaikka
                 $vanha_oletus_query = "SELECT *
                                        FROM tuotepaikat
-                                       WHERE tuoteno = '$tuoteno'
-                                       and yhtio = '$kukarow[yhtio]'
+                                       WHERE tuoteno  = '$tuoteno'
+                                       and yhtio      = '$kukarow[yhtio]'
                                        and oletus    != ''";
                 $oletusresult = pupe_query($vanha_oletus_query);
                 $oletusrow = mysql_fetch_assoc($oletusresult);
@@ -1960,18 +1960,18 @@ if ($kasitellaan_tiedosto) {
                 if (mysql_num_rows($oletusresult) == 1 and kuuluukovarastoon($oletusrow['hyllyalue'], $oletusrow['hyllynro']) == kuuluukovarastoon($hylly['hyllyalue'], $hylly['hyllynro'])) {
                   $uusi_oletus_query = "UPDATE tilausrivi
                                         SET hyllyalue = '$hylly[hyllyalue]',
-                                        hyllynro = '$hylly[hyllynro]',
-                                        hyllytaso = '$hylly[hyllytaso]',
-                                        hyllyvali = '$hylly[hyllyvali]'
-                                        WHERE yhtio = '$kukarow[yhtio]'
-                                        AND tuoteno = '$tuoteno'
-                                        AND hyllyalue = '$oletusrow[hyllyalue]'
-                                        AND hyllynro = '$oletusrow[hyllynro]'
-                                        AND hyllytaso = '$oletusrow[hyllytaso]'
-                                        AND hyllyvali = '$oletusrow[hyllyvali]'
-                                        AND tyyppi = 'O'
-                                        AND uusiotunnus = '0'
-                                        AND kpl = '0'
+                                        hyllynro         = '$hylly[hyllynro]',
+                                        hyllytaso        = '$hylly[hyllytaso]',
+                                        hyllyvali        = '$hylly[hyllyvali]'
+                                        WHERE yhtio      = '$kukarow[yhtio]'
+                                        AND tuoteno      = '$tuoteno'
+                                        AND hyllyalue    = '$oletusrow[hyllyalue]'
+                                        AND hyllynro     = '$oletusrow[hyllynro]'
+                                        AND hyllytaso    = '$oletusrow[hyllytaso]'
+                                        AND hyllyvali    = '$oletusrow[hyllyvali]'
+                                        AND tyyppi       = 'O'
+                                        AND uusiotunnus  = '0'
+                                        AND kpl          = '0'
                                         AND varattu     != '0'";
                   $paivitysresult = pupe_query($uusi_oletus_query);
 
@@ -2010,8 +2010,8 @@ if ($kasitellaan_tiedosto) {
                 //  Selvitet‰‰n vanha oletuspaikka
                 $vanha_oletus_query = "SELECT *
                                        FROM tuotepaikat
-                                       WHERE tuoteno = '$tuoteno'
-                                       and yhtio = '$kukarow[yhtio]'
+                                       WHERE tuoteno  = '$tuoteno'
+                                       and yhtio      = '$kukarow[yhtio]'
                                        and oletus    != ''";
                 $oletusresult = pupe_query($vanha_oletus_query);
                 $oletusrow = mysql_fetch_assoc($oletusresult);
@@ -2026,18 +2026,18 @@ if ($kasitellaan_tiedosto) {
                 if (mysql_num_rows($oletusresult) == 1 and kuuluukovarastoon($oletusrow['hyllyalue'], $oletusrow['hyllynro']) == kuuluukovarastoon($hylly['hyllyalue'], $hylly['hyllynro'])) {
                   $uusi_oletus_query = "UPDATE tilausrivi
                                         SET hyllyalue = '$hylly[hyllyalue]',
-                                        hyllynro = '$hylly[hyllynro]',
-                                        hyllytaso = '$hylly[hyllytaso]',
-                                        hyllyvali = '$hylly[hyllyvali]'
-                                        WHERE yhtio = '$kukarow[yhtio]'
-                                        AND tuoteno = '$tuoteno'
-                                        AND hyllyalue = '$oletusrow[hyllyalue]'
-                                        AND hyllynro = '$oletusrow[hyllynro]'
-                                        AND hyllytaso = '$oletusrow[hyllytaso]'
-                                        AND hyllyvali = '$oletusrow[hyllyvali]'
-                                        AND tyyppi = 'O'
-                                        AND uusiotunnus = '0'
-                                        AND kpl = '0'
+                                        hyllynro         = '$hylly[hyllynro]',
+                                        hyllytaso        = '$hylly[hyllytaso]',
+                                        hyllyvali        = '$hylly[hyllyvali]'
+                                        WHERE yhtio      = '$kukarow[yhtio]'
+                                        AND tuoteno      = '$tuoteno'
+                                        AND hyllyalue    = '$oletusrow[hyllyalue]'
+                                        AND hyllynro     = '$oletusrow[hyllynro]'
+                                        AND hyllytaso    = '$oletusrow[hyllytaso]'
+                                        AND hyllyvali    = '$oletusrow[hyllyvali]'
+                                        AND tyyppi       = 'O'
+                                        AND uusiotunnus  = '0'
+                                        AND kpl          = '0'
                                         AND varattu     != '0'";
                   $paivitysresult = pupe_query($uusi_oletus_query);
 
@@ -2056,8 +2056,8 @@ if ($kasitellaan_tiedosto) {
                     $query_x = "SELECT tunnus
                                 FROM dynaaminen_puu
                                 WHERE yhtio = '{$kukarow['yhtio']}'
-                                AND laji = '{$table_tarkenne}'
-                                AND koodi = '{$taulunrivit[$taulu][$eriviindex][$r]}'";
+                                AND laji    = '{$table_tarkenne}'
+                                AND koodi   = '{$taulunrivit[$taulu][$eriviindex][$r]}'";
                     $koodi_tunnus_res = pupe_query($query_x);
                     $koodi_tunnus_row = mysql_fetch_assoc($koodi_tunnus_res);
 
@@ -2466,19 +2466,19 @@ if ($kasitellaan_tiedosto) {
 
               //Tehd‰‰n tapahtuma
               $querytapahtuma = "INSERT into tapahtuma set
-                                 yhtio = '$kukarow[yhtio]',
-                                 tuoteno = '{$taulunrivit["tuotepaikat"][$eriviindex][array_search("TUOTENO", $taulunotsikot["tuotepaikat"])]}',
-                                 kpl = '0',
-                                 kplhinta = '0',
-                                 hinta = '0',
+                                 yhtio     = '$kukarow[yhtio]',
+                                 tuoteno   = '{$taulunrivit["tuotepaikat"][$eriviindex][array_search("TUOTENO", $taulunotsikot["tuotepaikat"])]}',
+                                 kpl       = '0',
+                                 kplhinta  = '0',
+                                 hinta     = '0',
                                  hyllyalue = '{$taulunrivit["tuotepaikat"][$eriviindex][array_search("HYLLYALUE", $taulunotsikot["tuotepaikat"])]}',
-                                 hyllynro = '{$taulunrivit["tuotepaikat"][$eriviindex][array_search("HYLLYNRO", $taulunotsikot["tuotepaikat"])]}',
+                                 hyllynro  = '{$taulunrivit["tuotepaikat"][$eriviindex][array_search("HYLLYNRO", $taulunotsikot["tuotepaikat"])]}',
                                  hyllytaso = '{$taulunrivit["tuotepaikat"][$eriviindex][array_search("HYLLYTASO", $taulunotsikot["tuotepaikat"])]}',
                                  hyllyvali = '{$taulunrivit["tuotepaikat"][$eriviindex][array_search("HYLLYVALI", $taulunotsikot["tuotepaikat"])]}',
-                                 laji = '$tapahtumalaji',
-                                 selite = '$tapahtumaselite',
-                                 laatija = '$kukarow[kuka]',
-                                 laadittu = now()";
+                                 laji      = '$tapahtumalaji',
+                                 selite    = '$tapahtumaselite',
+                                 laatija   = '$kukarow[kuka]',
+                                 laadittu  = now()";
               $resulttapahtuma = pupe_query($querytapahtuma);
             }
 

--- a/lue_data.php
+++ b/lue_data.php
@@ -2077,7 +2077,7 @@ if ($kasitellaan_tiedosto) {
               elseif ($table_mysql == 'customers_users' and $otsikko == 'USER_ID') {
                 $query .= " $otsikko = '{$taulunrivit[$taulu][$eriviindex][$r]}' ";
               }
-              elseif ($table_mysql == 'maksuehto' and in_array($otsikko, array('ABS_PVM','KASSA_ABSPVM')) and (empty($taulunrivit[$taulu][$eriviindex][$r]) or in_array($taulunrivit[$taulu][$eriviindex][$r], array('0000-00-00','NULL')))) {
+              elseif ($table_mysql == 'maksuehto' and in_array($otsikko, array('ABS_PVM', 'KASSA_ABSPVM')) and (empty($taulunrivit[$taulu][$eriviindex][$r]) or in_array($taulunrivit[$taulu][$eriviindex][$r], array('0000-00-00', 'NULL')))) {
                 $query .= ", $otsikko = NULL ";
               }
               elseif ($eilisataeikamuuteta == "") {

--- a/maksuaineisto_send.php
+++ b/maksuaineisto_send.php
@@ -68,7 +68,7 @@ $localdir_error = $maksuaineiston_siirto[$y]["local_dir_error"];
 $ftpsucc = $maksuaineiston_siirto[$y]["local_dir_ok"];
 $ftpfail = $localdir_error;
 
-# Lähetetään UTF-8 muodossa jos PUPE_UNICODE on true
+// Lähetetään UTF-8 muodossa jos PUPE_UNICODE on true
 $ftputf8 = PUPE_UNICODE;
 
 if (isset($maksuaineiston_siirto[$y]["port"]) and (int)$maksuaineiston_siirto[$y]["port"] > 0) {

--- a/maksusopimus_laskutukseen.php
+++ b/maksusopimus_laskutukseen.php
@@ -264,7 +264,7 @@ if (!function_exists("ennakkolaskuta")) {
     $result = pupe_query($query);
     $sumrow = mysql_fetch_assoc($result);
 
-    if (in_array($yhtiorow['ennakkolaskun_tyyppi'], array('E','K'))) {
+    if (in_array($yhtiorow['ennakkolaskun_tyyppi'], array('E', 'K'))) {
 
       $alet = generoi_alekentta_select('erikseen', 'M');
 
@@ -339,13 +339,13 @@ if (!function_exists("ennakkolaskuta")) {
           }
         }
 
-        $varattu = in_array($yhtiorow['ennakkolaskun_tyyppi'], array('E','K')) ? $row['varattu'] : 1;
-        $tilkpl = in_array($yhtiorow['ennakkolaskun_tyyppi'], array('E','K')) ? $row['tilkpl'] : 1;
+        $varattu = in_array($yhtiorow['ennakkolaskun_tyyppi'], array('E', 'K')) ? $row['varattu'] : 1;
+        $tilkpl = in_array($yhtiorow['ennakkolaskun_tyyppi'], array('E', 'K')) ? $row['tilkpl'] : 1;
 
         $ale_kentat = "";
         $ale_arvot = "";
 
-        if (in_array($yhtiorow['ennakkolaskun_tyyppi'], array('E','K'))) {
+        if (in_array($yhtiorow['ennakkolaskun_tyyppi'], array('E', 'K'))) {
           for ($i = 1; $i <= $yhtiorow['myynnin_alekentat']; $i++) {
             $ale_kentat .=  ",ale{$i}";
             $ale_arvot .= ", '".$row["ale{$i}"]."'";
@@ -354,7 +354,7 @@ if (!function_exists("ennakkolaskuta")) {
 
         $summa = round($summa, 6);
 
-        $laitetaanko_netto = in_array($yhtiorow['ennakkolaskun_tyyppi'], array('E','K')) ? "" : "N";
+        $laitetaanko_netto = in_array($yhtiorow['ennakkolaskun_tyyppi'], array('E', 'K')) ? "" : "N";
 
         $query  = "INSERT into tilausrivi (hinta, netto, varattu, tilkpl, otunnus, tuoteno, nimitys, yhtio, tyyppi, alv, kommentti, laatija, laadittu {$ale_kentat}) values
                    ('$summa', '{$laitetaanko_netto}', '{$varattu}', '{$tilkpl}', '$id', '{$yhtiorow['ennakkomaksu_tuotenumero']}', '$nimitys', '$kukarow[yhtio]', 'L', '$row[alv]', '$rivikommentti', '$kukarow[kuka]', now() {$ale_arvot})";

--- a/maksusopimus_laskutukseen.php
+++ b/maksusopimus_laskutukseen.php
@@ -447,7 +447,7 @@ if (strpos($_SERVER['SCRIPT_NAME'], "maksusopimus_laskutukseen.php") !== FALSE) 
       $query = "UPDATE lasku SET
                 alatila     = ''
                 WHERE yhtio = '{$kukarow['yhtio']}'
-                AND tunnus = '{$laskurow['tunnus']}'";
+                AND tunnus  = '{$laskurow['tunnus']}'";
       $upd_res = pupe_query($query);
 
       if (mysql_affected_rows() != 0) $laskurow['alatila'] = '';
@@ -599,10 +599,10 @@ if (strpos($_SERVER['SCRIPT_NAME'], "maksusopimus_laskutukseen.php") !== FALSE) 
 
       $query = "SELECT tunnus
                 FROM lasku
-                WHERE yhtio = '{$kukarow['yhtio']}'
-                AND tila    = 'N'
-                AND alatila = 'B'
-                AND jaksotettu  = '{$row['jaksotettu']}'";
+                WHERE yhtio    = '{$kukarow['yhtio']}'
+                AND tila       = 'N'
+                AND alatila    = 'B'
+                AND jaksotettu = '{$row['jaksotettu']}'";
       $tila_chk_res = pupe_query($query);
 
       // loppulaskutetaan maksusopimus

--- a/matkalasku.php
+++ b/matkalasku.php
@@ -3013,9 +3013,9 @@ function hae_matkustajan_kilometrit($tuoteno, $kuka) {
   $query = "SELECT sum(tilausrivi.kpl) yhteensa
             FROM tilausrivi
             JOIN lasku ON (tilausrivi.yhtio = lasku.yhtio AND tilausrivi.otunnus = lasku.tunnus AND lasku.tila in ('H','Y','M','P','Q'))
-            WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-              AND tilausrivi.tyyppi = 'M'
-              AND tilausrivi.tuoteno = 'km-16'
+            WHERE lasku.yhtio          = '{$kukarow['yhtio']}'
+              AND tilausrivi.tyyppi    = 'M'
+              AND tilausrivi.tuoteno   = 'km-16'
               AND lasku.toim_ovttunnus = '{$kuka}'";
   $result = pupe_query($query);
   $row = mysql_fetch_assoc($result);

--- a/mobiili/tuotteella_useita_tilauksia.php
+++ b/mobiili/tuotteella_useita_tilauksia.php
@@ -147,15 +147,15 @@ $query = "SELECT
           IF(IFNULL(tilausrivin_lisatiedot.suoraan_laskutukseen, 'NORM') = '', 'JT', IFNULL(tilausrivin_lisatiedot.suoraan_laskutukseen, '')) as tilausrivi_tyyppi
           FROM lasku
           JOIN tilausrivi ON (tilausrivi.yhtio=lasku.yhtio
-            AND tilausrivi.tyyppi = 'O'
-            AND tilausrivi.varattu != 0
+            AND tilausrivi.tyyppi                        = 'O'
+            AND tilausrivi.varattu                      != 0
             {$join_lisa})
           {$lasku_join_lisa}
           LEFT JOIN tilausrivin_lisatiedot ON (tilausrivin_lisatiedot.yhtio = tilausrivi.yhtio
-            AND tilausrivin_lisatiedot.tilausrivilinkki = tilausrivi.tunnus
-            AND tilausrivin_lisatiedot.tilausrivilinkki <> 0)
-          WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-          AND lasku.vanhatunnus = '{$kukarow['toimipaikka']}'
+            AND tilausrivin_lisatiedot.tilausrivilinkki  = tilausrivi.tunnus
+            AND tilausrivin_lisatiedot.tilausrivilinkki  <> 0)
+          WHERE lasku.yhtio                              = '{$kukarow['yhtio']}'
+          AND lasku.vanhatunnus                          = '{$kukarow['toimipaikka']}'
           {$where_lisa}
           {$query_lisa}
           ORDER BY {$orderby} {$ascdesc}";
@@ -188,15 +188,15 @@ if ($tilausten_lukumaara == 0 and (isset($_viivakoodi) and $_viivakoodi != "") a
             IF(IFNULL(tilausrivin_lisatiedot.suoraan_laskutukseen, 'NORM') = '', 'JT', IFNULL(tilausrivin_lisatiedot.suoraan_laskutukseen, '')) as tilausrivi_tyyppi
             FROM lasku
             JOIN tilausrivi ON (tilausrivi.yhtio=lasku.yhtio
-              AND tilausrivi.tyyppi = 'O'
-              AND tilausrivi.varattu != 0
+              AND tilausrivi.tyyppi                        = 'O'
+              AND tilausrivi.varattu                      != 0
               {$join_lisa})
             {$lasku_join_lisa}
             LEFT JOIN tilausrivin_lisatiedot ON (tilausrivin_lisatiedot.yhtio = tilausrivi.yhtio
-              AND tilausrivin_lisatiedot.tilausrivilinkki = tilausrivi.tunnus
-              AND tilausrivin_lisatiedot.tilausrivilinkki <> 0)
-            WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-            AND lasku.vanhatunnus = '{$kukarow['toimipaikka']}'
+              AND tilausrivin_lisatiedot.tilausrivilinkki  = tilausrivi.tunnus
+              AND tilausrivin_lisatiedot.tilausrivilinkki  <> 0)
+            WHERE lasku.yhtio                              = '{$kukarow['yhtio']}'
+            AND lasku.vanhatunnus                          = '{$kukarow['toimipaikka']}'
             {$where_lisa}
             {$query_lisa}
             ORDER BY {$orderby} {$ascdesc}";
@@ -332,8 +332,8 @@ while ($row = mysql_fetch_assoc($result)) {
   $query = "SELECT
             IF(tuotteen_toimittajat.tuotekerroin = 0, 1, tuotteen_toimittajat.tuotekerroin) tuotekerroin
             FROM tuotteen_toimittajat
-            WHERE tuotteen_toimittajat.yhtio = '{$kukarow['yhtio']}'
-            AND tuotteen_toimittajat.tuoteno = '{$row['tuoteno']}'
+            WHERE tuotteen_toimittajat.yhtio      = '{$kukarow['yhtio']}'
+            AND tuotteen_toimittajat.tuoteno      = '{$row['tuoteno']}'
             AND tuotteen_toimittajat.liitostunnus = '{$row['liitostunnus']}'";
   $ttres = pupe_query($query);
   $ttrow = mysql_fetch_assoc($ttres);

--- a/monistalasku.php
+++ b/monistalasku.php
@@ -542,7 +542,7 @@ if ($tee == "ETSILASKU") {
       echo "</{$ero}>";
 
       echo "<{$ero}>{$row['asiakas']}</{$ero}>";
-      echo "<{$ero}>",tarkistahetu($row['ytunnus']),"</{$ero}>";
+      echo "<{$ero}>", tarkistahetu($row['ytunnus']), "</{$ero}>";
       echo "<{$ero}>{$row['summa']}</{$ero}>";
       echo "<{$ero}>".tv1dateconv($row["tapvm"])."</{$ero}>";
       echo "<{$ero}>".tv1dateconv($row["luontiaika"])."</{$ero}>";

--- a/muokkaatilaus.php
+++ b/muokkaatilaus.php
@@ -118,7 +118,7 @@ if (isset($tee) and $tee == 'MITATOI_TARJOUS') {
               SET tyyppi = 'D'
               WHERE yhtio = '{$kukarow['yhtio']}'
               {$tilausrivityyppilisa}
-              AND otunnus  = $tilausnumero";
+              AND otunnus = $tilausnumero";
     pupe_query($query);
 
     //Nollataan sarjanumerolinkit

--- a/muokkaatilaus.php
+++ b/muokkaatilaus.php
@@ -2624,7 +2624,7 @@ if (mysql_num_rows($result) != 0) {
         }
         elseif ($whiletoim == "YLLAPITO" and $fieldname == "asiakas") {
           list($_ytunnus, $_nimi) = explode('<br>', $row["asiakas"]);
-          echo "<td class='$class' valign='top'>",tarkistahetu($_ytunnus),"<br>{$_nimi}","</td>";
+          echo "<td class='$class' valign='top'>", tarkistahetu($_ytunnus), "<br>{$_nimi}", "</td>";
         }
         else {
           echo "<td class='$class' valign='top'>".$row[$fieldname]."</td>";
@@ -2994,7 +2994,7 @@ if (mysql_num_rows($result) != 0) {
       echo "</form></td>";
 
       if (((($whiletoim == "TARJOUS" or $whiletoim == "TARJOUSSUPER") and $deletarjous)
-        or ($toim == 'SUPER' and $deletilaus)) and $kukarow["mitatoi_tilauksia"] == "") {
+          or ($toim == 'SUPER' and $deletilaus)) and $kukarow["mitatoi_tilauksia"] == "") {
 
         echo "<td class='back'><form method='post' action='muokkaatilaus.php' onSubmit='return tarkista_mitatointi(1, \"{$whiletoim}\");'>";
         echo "<input type='hidden' name='toim' value='$whiletoim'>";

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -1151,7 +1151,7 @@ if ($tee == 'M') {
       list($saldo, $hyllyssa, $myytavissa) = saldo_myytavissa($tuoteno, 'JTSPEC', '', '', $saldorow["hyllyalue"], $saldorow["hyllynro"], $saldorow["hyllyvali"], $saldorow["hyllytaso"]);
 
       if ($saldorow["saldo"] == 0 and $hyllyssa == 0 and $myytavissa == 0) {
-        #Tarkistetaan varaako reklamaatio tuotepaikkaa
+        //Tarkistetaan varaako reklamaatio tuotepaikkaa
         $query = "SELECT *
                   FROM lasku
                   JOIN tilausrivi ON (

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -512,7 +512,7 @@ if ($tee == 'N') {
         $myytavissa += $kappaleet[$iii];
       }
 
-      
+
       if ($kappaleet[$iii] == $hyllyssa and $myytavissa < $kappaleet[$iii]) {
         $siirretaan_varattua = true;
       }

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -573,13 +573,13 @@ if ($tee == 'N') {
       if ($siirretaan_varattua) {
         $query = "UPDATE tilausrivi
                   SET hyllyalue = '$minnerow[hyllyalue]',
-                    hyllynro    = '$minnerow[hyllynro]',
-                    hyllyvali   = '$minnerow[hyllyvali]',
-                    hyllytaso   = '$minnerow[hyllytaso]'
+                    hyllynro      = '$minnerow[hyllynro]',
+                    hyllyvali     = '$minnerow[hyllyvali]',
+                    hyllytaso     = '$minnerow[hyllytaso]'
                   WHERE tuoteno   = '$tuotteet[$iii]'
                     AND yhtio     = '$kukarow[yhtio]'
-                    AND tyyppi IN ('L','G','V')
-                    AND varattu <> 0
+                    AND tyyppi    IN ('L','G','V')
+                    AND varattu   <> 0
                     AND hyllyalue = '$mistarow[hyllyalue]'
                     AND hyllynro  = '$mistarow[hyllynro]'
                     AND hyllyvali = '$mistarow[hyllyvali]'
@@ -1155,17 +1155,17 @@ if ($tee == 'M') {
         $query = "SELECT *
                   FROM lasku
                   JOIN tilausrivi ON (
-                    tilausrivi.yhtio = lasku.yhtio AND
-                    tilausrivi.otunnus = lasku.tunnus
+                    tilausrivi.yhtio       = lasku.yhtio AND
+                    tilausrivi.otunnus     = lasku.tunnus
                   )
-                  WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-                  AND lasku.tila = 'C'
-                  AND lasku.alatila IN ('', 'A', 'B', 'C')
+                  WHERE lasku.yhtio        = '{$kukarow['yhtio']}'
+                  AND lasku.tila           = 'C'
+                  AND lasku.alatila        IN ('', 'A', 'B', 'C')
                   AND tilausrivi.hyllyalue = '{$saldorow['hyllyalue']}'
-                  AND tilausrivi.hyllynro = '{$saldorow['hyllynro']}'
+                  AND tilausrivi.hyllynro  = '{$saldorow['hyllynro']}'
                   AND tilausrivi.hyllyvali = '{$saldorow['hyllyvali']}'
                   AND tilausrivi.hyllytaso = '{$saldorow['hyllytaso']}'
-                  AND tilausrivi.tuoteno = '{$saldorow["tuoteno"]}'";
+                  AND tilausrivi.tuoteno   = '{$saldorow["tuoteno"]}'";
         $reklares = pupe_query($query);
 
         $reklacheck = (mysql_num_rows($reklares) > 0);

--- a/myyntires/factoring.php
+++ b/myyntires/factoring.php
@@ -9,15 +9,15 @@ if (isset($maksuehto) and isset($tunnus)) {
   // tutkaillaan maksuehtoa
   $query = "SELECT *
             from maksuehto
-            where yhtio    = '$kukarow[yhtio]'
-            and tunnus     = '$maksuehto'
+            where yhtio = '$kukarow[yhtio]'
+            and tunnus  = '$maksuehto'
             and factoring_id is not null";
 
   if ($laji == 'pois') {
     $query = "SELECT *
               FROM maksuehto
-              WHERE yhtio   = '$kukarow[yhtio]'
-              and tunnus    = '$maksuehto'
+              WHERE yhtio = '$kukarow[yhtio]'
+              and tunnus  = '$maksuehto'
               and factoring_id is null";
   }
 
@@ -155,11 +155,11 @@ if (isset($laskuno)) {
             JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio
               and lasku.maksuehto = maksuehto.tunnus
               and maksuehto.factoring_id is null)
-            where lasku.yhtio  = '$kukarow[yhtio]'
-            and lasku.laskunro = '$laskuno'
-            and lasku.tila     = 'U'
-            and lasku.alatila  = 'X'
-            and lasku.mapvm    = '0000-00-00'";
+            where lasku.yhtio     = '$kukarow[yhtio]'
+            and lasku.laskunro    = '$laskuno'
+            and lasku.tila        = 'U'
+            and lasku.alatila     = 'X'
+            and lasku.mapvm       = '0000-00-00'";
 
   if ($laji == 'pois') {
     $query = "SELECT lasku.*, lasku.tunnus ltunnus, maksuehto.tunnus, maksuehto.teksti
@@ -167,11 +167,11 @@ if (isset($laskuno)) {
               JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio
                 and lasku.maksuehto = maksuehto.tunnus
                 and maksuehto.factoring_id is not null)
-              where lasku.yhtio  = '$kukarow[yhtio]'
-              and lasku.laskunro = '$laskuno'
-              and lasku.tila     = 'U'
-              and lasku.alatila  = 'X'
-              and lasku.mapvm    = '0000-00-00'";
+              where lasku.yhtio     = '$kukarow[yhtio]'
+              and lasku.laskunro    = '$laskuno'
+              and lasku.tila        = 'U'
+              and lasku.alatila     = 'X'
+              and lasku.mapvm       = '0000-00-00'";
   }
   $result = pupe_query($query);
 

--- a/myyntires/factoringkorko.php
+++ b/myyntires/factoringkorko.php
@@ -144,17 +144,17 @@ if (isset($tapa) and $tapa == 'pois') {
   if (isset($viite)) {
     $query = "SELECT suoritus.*, tiliointi.summa
               from suoritus, yriti, tiliointi
-              where suoritus.yhtio  = '$kukarow[yhtio]'
-              and suoritus.kohdpvm  > '0000-00-00'
-              and suoritus.ltunnus  > 0
-              and suoritus.summa    = 0
-              and suoritus.viite    like '$viite%'
-              and suoritus.yhtio    = yriti.yhtio
-              and suoritus.tilino   = yriti.tilino
+              where suoritus.yhtio = '$kukarow[yhtio]'
+              and suoritus.kohdpvm > '0000-00-00'
+              and suoritus.ltunnus > 0
+              and suoritus.summa   = 0
+              and suoritus.viite   like '$viite%'
+              and suoritus.yhtio   = yriti.yhtio
+              and suoritus.tilino  = yriti.tilino
               and yriti.factoring_id is not null
-              and tiliointi.yhtio   = suoritus.yhtio
-              and tiliointi.selite  = '".t("Kohdistettiin korkoihin")."'
-              and tiliointi.tunnus  = suoritus.ltunnus";
+              and tiliointi.yhtio  = suoritus.yhtio
+              and tiliointi.selite = '".t("Kohdistettiin korkoihin")."'
+              and tiliointi.tunnus = suoritus.ltunnus";
     $result = pupe_query($query);
 
     if (mysql_num_rows($result) == 0) {

--- a/myyntires/karhu.php
+++ b/myyntires/karhu.php
@@ -106,7 +106,7 @@ if ($tee == "ALOITAKARHUAMINEN") {
       $factoringrow = mysql_fetch_assoc($result);
       $query = "SELECT GROUP_CONCAT(tunnus) karhuttavat
                 FROM maksuehto
-                WHERE yhtio   = '$kukarow[yhtio]'
+                WHERE yhtio      = '$kukarow[yhtio]'
                 AND factoring_id = '$factoringrow[tunnus]'";
       $result = pupe_query($query);
 

--- a/myyntires/maksunsyotto.php
+++ b/myyntires/maksunsyotto.php
@@ -300,10 +300,10 @@ if ($tee == "SYOTTO") {
 if (!empty($viite_haku) and $tee == "ETSI") {
   $query = "SELECT liitostunnus, valkoodi
             FROM lasku
-            WHERE yhtio  = '$kukarow[yhtio]'
-            and tila     = 'U'
-            and alatila  = 'X'
-            and viite = '$viite_haku'";
+            WHERE yhtio = '$kukarow[yhtio]'
+            and tila    = 'U'
+            and alatila = 'X'
+            and viite   = '$viite_haku'";
   $result  = pupe_query($query);
 
   if ($asiakas = mysql_fetch_assoc($result)) {

--- a/myyntires/maksunsyotto.php
+++ b/myyntires/maksunsyotto.php
@@ -635,9 +635,9 @@ if ($tee == "" and $ytunnus == "") {
 
   echo "<table>";
   echo "<tr>";
-  echo "<th>",t("Maksaja"),"</th>";
-  echo "<td>",livesearch_kentta("maksaja", "ASIAKASHAKU", "asiakasid", 300, $maksaja_haku),"</td>";
-  echo "<td class='back'>",asiakashakuohje(),"</td>";
+  echo "<th>", t("Maksaja"), "</th>";
+  echo "<td>", livesearch_kentta("maksaja", "ASIAKASHAKU", "asiakasid", 300, $maksaja_haku), "</td>";
+  echo "<td class='back'>", asiakashakuohje(), "</td>";
   echo "</tr>";
 
   echo "<tr>";
@@ -645,7 +645,7 @@ if ($tee == "" and $ytunnus == "") {
   echo "</tr>";
 
   echo "<tr>";
-  echo "<th>",t("Laskunro")."</th><td><input type='text' name='laskunro_haku' size='25'></td>";
+  echo "<th>", t("Laskunro")."</th><td><input type='text' name='laskunro_haku' size='25'></td>";
   echo "</tr>";
 
   echo "<tr>";
@@ -653,7 +653,7 @@ if ($tee == "" and $ytunnus == "") {
   echo "</tr>";
 
   echo "<tr>";
-  echo "<th>",t("Viitenumero")."</th><td><input type='text' name='viite_haku' size='25'></td>";
+  echo "<th>", t("Viitenumero")."</th><td><input type='text' name='viite_haku' size='25'></td>";
   echo "</tr>";
   echo "</table>";
 

--- a/myyntires/paperikarhu.php
+++ b/myyntires/paperikarhu.php
@@ -425,7 +425,7 @@ if (!function_exists("loppu")) {
       $query = "SELECT *
                 FROM factoring
                 WHERE yhtio = '$kukarow[yhtio]'
-                AND tunnus = '$maksuehtotiedot[factoring_id]'";
+                AND tunnus  = '$maksuehtotiedot[factoring_id]'";
       $fac_result = pupe_query($query);
       $factoringrow = mysql_fetch_assoc($fac_result);
 

--- a/myyntires/paperitiliote.php
+++ b/myyntires/paperitiliote.php
@@ -215,8 +215,8 @@ function loppu($firstpage, $summat, $astunnus) {
             FROM asiakas
             JOIN maksuehto on (asiakas.yhtio = maksuehto.yhtio
             AND asiakas.maksuehto = maksuehto.tunnus)
-            WHERE asiakas.yhtio = '$kukarow[yhtio]'
-            and asiakas.tunnus = $astunnus";
+            WHERE asiakas.yhtio   = '$kukarow[yhtio]'
+            and asiakas.tunnus    = $astunnus";
   $result = pupe_query($query);
   $fcheck_row = mysql_fetch_assoc($result);
 
@@ -224,9 +224,9 @@ function loppu($firstpage, $summat, $astunnus) {
 
     $query = "SELECT *
               FROM factoring
-              WHERE yhtio        = '$kukarow[yhtio]'
-              and tunnus         = '$fcheck_row[factoring_id]'
-              and valkoodi       = '$valuutta'";
+              WHERE yhtio  = '$kukarow[yhtio]'
+              and tunnus   = '$fcheck_row[factoring_id]'
+              and valkoodi = '$valuutta'";
     $result = pupe_query($query);
     $factoring_row = mysql_fetch_assoc($result);
 

--- a/myyntires/suoritusselailu.php
+++ b/myyntires/suoritusselailu.php
@@ -75,9 +75,9 @@ if ($tila == 'poistasuoritus' or $tila == 'siirrasuoritus' or $tila == "siirrasu
     // Haetaan suorituksen pankkitili
     $query = "SELECT oletus_rahatili
               FROM yriti
-              WHERE yhtio   = '$kukarow[yhtio]'
-              AND kaytossa != 'E'
-              and tilino    = '$suoritus_row[tilino]'
+              WHERE yhtio          = '$kukarow[yhtio]'
+              AND kaytossa        != 'E'
+              and tilino           = '$suoritus_row[tilino]'
               and oletus_rahatili != ''";
     $yriti_res = pupe_query($query);
 
@@ -103,9 +103,9 @@ if ($tila == 'poistasuoritus' or $tila == 'siirrasuoritus' or $tila == "siirrasu
       // katsotaan onko tiliöinti poistettu, ja etsitään tosite poistetun tiliöinnin kautta
       $query = "SELECT *
                 FROM tiliointi
-                WHERE yhtio  = '{$kukarow['yhtio']}'
-                AND tunnus   = '{$suoritus_row['ltunnus']}'
-                AND ltunnus  > 0";
+                WHERE yhtio = '{$kukarow['yhtio']}'
+                AND tunnus  = '{$suoritus_row['ltunnus']}'
+                AND ltunnus > 0";
       $tiliointi1_res = pupe_query($query);
 
       if (mysql_num_rows($tiliointi1_res) !== 1) {
@@ -138,12 +138,12 @@ if ($tila == 'poistasuoritus' or $tila == 'siirrasuoritus' or $tila == "siirrasu
     // Haetaan suorituksen pankkitili-tiliöinti
     $query = "SELECT tilino
               FROM tiliointi
-              WHERE yhtio  = '$kukarow[yhtio]'
-              and ltunnus  = '$tiliointi1_row[ltunnus]'
-              and tilino   = '$yriti_row[oletus_rahatili]'
-              and tilino  != ''
-              and summa    =  $tiliointi1_row[summa] * -1
-              and korjattu = ''
+              WHERE yhtio   = '$kukarow[yhtio]'
+              and ltunnus   = '$tiliointi1_row[ltunnus]'
+              and tilino    = '$yriti_row[oletus_rahatili]'
+              and tilino   != ''
+              and summa     =  $tiliointi1_row[summa] * -1
+              and korjattu  = ''
               LIMIT 1";
     $tiliointi2_res = pupe_query($query);
 
@@ -248,12 +248,12 @@ if ($tila == 'uudelleenkohdista_viitemaksut') {
               AND lasku.valkoodi         = suoritus.valkoodi
               AND (lasku.summa - lasku.saldo_maksettu) = suoritus.summa)
             JOIN tiliointi AS suorinT ON (suorinT.yhtio = suoritus.yhtio
-              AND suorinT.tunnus = suoritus.ltunnus
-              AND suorinT.korjattu = '')
+              AND suorinT.tunnus         = suoritus.ltunnus
+              AND suorinT.korjattu       = '')
             JOIN tiliointi AS laskunT ON (laskunT.yhtio = lasku.yhtio
-              AND laskunT.ltunnus = lasku.tunnus
-              AND laskunT.tilino = suorinT.tilino
-              AND laskunT.korjattu = '')
+              AND laskunT.ltunnus        = lasku.tunnus
+              AND laskunT.tilino         = suorinT.tilino
+              AND laskunT.korjattu       = '')
             WHERE suoritus.yhtio         = '$kukarow[yhtio]'
             AND suoritus.kohdpvm         = '0000-00-00'
             AND suoritus.asiakas_tunnus != 0";

--- a/nordeafactoring.php
+++ b/nordeafactoring.php
@@ -40,7 +40,7 @@ if ($tee == 'TARKISTA') {
 
 $query = "SELECT *
           FROM factoring
-          WHERE yhtio = '{$kukarow["yhtio"]}'
+          WHERE yhtio        = '{$kukarow["yhtio"]}'
           and factoringyhtio = '{$factoringyhtio}'
           {$factoring_tarkista_lisa}";
 $factoring_result = pupe_query($query);
@@ -102,8 +102,8 @@ if ($tee == 'TOIMINNOT') {
   $query = "SELECT min(laskunro) eka, max(laskunro) vika
             FROM lasku use index (yhtio_tila_tapvm)
             JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio
-              and lasku.maksuehto = maksuehto.tunnus
-              and maksuehto.factoring_id = '$factoring_id')
+              and lasku.maksuehto            = maksuehto.tunnus
+              and maksuehto.factoring_id     = '$factoring_id')
             WHERE lasku.yhtio                = '$kukarow[yhtio]'
             and lasku.tila                   = 'U'
             and lasku.tapvm                  > date_sub(CURDATE(), interval 6 month)
@@ -301,13 +301,13 @@ if ($tee == 'TULOSTA') {
   $dquery = "SELECT lasku.yhtio
              FROM lasku
              JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio
-              and lasku.maksuehto = maksuehto.tunnus
-              and maksuehto.factoring_id = '$factoring_id')
-             WHERE lasku.yhtio   = '$kukarow[yhtio]'
-             and lasku.tila      = 'U'
-             and lasku.alatila   = 'X'
-             and lasku.summa    != 0
-             and lasku.valkoodi  = '$valkoodi'
+              and lasku.maksuehto         = maksuehto.tunnus
+              and maksuehto.factoring_id  = '$factoring_id')
+             WHERE lasku.yhtio            = '$kukarow[yhtio]'
+             and lasku.tila               = 'U'
+             and lasku.alatila            = 'X'
+             and lasku.summa             != 0
+             and lasku.valkoodi           = '$valkoodi'
              $where";
   $dresult = pupe_query($dquery);
 
@@ -346,13 +346,13 @@ if ($tee == 'TULOSTA') {
             lasku.liitostunnus
             FROM lasku
             JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio
-              and lasku.maksuehto = maksuehto.tunnus
-              and maksuehto.factoring_id = '$factoring_id')
-            WHERE lasku.yhtio   = '$kukarow[yhtio]'
-            and lasku.tila      = 'U'
-            and lasku.alatila   = 'X'
-            and lasku.summa    != 0
-            and lasku.valkoodi  = '$valkoodi'
+              and lasku.maksuehto         = maksuehto.tunnus
+              and maksuehto.factoring_id  = '$factoring_id')
+            WHERE lasku.yhtio             = '$kukarow[yhtio]'
+            and lasku.tila                = 'U'
+            and lasku.alatila             = 'X'
+            and lasku.summa              != 0
+            and lasku.valkoodi            = '$valkoodi'
             $where
             ORDER BY laskunro";
   $laskures = pupe_query($query);

--- a/pankkiyhteysadmin.php
+++ b/pankkiyhteysadmin.php
@@ -37,9 +37,9 @@ if ($tee == 'paivita_hae_factoring') {
   $hae_factoring = isset($hae_factoring) ? 1 : 0;
 
   $query = "UPDATE pankkiyhteys SET
-            hae_factoring   = {$hae_factoring}
-            WHERE yhtio = '{$kukarow['yhtio']}'
-            AND tunnus  = {$pankkiyhteys_tunnus}";
+            hae_factoring = {$hae_factoring}
+            WHERE yhtio   = '{$kukarow['yhtio']}'
+            AND tunnus    = {$pankkiyhteys_tunnus}";
   pupe_query($query);
 
   $tee = "";
@@ -330,8 +330,8 @@ if ($tee == "uusi_sertifikaatti_hae") {
               SET signing_certificate          = '{$oss}',
                   signing_private_key          = '{$sk}',
                   signing_certificate_valid_to = '{$oss_time}'
-              WHERE yhtio = '{$kukarow['yhtio']}'
-                AND tunnus = {$pankkiyhteys_tunnus}";
+              WHERE yhtio                      = '{$kukarow['yhtio']}'
+                AND tunnus                     = {$pankkiyhteys_tunnus}";
     $result = pupe_query($query);
 
     ok("Sertifikaatti päivitetty!");

--- a/pankkiyhteysadmin.php
+++ b/pankkiyhteysadmin.php
@@ -638,7 +638,7 @@ if ($tee == "") {
       echo "<input type='hidden' name='tee' value='paivita_hae_factoring'>";
       echo "<input type='hidden' name='pankkiyhteys_tunnus' value='{$pankkiyhteys["tunnus"]}'/>";
       $checked = $pankkiyhteys['hae_factoring'] == 1 ? ' checked' : '';
-      $disabled = !in_array($pankkiyhteys['pankki'], array('DABAFIHH','NDEAFIHH')) ? ' disabled' : '';
+      $disabled = !in_array($pankkiyhteys['pankki'], array('DABAFIHH', 'NDEAFIHH')) ? ' disabled' : '';
       echo "<input type='checkbox' name='hae_factoring' value='1'{$checked} onchange='this.form.submit()'{$disabled}>";
       echo "</form>";
       echo "</td>";

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -1628,9 +1628,9 @@ function laheta_excel_koontilahete($otunnukset, $toimitustaparow) {
 
   if (!empty($header_nimi)) {
     $worksheet->writeString($excelrivi,
-                            $excelsarake,
-                            "Deliveries to {$header_nimi}",
-                            $format_bold);
+      $excelsarake,
+      "Deliveries to {$header_nimi}",
+      $format_bold);
 
     for ($i=0; $i < 3; $i++) $excelrivi++;
   }

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -1572,38 +1572,38 @@ function laheta_excel_koontilahete($otunnukset, $toimitustaparow) {
   $_otunnukset = implode(',', $otunnukset);
 
   $query = "SELECT lasku.asiakkaan_tilausnumero,
-                   lasku.nimi,
-                   lasku.toim_nimi,
-                   asiakaskommentti.kommentti,
-                   tilausrivi.tuoteno,
-                   tilausrivi.tilkpl,
-                   tuote.eankoodi,
-                   tuote.myynti_era,
-                   IFNULL(avainsana_nimitys.selite, tuote.nimitys) AS nimitys
+            lasku.nimi,
+            lasku.toim_nimi,
+            asiakaskommentti.kommentti,
+            tilausrivi.tuoteno,
+            tilausrivi.tilkpl,
+            tuote.eankoodi,
+            tuote.myynti_era,
+            IFNULL(avainsana_nimitys.selite, tuote.nimitys) AS nimitys
             FROM lasku
             JOIN tilausrivi
-              ON tilausrivi.yhtio = lasku.yhtio
-              AND tilausrivi.otunnus = lasku.tunnus
-              AND tilausrivi.keratty <> ''
+            ON tilausrivi.yhtio = lasku.yhtio
+            AND tilausrivi.otunnus        = lasku.tunnus
+            AND tilausrivi.keratty        <> ''
             JOIN tuote
-              ON tuote.yhtio = tilausrivi.yhtio
-              AND tuote.tuoteno = tilausrivi.tuoteno
+            ON tuote.yhtio = tilausrivi.yhtio
+            AND tuote.tuoteno             = tilausrivi.tuoteno
             JOIN asiakas
-              ON asiakas.yhtio = lasku.yhtio
-              AND asiakas.tunnus = lasku.liitostunnus
+            ON asiakas.yhtio = lasku.yhtio
+            AND asiakas.tunnus            = lasku.liitostunnus
             LEFT JOIN asiakaskommentti
-              ON asiakaskommentti.yhtio = tilausrivi.yhtio
-              AND asiakaskommentti.ytunnus = lasku.ytunnus
-              AND asiakaskommentti.tuoteno = tilausrivi.tuoteno
+            ON asiakaskommentti.yhtio = tilausrivi.yhtio
+            AND asiakaskommentti.ytunnus  = lasku.ytunnus
+            AND asiakaskommentti.tuoteno  = tilausrivi.tuoteno
             LEFT JOIN tuotteen_avainsanat AS avainsana_nimitys
-              ON avainsana_nimitys.yhtio = tuote.yhtio
-              AND avainsana_nimitys.kieli = asiakas.kieli
-              AND avainsana_nimitys.laji = 'nimitys'
-              AND avainsana_nimitys.tuoteno = tuote.tuoteno
-            WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-              AND lasku.tila = 'L'
-              AND lasku.alatila = 'B'
-              AND lasku.tunnus IN ($_otunnukset)";
+            ON avainsana_nimitys.yhtio = tuote.yhtio
+            AND avainsana_nimitys.kieli   = asiakas.kieli
+            AND avainsana_nimitys.laji    = 'nimitys'
+            AND avainsana_nimitys.tuoteno = tuote.tuoteno
+            WHERE lasku.yhtio             = '{$kukarow['yhtio']}'
+            AND lasku.tila                = 'L'
+            AND lasku.alatila             = 'B'
+            AND lasku.tunnus              IN ($_otunnukset)";
   $result = pupe_query($query);
 
   if (mysql_num_rows($result) == 0) return false;

--- a/rahtikirja.php
+++ b/rahtikirja.php
@@ -2374,7 +2374,7 @@ if (($id == 'dummy' and $mista == 'rahtikirja-tulostus.php') or $id != 0) {
     // haetaan kaikki toimitustavat
     $query  = "SELECT *
                FROM toimitustapa
-               WHERE yhtio       = '$kukarow[yhtio]'
+               WHERE yhtio = '$kukarow[yhtio]'
                and (tulostustapa != 'X' OR selite = '{$otsik["toimitustapa"]}')
                {$toimtapalisa}
                order by jarjestys, selite";

--- a/rahtikirja_custom.php
+++ b/rahtikirja_custom.php
@@ -65,9 +65,9 @@ if (isset($_POST['valmis']) and $_POST['valmis'] != '') {
 
   // korjataan ensimmäinen rivi jossa on väärä otsikkonro sekä rahtikirjanro
   $query = "UPDATE rahtikirjat SET
-            otsikkonro = '{$rahtikirjanro}',
+            otsikkonro    = '{$rahtikirjanro}',
             rahtikirjanro = '{$rahtikirjanro}'
-            WHERE tunnus = '{$otsikkonro}'";
+            WHERE tunnus  = '{$otsikkonro}'";
   pupe_query($query);
 
   $tulosta = "JOO";
@@ -150,7 +150,7 @@ if ((isset($tulosta) or isset($tulostakopio)) and $otsikkonro > 0) {
                     if(asiakas.puhelin != '', asiakas.puhelin, ''))) AS toim_puh
                 FROM asiakas
                 WHERE yhtio = '$kukarow[yhtio]'
-                AND tunnus = '$asiakasid'";
+                AND tunnus  = '$asiakasid'";
       $asres = pupe_query($query);
       $asiakasrow = mysql_fetch_assoc($asres);
 
@@ -276,11 +276,11 @@ if ((isset($tulosta) or isset($tulostakopio)) and $otsikkonro > 0) {
 
     $query = "SELECT summa, viite, valkoodi
               FROM lasku
-              WHERE yhtio = '$kukarow[yhtio]'
-              and tila = 'U'
-              and alatila = 'X'
+              WHERE yhtio      = '$kukarow[yhtio]'
+              and tila         = 'U'
+              and alatila      = 'X'
               and liitostunnus = '$asiakasrow[tunnus]'
-              and tunnus = $lt";
+              and tunnus       = $lt";
     $res = pupe_query($query);
     $row = mysql_fetch_array($res);
 
@@ -717,11 +717,11 @@ if ($asiakasid or $rahtikirja_ilman_asiakasta) {
     $query = "SELECT lasku.*
               FROM lasku use index (yhtio_tila_liitostunnus_tapvm)
               JOIN maksuehto ON (lasku.yhtio=maksuehto.yhtio and lasku.maksuehto=maksuehto.tunnus and maksuehto.jv!='')
-              WHERE lasku.yhtio     = '$kukarow[yhtio]'
-              and lasku.tila        = 'U'
-              and lasku.alatila     = 'X'
+              WHERE lasku.yhtio      = '$kukarow[yhtio]'
+              and lasku.tila         = 'U'
+              and lasku.alatila      = 'X'
               and lasku.liitostunnus = '$asiakasid'
-              and lasku.tapvm >= date_sub(now(), INTERVAL 90 DAY)";
+              and lasku.tapvm        >= date_sub(now(), INTERVAL 90 DAY)";
     $res = pupe_query($query);
 
     if (mysql_num_rows($res)) {

--- a/rahtikirja_custom.php
+++ b/rahtikirja_custom.php
@@ -471,7 +471,7 @@ if (!$asiakasid and !$rahtikirja_ilman_asiakasta) {
 
         mysql_data_seek($kirre, 0);
 
-        echo "<option value='-88'>",t("PDF ruudulle"),"</option>";
+        echo "<option value='-88'>", t("PDF ruudulle"), "</option>";
 
         while ($kirow = mysql_fetch_assoc($kirre)) {
           echo "<option value='$kirow[tunnus]'>$kirow[kirjoitin]</option>";

--- a/rajapinnat/edi.php
+++ b/rajapinnat/edi.php
@@ -5,10 +5,12 @@ class Edi {
   /**
    * Luo edi tilauksen
    *
-   * @param  array   $order   Tilauksen tiedot ja tilauserivit
-   * @param  array   $options Tarvittavat parametrit
+   * @param array   $order   Tilauksen tiedot ja tilauserivit
+   * @param array   $options Tarvittavat parametrit
    * @return string           Luodun tiedoston polku
    */
+
+
   static function create($order, $options) {
     $magento_api_ht_edi            = $options['edi_polku'];
     $ovt_tunnus                    = $options['ovt_tunnus'];

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -9,6 +9,7 @@
  * Hakee tilauksia pupesoftiin.
  */
 
+
 require_once "rajapinnat/edi.php";
 
 class MagentoClient {
@@ -548,7 +549,7 @@ class MagentoClient {
                     $tuote['tuoteno'],
                     $tuotteen_kauppakohtainen_data,
                     $kauppatunnus
-                    )
+                  )
                 );
               }
 
@@ -729,6 +730,7 @@ class MagentoClient {
       }
 
       try {
+
         /**
          * Loopataan tuotteen (configurable) lapsituotteet (simple) l‰pi
          * ja p‰ivitet‰‰n niiden attribuutit kuten koko ja v‰ri.
@@ -854,7 +856,7 @@ class MagentoClient {
                       $nimitys,
                       $tuotteen_kauppakohtainen_data,
                       $kauppatunnus
-                      )
+                    )
                   );
                 }
 

--- a/rajapinnat/presta/PSWebServiceLibrary.php
+++ b/rajapinnat/presta/PSWebServiceLibrary.php
@@ -27,26 +27,44 @@
 */
 
 /**
+ *
  * @package PrestaShopWebservice
  */
-class PrestaShopWebservice
-{
 
-  /** @var string Shop URL */
+
+class PrestaShopWebservice {
+
+  /**
+   *
+   * @var string Shop URL
+   */
   protected $url;
 
-  /** @var string Authentification key */
+  /**
+   *
+   * @var string Authentification key
+   */
   protected $key;
 
-  /** @var boolean is debug activated */
+  /**
+   *
+   * @var boolean is debug activated
+   */
   protected $debug;
 
-  /** @var string PS version */
+  /**
+   *
+   * @var string PS version
+   */
   protected $version;
 
-  /** @var array compatible versions of PrestaShop Webservice */
+  /**
+   *
+   * @var array compatible versions of PrestaShop Webservice
+   */
   const psCompatibleVersionsMin = '1.4.0.0';
   const psCompatibleVersionsMax = '1.6.1.5';
+
 
   /**
    * PrestaShopWebservice constructor. Throw an exception when CURL is not installed/activated
@@ -64,10 +82,11 @@ class PrestaShopWebservice
    * }
    * ?>
    * </code>
-   * @param string $url Root URL for the shop
-   * @param string $key Authentification key
-   * @param mixed $debug Debug mode Activated (true) or deactivated (false)
-  */
+   *
+   * @param string  $url   Root URL for the shop
+   * @param string  $key   Authentification key
+   * @param mixed   $debug Debug mode Activated (true) or deactivated (false)
+   */
   function __construct($url, $key, $debug = true) {
     if (!extension_loaded('curl'))
       throw new PrestaShopWebserviceException('Please activate the PHP extension \'curl\' to allow use of PrestaShop webservice library');
@@ -79,39 +98,39 @@ class PrestaShopWebservice
 
   /**
    * Take the status code and throw an exception if the server didn't return 200 or 201 code
-   * @param int $status_code Status code of an HTTP return
+   *
+   * @param int     $status_code Status code of an HTTP return
    */
-  protected function checkStatusCode($status_code, $error_msg = null, $url = null, $post_data = null)
-  {
+  protected function checkStatusCode($status_code, $error_msg = null, $url = null, $post_data = null) {
     $error_label = "This call to PrestaShop Web Services failed and returned an HTTP status of %d. That means: %s.\n";
     if (!empty($error_msg)) $error_label .= "Response:\n{$error_msg}\n\n";
     if (!empty($url)) $error_label .= "Request URL:\n{$url}\n\n";
     if (!empty($post_data)) $error_label .= "POST data:\n{$post_data}\n\n";
 
-    switch($status_code)
-    {
-      case 200: case 201: break;
-      case 204: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'No content'));break;
-      case 400: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'Bad Request'));break;
-      case 401: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'Unauthorized'));break;
-      case 404: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'Not Found'));break;
-      case 405: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'Method Not Allowed'));break;
-      case 500: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'Internal Server Error'));break;
-      default: throw new PrestaShopWebserviceException('This call to PrestaShop Web Services returned an unexpected HTTP status of:' . $status_code);
+    switch ($status_code) {
+    case 200: case 201: break;
+    case 204: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'No content'));break;
+    case 400: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'Bad Request'));break;
+    case 401: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'Unauthorized'));break;
+    case 404: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'Not Found'));break;
+    case 405: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'Method Not Allowed'));break;
+    case 500: throw new PrestaShopWebserviceException(sprintf($error_label, $status_code, 'Internal Server Error'));break;
+    default: throw new PrestaShopWebserviceException('This call to PrestaShop Web Services returned an unexpected HTTP status of:' . $status_code);
     }
   }
+
   /**
    * Handles a CURL request to PrestaShop Webservice. Can throw exception.
-   * @param string $url Resource name
-   * @param mixed $curl_params CURL parameters (sent to curl_set_opt)
+   *
+   * @param string  $url         Resource name
+   * @param mixed   $curl_params CURL parameters (sent to curl_set_opt)
    * @return array status_code, response
    */
   // CUSTOM HACK
   // This functions has been changed public, we need to get a raw response from presta
   // if we want to fetch the images. this is called from PrestaProducts
   // CUSTOM HACK
-  public function executeRequest($url, $curl_params = array())
-  {
+  public function executeRequest($url, $curl_params = array()) {
     $defaultParams = array(
       CURLOPT_HEADER => TRUE,
       CURLOPT_RETURNTRANSFER => TRUE,
@@ -124,8 +143,7 @@ class PrestaShopWebservice
     $session = curl_init($url);
 
     $curl_options = array();
-    foreach ($defaultParams as $defkey => $defval)
-    {
+    foreach ($defaultParams as $defkey => $defval) {
       if (isset($curl_params[$defkey]))
         $curl_options[$defkey] = $curl_params[$defkey];
       else
@@ -135,7 +153,7 @@ class PrestaShopWebservice
       if (!isset($curl_options[$defkey]))
         $curl_options[$defkey] = $curl_params[$defkey];
 
-    curl_setopt_array($session, $curl_options);
+      curl_setopt_array($session, $curl_options);
     $response = curl_exec($session);
 
     $index = strpos($response, "\r\n\r\n");
@@ -148,26 +166,23 @@ class PrestaShopWebservice
     $headerArrayTmp = explode("\n", $header);
 
     $headerArray = array();
-    foreach ($headerArrayTmp as &$headerItem)
-    {
+    foreach ($headerArrayTmp as &$headerItem) {
       $tmp = explode(':', $headerItem);
       $tmp = array_map('trim', $tmp);
       if (count($tmp) == 2)
         $headerArray[$tmp[0]] = $tmp[1];
     }
 
-    if (array_key_exists('PSWS-Version', $headerArray))
-    {
+    if (array_key_exists('PSWS-Version', $headerArray)) {
       $this->version = $headerArray['PSWS-Version'];
       if (
         version_compare(PrestaShopWebservice::psCompatibleVersionsMin, $headerArray['PSWS-Version']) == 1 ||
         version_compare(PrestaShopWebservice::psCompatibleVersionsMax, $headerArray['PSWS-Version']) == -1
       )
-      throw new PrestaShopWebserviceException('This library is not compatible with this version of PrestaShop. Please upgrade/downgrade this library');
+        throw new PrestaShopWebserviceException('This library is not compatible with this version of PrestaShop. Please upgrade/downgrade this library');
     }
 
-    if ($this->debug)
-    {
+    if ($this->debug) {
       $this->printDebug('HTTP REQUEST HEADER', curl_getinfo($session, CURLINFO_HEADER_OUT));
       $this->printDebug('HTTP RESPONSE HEADER', $header);
 
@@ -176,8 +191,7 @@ class PrestaShopWebservice
     if ($status_code === 0)
       throw new PrestaShopWebserviceException('CURL Error: '.curl_error($session));
     curl_close($session);
-    if ($this->debug)
-    {
+    if ($this->debug) {
       if ($curl_params[CURLOPT_CUSTOMREQUEST] == 'PUT' || $curl_params[CURLOPT_CUSTOMREQUEST] == 'POST')
         $this->printDebug('XML SENT', urldecode($curl_params[CURLOPT_POSTFIELDS]));
       if ($curl_params[CURLOPT_CUSTOMREQUEST] != 'DELETE' && $curl_params[CURLOPT_CUSTOMREQUEST] != 'HEAD')
@@ -186,30 +200,26 @@ class PrestaShopWebservice
     return array('status_code' => $status_code, 'response' => $body, 'header' => $header);
   }
 
-  public function printDebug($title, $content)
-  {
+  public function printDebug($title, $content) {
     echo '<div style="display:table;background:#CCC;font-size:8pt;padding:7px"><h6 style="font-size:9pt;margin:0">'.$title.'</h6><pre>'.htmlentities($content).'</pre></div>';
   }
 
-  public function getVersion()
-  {
+  public function getVersion() {
     return $this->version;
   }
 
   /**
    * Load XML from string. Can throw exception
-   * @param string $response String from a CURL response
+   *
+   * @param string  $response String from a CURL response
    * @return SimpleXMLElement status_code, response
    */
-  protected function parseXML($response)
-  {
-    if ($response != '')
-    {
+  protected function parseXML($response) {
+    if ($response != '') {
       libxml_clear_errors();
       libxml_use_internal_errors(true);
-      $xml = simplexml_load_string($response,'SimpleXMLElement', LIBXML_NOCDATA);
-      if (libxml_get_errors())
-      {
+      $xml = simplexml_load_string($response, 'SimpleXMLElement', LIBXML_NOCDATA);
+      if (libxml_get_errors()) {
         $msg = var_export(libxml_get_errors(), true);
         libxml_clear_errors();
         throw new PrestaShopWebserviceException('HTTP XML response is not parsable: '.$msg);
@@ -226,15 +236,14 @@ class PrestaShopWebservice
    * 'resource' => Resource name<br>
    * 'postXml' => Full XML string to add resource<br><br>
    * Examples are given in the tutorial</p>
-   * @param array $options
+   *
+   * @param array   $options
    * @return SimpleXMLElement status_code, response
    */
-  public function add($options)
-  {
+  public function add($options) {
     $xml = '';
 
-    if (isset($options['resource'], $options['postXml']) || isset($options['url'], $options['postXml']))
-    {
+    if (isset($options['resource'], $options['postXml']) || isset($options['url'], $options['postXml'])) {
       $url = (isset($options['resource']) ? $this->url.'/api/'.$options['resource'] : $options['url']);
       $xml = $options['postXml'];
       if (isset($options['id_shop']))
@@ -275,15 +284,14 @@ class PrestaShopWebservice
    * }
    * ?>
    * </code>
-   * @param array $options Array representing resource to get.
+   *
+   * @param array   $options Array representing resource to get.
    * @return SimpleXMLElement status_code, response
    */
-  public function get($options)
-  {
+  public function get($options) {
     if (isset($options['url']))
       $url = $options['url'];
-    elseif (isset($options['resource']))
-    {
+    elseif (isset($options['resource'])) {
       $url = $this->url.'/api/'.$options['resource'];
       $url_params = array();
       if (isset($options['id']))
@@ -294,8 +302,8 @@ class PrestaShopWebservice
         foreach ($options as $k => $o)
           if (strpos($k, $p) !== false)
             $url_params[$k] = $options[$k];
-      if (count($url_params) > 0)
-        $url .= '?'.http_build_query($url_params);
+          if (count($url_params) > 0)
+            $url .= '?'.http_build_query($url_params);
     }
     else
       throw new PrestaShopWebserviceException('Bad parameters given');
@@ -309,15 +317,13 @@ class PrestaShopWebservice
   /**
    * Head method (HEAD) a resource
    *
-   * @param array $options Array representing resource for head request.
+   * @param array   $options Array representing resource for head request.
    * @return SimpleXMLElement status_code, response
    */
-  public function head($options)
-  {
+  public function head($options) {
     if (isset($options['url']))
       $url = $options['url'];
-    elseif (isset($options['resource']))
-    {
+    elseif (isset($options['resource'])) {
       $url = $this->url.'/api/'.$options['resource'];
       $url_params = array();
       if (isset($options['id']))
@@ -328,8 +334,8 @@ class PrestaShopWebservice
         foreach ($options as $k => $o)
           if (strpos($k, $p) !== false)
             $url_params[$k] = $options[$k];
-      if (count($url_params) > 0)
-        $url .= '?'.http_build_query($url_params);
+          if (count($url_params) > 0)
+            $url .= '?'.http_build_query($url_params);
     }
     else
       throw new PrestaShopWebserviceException('Bad parameters given');
@@ -337,6 +343,7 @@ class PrestaShopWebservice
     self::checkStatusCode($request['status_code'], $request['response'], $url);// check the response validity
     return $request['header'];
   }
+
   /**
    * Edit (PUT) a resource
    * <p>Unique parameter must take : <br><br>
@@ -344,15 +351,14 @@ class PrestaShopWebservice
    * 'id' => ID of a resource you want to edit,<br>
    * 'putXml' => Modified XML string of a resource<br><br>
    * Examples are given in the tutorial</p>
-   * @param array $options Array representing resource to edit.
+   *
+   * @param array   $options Array representing resource to edit.
    */
-  public function edit($options)
-  {
+  public function edit($options) {
     $xml = '';
     if (isset($options['url']))
       $url = $options['url'];
-    elseif ((isset($options['resource'], $options['id']) || isset($options['url'])) && $options['putXml'])
-    {
+    elseif ((isset($options['resource'], $options['id']) || isset($options['url'])) && $options['putXml']) {
       $url = (isset($options['url']) ? $options['url'] : $this->url.'/api/'.$options['resource'].'/'.$options['id']);
       $xml = $options['putXml'];
       if (isset($options['id_shop']))
@@ -389,10 +395,10 @@ class PrestaShopWebservice
    * }
    * ?>
    * </code>
-   * @param array $options Array representing resource to delete.
+   *
+   * @param array   $options Array representing resource to delete.
    */
-  public function delete($options)
-  {
+  public function delete($options) {
     if (isset($options['url']))
       $url = $options['url'];
     elseif (isset($options['resource']) && isset($options['id']))
@@ -400,11 +406,11 @@ class PrestaShopWebservice
         $url = $this->url.'/api/'.$options['resource'].'/?id=['.implode(',', $options['id']).']';
       else
         $url = $this->url.'/api/'.$options['resource'].'/'.$options['id'];
-    if (isset($options['id_shop']))
-      $url .= '&id_shop='.$options['id_shop'];
-    if (isset($options['id_group_shop']))
-      $url .= '&id_group_shop='.$options['id_group_shop'];
-    $request = self::executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'DELETE'));
+      if (isset($options['id_shop']))
+        $url .= '&id_shop='.$options['id_shop'];
+      if (isset($options['id_group_shop']))
+        $url .= '&id_group_shop='.$options['id_group_shop'];
+      $request = self::executeRequest($url, array(CURLOPT_CUSTOMREQUEST => 'DELETE'));
     self::checkStatusCode($request['status_code'], $request['response'], $url);// check the response validity
     return true;
   }
@@ -413,6 +419,7 @@ class PrestaShopWebservice
 }
 
 /**
+ *
  * @package PrestaShopWebservice
  */
 class PrestaShopWebserviceException extends Exception { }

--- a/rajapinnat/presta/presta_addresses.php
+++ b/rajapinnat/presta/presta_addresses.php
@@ -22,6 +22,8 @@ class PrestaAddresses extends PrestaClient {
    * @param SimpleXMLElement $existing_address
    * @return \SimpleXMLElement
    */
+
+
   protected function generate_xml($address, SimpleXMLElement $existing_address = null) {
     if (is_null($existing_address)) {
       $xml = $this->empty_xml();

--- a/rajapinnat/presta/presta_client.php
+++ b/rajapinnat/presta/presta_client.php
@@ -19,6 +19,8 @@ abstract class PrestaClient {
    *
    * @var PrestaShopWebservice REST-client
    */
+
+
   protected $ws = null;
 
   /**
@@ -383,7 +385,7 @@ abstract class PrestaClient {
 
   protected function delete_all() {
     $this->logger->log('---------Start ' . $this->resource_name() . ' delete all---------');
-    # TODO, this only fetches records from the default shop
+    // TODO, this only fetches records from the default shop
     $existing_resources = $this->all(array('id'));
     $existing_resources = array_column($existing_resources, 'id');
 
@@ -507,7 +509,7 @@ abstract class PrestaClient {
     }
     else {
       // substract one, since API key starts from zero
-      return ($this->languages_table[$code] - 1);
+      return $this->languages_table[$code] - 1;
     }
   }
 

--- a/rajapinnat/presta/presta_customers.php
+++ b/rajapinnat/presta/presta_customers.php
@@ -24,6 +24,7 @@ class PrestaCustomers extends PrestaClient {
    * @return \SimpleXMLElement
    */
 
+
   protected function generate_xml($customer, SimpleXMLElement $existing_customer = null) {
     if (is_null($existing_customer)) {
       $xml = $this->empty_xml();

--- a/rajapinnat/presta/presta_functions.php
+++ b/rajapinnat/presta/presta_functions.php
@@ -85,7 +85,7 @@ function presta_hae_asiakasryhmat() {
   return $ryhmat;
 }
 
-function presta_specific_prices(Array $ajolista) {
+function presta_specific_prices(array $ajolista) {
   global $kukarow, $yhtiorow;
 
   presta_echo("Haetaan tuotteiden ".implode(', ', $ajolista).".");
@@ -688,7 +688,7 @@ function presta_tallenna_liite($params) {
   tallenna_liite($filename, 'tuote', $liitostunnus, $image_id, 'TK');
 }
 
-function presta_poista_ylimaaraiset_kuvat($sku, Array $all_ids) {
+function presta_poista_ylimaaraiset_kuvat($sku, array $all_ids) {
   $kukarow  = $GLOBALS["kukarow"];
   $yhtiorow = $GLOBALS["yhtiorow"];
 

--- a/rajapinnat/presta/presta_functions.php
+++ b/rajapinnat/presta/presta_functions.php
@@ -22,13 +22,13 @@ function presta_hae_asiakkaat() {
             FROM yhteyshenkilo
             INNER JOIN asiakas
             ON (asiakas.yhtio = yhteyshenkilo.yhtio
-              AND asiakas.tunnus = yhteyshenkilo.liitostunnus )
+              AND asiakas.tunnus      = yhteyshenkilo.liitostunnus )
             LEFT JOIN avainsana
             ON (avainsana.yhtio = asiakas.yhtio
-              AND avainsana.selite = asiakas.ryhma
-              AND avainsana.laji = 'ASIAKASRYHMA')
+              AND avainsana.selite    = asiakas.ryhma
+              AND avainsana.laji      = 'ASIAKASRYHMA')
             WHERE yhteyshenkilo.yhtio = '{$kukarow['yhtio']}'
-            AND yhteyshenkilo.rooli = 'Presta'
+            AND yhteyshenkilo.rooli   = 'Presta'
             {$muutoslisa}";
   $result = pupe_query($query);
 
@@ -51,8 +51,8 @@ function presta_hae_yhteyshenkilon_asiakas_ulkoisella_asiakasnumerolla($asiakasn
             FROM yhteyshenkilo
             INNER JOIN asiakas
             ON (asiakas.yhtio = yhteyshenkilo.yhtio
-              AND asiakas.tunnus = yhteyshenkilo.liitostunnus)
-            WHERE yhteyshenkilo.yhtio = '{$kukarow['yhtio']}'
+              AND asiakas.tunnus                     = yhteyshenkilo.liitostunnus)
+            WHERE yhteyshenkilo.yhtio                = '{$kukarow['yhtio']}'
             AND yhteyshenkilo.ulkoinen_asiakasnumero = {$asiakasnumero}
             LIMIT 1";
   $result = pupe_query($query);
@@ -74,7 +74,7 @@ function presta_hae_asiakasryhmat() {
             avainsana.selitetark_5 AS presta_customergroup_id
             FROM avainsana
             WHERE avainsana.yhtio = '{$kukarow['yhtio']}'
-            AND laji = 'ASIAKASRYHMA'";
+            AND laji              = 'ASIAKASRYHMA'";
   $result = pupe_query($query);
 
   $ryhmat = array();
@@ -127,15 +127,15 @@ function presta_specific_prices(Array $ajolista) {
                 'asiakashinta' AS tyyppi
                 FROM asiakashinta
                 LEFT JOIN avainsana ON (avainsana.yhtio = asiakashinta.yhtio
-                  AND avainsana.selite = asiakashinta.asiakas_ryhma
-                  AND avainsana.laji = 'ASIAKASRYHMA')
+                  AND avainsana.selite           = asiakashinta.asiakas_ryhma
+                  AND avainsana.laji             = 'ASIAKASRYHMA')
                 LEFT JOIN yhteyshenkilo ON (yhteyshenkilo.yhtio = asiakashinta.yhtio
                   AND yhteyshenkilo.liitostunnus = asiakashinta.asiakas)
-                WHERE asiakashinta.yhtio = '{$kukarow['yhtio']}'
-                AND asiakashinta.tuoteno = '{$tuote['tuoteno']}'
+                WHERE asiakashinta.yhtio         = '{$kukarow['yhtio']}'
+                AND asiakashinta.tuoteno         = '{$tuote['tuoteno']}'
                 AND if(asiakashinta.alkupvm  = '0000-00-00', '0001-01-01', asiakashinta.alkupvm)  <= current_date
                 AND if(asiakashinta.loppupvm = '0000-00-00', '9999-12-31', asiakashinta.loppupvm) >= current_date
-                AND asiakashinta.hinta > 0";
+                AND asiakashinta.hinta           > 0";
       $asiakashintaresult = pupe_query($query);
 
       while ($asiakashinta = mysql_fetch_assoc($asiakashintaresult)) {
@@ -157,15 +157,15 @@ function presta_specific_prices(Array $ajolista) {
                 'asiakasalennus' AS tyyppi
                 FROM asiakasalennus
                 LEFT JOIN avainsana ON (avainsana.yhtio = asiakasalennus.yhtio
-                  AND avainsana.selite = asiakasalennus.asiakas_ryhma
-                  AND avainsana.laji = 'ASIAKASRYHMA')
+                  AND avainsana.selite           = asiakasalennus.asiakas_ryhma
+                  AND avainsana.laji             = 'ASIAKASRYHMA')
                 LEFT JOIN yhteyshenkilo ON (yhteyshenkilo.yhtio = asiakasalennus.yhtio
                   AND yhteyshenkilo.liitostunnus = asiakasalennus.asiakas)
-                WHERE asiakasalennus.yhtio = '{$kukarow['yhtio']}'
-                AND asiakasalennus.tuoteno = '{$tuote['tuoteno']}'
+                WHERE asiakasalennus.yhtio       = '{$kukarow['yhtio']}'
+                AND asiakasalennus.tuoteno       = '{$tuote['tuoteno']}'
                 AND if(asiakasalennus.alkupvm  = '0000-00-00', '0001-01-01', asiakasalennus.alkupvm)  <= current_date
                 AND if(asiakasalennus.loppupvm = '0000-00-00', '9999-12-31', asiakasalennus.loppupvm) >= current_date
-                AND asiakasalennus.alennus > 0";
+                AND asiakasalennus.alennus       > 0";
       $asiakasalennusresult = pupe_query($query);
 
       while ($asiakasalennus = mysql_fetch_assoc($asiakasalennusresult)) {
@@ -185,8 +185,8 @@ function presta_specific_prices(Array $ajolista) {
                 FROM hinnasto
                 WHERE hinnasto.yhtio = '{$kukarow['yhtio']}'
                 AND hinnasto.tuoteno = '{$tuote['tuoteno']}'
-                AND hinnasto.laji in ('', 'N', 'E')
-                AND hinnasto.hinta > 0";
+                AND hinnasto.laji    in ('', 'N', 'E')
+                AND hinnasto.hinta   > 0";
       $hintavalresult = pupe_query($query);
 
       while ($hintavalrow = mysql_fetch_assoc($hintavalresult)) {
@@ -200,15 +200,15 @@ function presta_specific_prices(Array $ajolista) {
                   hinnasto.maa,
                   'hinnastohinta' AS tyyppi
                   FROM hinnasto
-                  WHERE hinnasto.yhtio = '$kukarow[yhtio]'
-                  AND hinnasto.tuoteno = '$hintavalrow[tuoteno]'
-                  AND hinnasto.tuoteno = '{$hintavalrow['tuoteno']}'
+                  WHERE hinnasto.yhtio  = '$kukarow[yhtio]'
+                  AND hinnasto.tuoteno  = '$hintavalrow[tuoteno]'
+                  AND hinnasto.tuoteno  = '{$hintavalrow['tuoteno']}'
                   AND hinnasto.valkoodi = '$hintavalrow[valkoodi]'
-                  AND hinnasto.maa = '$hintavalrow[maa]'
-                  AND hinnasto.laji in ('', 'N', 'E')
+                  AND hinnasto.maa      = '$hintavalrow[maa]'
+                  AND hinnasto.laji     in ('', 'N', 'E')
                   AND if(hinnasto.alkupvm  = '0000-00-00', '0001-01-01', hinnasto.alkupvm)  <= current_date
                   AND if(hinnasto.loppupvm = '0000-00-00', '9999-12-31', hinnasto.loppupvm) >= current_date
-                  AND hinnasto.hinta > 0
+                  AND hinnasto.hinta    > 0
                   ORDER BY IFNULL(TO_DAYS(current_date) - TO_DAYS(hinnasto.alkupvm), 9999999999999), tunnus DESC
                   LIMIT 1";
         $hinnastoresult = pupe_query($query);
@@ -236,7 +236,7 @@ function presta_specific_prices(Array $ajolista) {
               '' AS presta_customer_id,
               'customhinta' AS tyyppi
               FROM tuote
-              WHERE tuote.yhtio = '{$kukarow['yhtio']}'
+              WHERE tuote.yhtio     = '{$kukarow['yhtio']}'
               AND tuote.myyntihinta > 0
               {$tuoterajaus}";
     $result = pupe_query($query);
@@ -283,14 +283,14 @@ function presta_hae_kategoriat() {
             (SELECT parent.tunnus
              FROM dynaaminen_puu AS parent
              WHERE parent.yhtio = node.yhtio
-             AND parent.laji = node.laji
-             AND parent.lft < node.lft
-             AND parent.rgt > node.rgt
+             AND parent.laji    = node.laji
+             AND parent.lft     < node.lft
+             AND parent.rgt     > node.rgt
              ORDER by parent.lft DESC
              LIMIT 1) as parent_tunnus
             FROM dynaaminen_puu AS node
-            WHERE node.yhtio = '{$kukarow['yhtio']}'
-            AND node.laji = 'tuote'
+            WHERE node.yhtio    = '{$kukarow['yhtio']}'
+            AND node.laji       = 'tuote'
             ORDER BY node.syvyys, node.lft";
   $result = pupe_query($query);
 
@@ -300,10 +300,10 @@ function presta_hae_kategoriat() {
     // Haetaan kategorian käännökset
     $query = "SELECT kieli, tarkenne
               FROM dynaaminen_puu_avainsanat
-              WHERE yhtio = '{$kukarow['yhtio']}'
+              WHERE yhtio      = '{$kukarow['yhtio']}'
               AND liitostunnus = '{$kategoria['node_tunnus']}'
-              AND laji = 'tuote'
-              AND avainsana = 'nimi'";
+              AND laji         = 'tuote'
+              AND avainsana    = 'nimi'";
     $tr_result = pupe_query($query);
     $kaannokset = array();
 
@@ -353,9 +353,9 @@ function presta_hae_kaikki_tuotteet() {
     // Katsotaan onko tämä isätuote
     $query = "SELECT tunnus
               FROM tuoteperhe
-              WHERE yhtio = '{$kukarow['yhtio']}'
+              WHERE yhtio    = '{$kukarow['yhtio']}'
               AND isatuoteno = '{$tuoteno}'
-              AND tyyppi = 'P'
+              AND tyyppi     = 'P'
               LIMIT 1";
     $tr_result = pupe_query($query);
 
@@ -413,12 +413,12 @@ function presta_hae_tuotteet() {
   $query = "SELECT distinct tuote.*
             FROM tuote
             LEFT JOIN puun_alkio ON (puun_alkio.yhtio = tuote.yhtio
-              AND puun_alkio.laji = 'tuote'
-              AND puun_alkio.liitos = tuote.tuoteno)
+              AND puun_alkio.laji             = 'tuote'
+              AND puun_alkio.liitos           = tuote.tuoteno)
             LEFT JOIN tuotteen_avainsanat ON (tuotteen_avainsanat.yhtio = tuote.yhtio
               AND tuotteen_avainsanat.tuoteno = tuote.tuoteno
-              AND tuotteen_avainsanat.laji IN ('nimitys', 'kuvaus', 'lyhytkuvaus'))
-            WHERE tuote.yhtio = '{$kukarow['yhtio']}'
+              AND tuotteen_avainsanat.laji    IN ('nimitys', 'kuvaus', 'lyhytkuvaus'))
+            WHERE tuote.yhtio                 = '{$kukarow['yhtio']}'
             {$tuoterajaus}";
   $res = pupe_query($query);
   $dnstuote = array();
@@ -452,7 +452,7 @@ function presta_hae_tuotteet() {
               FROM tuotteen_avainsanat
               WHERE yhtio = '{$kukarow['yhtio']}'
               AND tuoteno = '{$row['tuoteno']}'
-              AND laji IN ('nimitys', 'kuvaus', 'lyhytkuvaus')";
+              AND laji    IN ('nimitys', 'kuvaus', 'lyhytkuvaus')";
     $tr_result = pupe_query($query);
     $tuotteen_kaannokset = array();
 
@@ -472,9 +472,9 @@ function presta_hae_tuotteet() {
     // Haetaan tuotteen lapsituotteet, jos tämä on isätuote
     $query = "SELECT tuoteno, kerroin
               FROM tuoteperhe
-              WHERE yhtio = '{$kukarow['yhtio']}'
+              WHERE yhtio    = '{$kukarow['yhtio']}'
               AND isatuoteno = '{$row['tuoteno']}'
-              AND tyyppi = 'P'";
+              AND tyyppi     = 'P'";
     $tr_result = pupe_query($query);
     $tuotteen_lapsituotteet = array();
 
@@ -491,8 +491,8 @@ function presta_hae_tuotteet() {
     $query = "SELECT puun_tunnus
               FROM puun_alkio
               WHERE yhtio = '{$kukarow['yhtio']}'
-              AND laji = 'tuote'
-              AND liitos = '{$row['tuoteno']}'";
+              AND laji    = 'tuote'
+              AND liitos  = '{$row['tuoteno']}'";
     $result_tp = pupe_query($query);
     $tuotepuun_tunnukset = array();
 
@@ -600,9 +600,9 @@ function presta_export_checkpoint($checkpoint) {
 
     // Päivitetään timestamppi tähän hetkeen
     $query = "UPDATE avainsana SET
-              selite = now()
+              selite      = now()
               WHERE yhtio = '{$kukarow['yhtio']}'
-              AND laji = '{$checkpoint}'";
+              AND laji    = '{$checkpoint}'";
     pupe_query($query);
   }
   else {
@@ -649,11 +649,11 @@ function presta_image_exists($sku, $id) {
   // katsotaan onko meillä jo tämä tuotekuva tallessa
   $query = "SELECT tunnus
             FROM liitetiedostot
-            WHERE yhtio = '{$kukarow['yhtio']}'
-            AND liitos = 'tuote'
-            AND liitostunnus = {$liitostunnus}
+            WHERE yhtio         = '{$kukarow['yhtio']}'
+            AND liitos          = 'tuote'
+            AND liitostunnus    = {$liitostunnus}
             AND kayttotarkoitus = 'TK'
-            AND selite = '{$id}'";
+            AND selite          = '{$id}'";
   $result = pupe_query($query);
 
   if (mysql_num_rows($result) == 0) {
@@ -717,9 +717,9 @@ function presta_poista_ylimaaraiset_kuvat($sku, Array $all_ids) {
   // dellataan kuvat
   $query = "DELETE
             FROM liitetiedostot
-            WHERE yhtio = '{$kukarow['yhtio']}'
-            AND liitos = 'tuote'
-            AND liitostunnus = {$liitostunnus}
+            WHERE yhtio         = '{$kukarow['yhtio']}'
+            AND liitos          = 'tuote'
+            AND liitostunnus    = {$liitostunnus}
             AND kayttotarkoitus = 'TK'
             {$selite_query}";
   $result = pupe_query($query);
@@ -740,8 +740,8 @@ function presta_hae_tilaustuote() {
   $query = "SELECT kieli, selite, selitetark
             FROM avainsana
             WHERE yhtio = '{$kukarow['yhtio']}'
-            AND laji = 'S'
-            AND selite = 'T'";
+            AND laji    = 'S'
+            AND selite  = 'T'";
   $tr_result = pupe_query($query);
   $tuotteen_statukset = array();
 

--- a/rajapinnat/presta/presta_products.php
+++ b/rajapinnat/presta/presta_products.php
@@ -49,6 +49,8 @@ class PrestaProducts extends PrestaClient {
    * @param SimpleXMLElement $existing_product
    * @return \SimpleXMLElement
    */
+
+
   protected function generate_xml($product, SimpleXMLElement $existing_product = null) {
     if (is_null($existing_product)) {
       $xml = $this->empty_xml();
@@ -151,19 +153,19 @@ class PrestaProducts extends PrestaClient {
       $field = strtolower($translation['kentta']);
 
       switch ($field) {
-        case 'nimitys':
-          $xml->product->name->language[$tr_id] = $value;
-          $xml->product->link_rewrite->language[$tr_id] = $this->saniteze_link_rewrite("{$product['tuoteno']}_{$value}");
-          break;
-        case 'kuvaus':
-          $xml->product->description->language[$tr_id] = $value;
-          break;
-        case 'lyhytkuvaus':
-          $xml->product->description_short->language[$tr_id] = $value;
-          break;
-        case 'tilaustuote':
-          $xml->product->available_later->language[$tr_id] = $value;
-          break;
+      case 'nimitys':
+        $xml->product->name->language[$tr_id] = $value;
+        $xml->product->link_rewrite->language[$tr_id] = $this->saniteze_link_rewrite("{$product['tuoteno']}_{$value}");
+        break;
+      case 'kuvaus':
+        $xml->product->description->language[$tr_id] = $value;
+        break;
+      case 'lyhytkuvaus':
+        $xml->product->description_short->language[$tr_id] = $value;
+        break;
+      case 'tilaustuote':
+        $xml->product->available_later->language[$tr_id] = $value;
+        break;
       }
 
       $this->logger->log("Käännös {$translation['kieli']}, {$translation['kentta']}: $value");
@@ -363,8 +365,8 @@ class PrestaProducts extends PrestaClient {
         }
       }
       catch (Exception $e) {
-          //Do nothing here. If create / update throws exception loggin happens inside those functions
-          //Exception is not thrown because we still want to continue syncing for other products
+        //Do nothing here. If create / update throws exception loggin happens inside those functions
+        //Exception is not thrown because we still want to continue syncing for other products
       }
 
       $this->logger->log("Tuote {$product['tuoteno']} käsitelty.\n");

--- a/rajapinnat/presta/presta_sales_orders.php
+++ b/rajapinnat/presta/presta_sales_orders.php
@@ -133,6 +133,8 @@ class PrestaSalesOrders extends PrestaClient {
    *
    * @return array
    */
+
+
   public function fetch_sales_orders() {
     $this->logger->log('Fetching sales orders');
 
@@ -266,7 +268,7 @@ class PrestaSalesOrders extends PrestaClient {
     if (isset($order_rows['order_rows'])) {
       $rows = $order_rows['order_rows'];
     }
-    elseif(isset($order_rows['order_row'])) {
+    elseif (isset($order_rows['order_row'])) {
       $rows = $order_rows['order_row'];
     }
     else {

--- a/rajapinnat/presta/presta_specific_prices.php
+++ b/rajapinnat/presta/presta_specific_prices.php
@@ -28,6 +28,7 @@ class PrestaSpecificPrices extends PrestaClient {
    * @return \SimpleXMLElement
    */
 
+
   protected function generate_xml($specific_price, SimpleXMLElement $existing_specific_price = null) {
     if (is_null($existing_specific_price)) {
       $xml = $this->empty_xml();

--- a/rajapinnat/pupenext.php
+++ b/rajapinnat/pupenext.php
@@ -68,7 +68,7 @@ function pupenext_luo_myyntitilausotsikko($params) {
   $query = "SELECT *
             FROM asiakas
             WHERE yhtio = '{$kukarow['yhtio']}'
-            AND tunnus = {$customer_id}
+            AND tunnus  = {$customer_id}
             LIMIT 1";
   $result = pupe_query($query);
 
@@ -101,7 +101,7 @@ function pupenext_tilaus_valmis($params) {
   $query = "SELECT *
             FROM lasku
             WHERE yhtio = '{$kukarow['yhtio']}'
-            AND tunnus = {$order_id}
+            AND tunnus  = {$order_id}
             LIMIT 1";
   $result = pupe_query($query);
 
@@ -127,7 +127,7 @@ function pupenext_lisaa_rivi($params) {
 
   $query = "SELECT *
             FROM tuote
-            WHERE tuote.yhtio = '{$kukarow['yhtio']}'
+            WHERE tuote.yhtio  = '{$kukarow['yhtio']}'
               AND tuote.tunnus = $product_id
             LIMIT 1";
   $result = pupe_query($query);
@@ -139,7 +139,7 @@ function pupenext_lisaa_rivi($params) {
   $query = "SELECT *
             FROM lasku
             WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-            AND lasku.tunnus = $order_id";
+            AND lasku.tunnus  = $order_id";
   $result = pupe_query($query);
 
   if (mysql_num_rows($result) != 1) die('Tilausta ei löytynyt');

--- a/rajapinnat/relex/relex_customers.php
+++ b/rajapinnat/relex/relex_customers.php
@@ -131,12 +131,12 @@ while ($row = mysql_fetch_assoc($res)) {
   $rivi  = "{$row['maa']}-{$row['tunnus']};";
   $rivi .= pupesoft_csvstring($row['nimi']).";";
   $rivi .= pupesoft_csvstring($row['ryhma']);
-  
+
   if ($extra_asiakastiedot) {
     $rivi .= ";".pupesoft_csvstring($row['asiakasnro']);
     $rivi .= ";".pupesoft_csvstring($row['myyjanro']);
-  } 
-  
+  }
+
   $rivi .= "\n";
 
   fwrite($fp, $rivi);

--- a/rajapinnat/tuote_export_functions.php
+++ b/rajapinnat/tuote_export_functions.php
@@ -967,9 +967,9 @@ function tuote_export_paivita_avainsana($timestamp) {
 
   // P‰ivitet‰‰n timestamp avainsanaan
   $query = "UPDATE avainsana SET
-            selite = '{$timestamp}'
+            selite      = '{$timestamp}'
             WHERE yhtio = '{$kukarow['yhtio']}'
-            AND laji = 'TUOTE_EXP_CRON'";
+            AND laji    = 'TUOTE_EXP_CRON'";
   pupe_query($query);
 
   if (mysql_affected_rows() != 1) {

--- a/rajapinnat/yrityspeli.php
+++ b/rajapinnat/yrityspeli.php
@@ -112,11 +112,11 @@ function hae_tilauksettomat_yhtiot($alkuaika, $loppuaika) {
                     sum(tilausrivi.varattu * tilausrivi.hinta) as summa
                     FROM yhtio
                     LEFT JOIN lasku ON (lasku.yhtio = yhtio.yhtio
-                      AND lasku.tila IN ('N','L')
+                      AND lasku.tila         IN ('N','L')
                       AND lasku.luontiaika BETWEEN '$alkuaika' AND '$loppuaika')
                     LEFT JOIN tilausrivi ON (tilausrivi.yhtio = lasku.yhtio
                       AND tilausrivi.otunnus = lasku.tunnus)
-                    WHERE yhtio.yhtio = '{$row['yhtio']}'
+                    WHERE yhtio.yhtio        = '{$row['yhtio']}'
                     GROUP BY yhtio.yhtio";
     $tilausresult = pupe_query($tilausquery);
     $tilausrow = mysql_fetch_assoc($tilausresult);
@@ -155,7 +155,7 @@ function generoi_myyntitilauksia($yhtiot, $kokonaiskustannus, $tilausmaara, $kau
 function hae_oletusasiakkuus($yhtio, $kauppakeskus_myyra) {
   $query = "SELECT *
             FROM asiakas
-            WHERE yhtio = '{$yhtio}'
+            WHERE yhtio   = '{$yhtio}'
             AND ovttunnus = '{$kauppakeskus_myyra}'
             LIMIT 1";
   $result = pupe_query($query);
@@ -229,10 +229,10 @@ function luo_tilausotsikot_ja_tilausrivit($yhtio, $asiakas, $kokonaiskustannus) 
 function tuotearvonta($yhtio) {
   $query = "SELECT *
             FROM tuote
-            WHERE yhtio = '{$yhtio}'
-            AND status != 'P'
-            AND myyntihinta > 0
-            AND tuotetyyppi NOT in ('A','B')
+            WHERE yhtio      = '{$yhtio}'
+            AND status      != 'P'
+            AND myyntihinta  > 0
+            AND tuotetyyppi  NOT in ('A','B')
             ORDER BY RAND() LIMIT 0, 1";
   $result = pupe_query($query);
 

--- a/rajapinnat/yrityspeli.php
+++ b/rajapinnat/yrityspeli.php
@@ -202,7 +202,7 @@ function luo_tilausotsikot_ja_tilausrivit($yhtio, $asiakas, $kokonaiskustannus) 
       return;
     }
 
-    $kpl = rand(1,3);
+    $kpl = rand(1, 3);
     $hintacounter += ($trow['myyntihinta'] * $kpl);
 
     $params = array(

--- a/raportit/alv_laskelma_uusi.php
+++ b/raportit/alv_laskelma_uusi.php
@@ -787,11 +787,11 @@ function laskeveroja($taso, $tulos) {
                   FROM lasku USE INDEX (yhtio_tila_tapvm)
                   JOIN tilausrivi USE INDEX (uusiotunnus_index) ON (tilausrivi.yhtio = lasku.yhtio and tilausrivi.uusiotunnus = lasku.tunnus)
                   JOIN tuote USE INDEX (tuoteno_index) ON (tuote.yhtio = tilausrivi.yhtio and tuote.tuoteno = tilausrivi.tuoteno and tuote.tuoteno != '$yhtiorow[ennakkomaksu_tuotenumero]' $tuotetyyppilisa)
-                  WHERE lasku.yhtio = '$kukarow[yhtio]'
-                  and lasku.tila    = 'U'
-                  and lasku.tapvm   >= '$startmonth'
-                  and lasku.tapvm   <= '$endmonth'
-                  and lasku.vienti  = 'E'
+                  WHERE lasku.yhtio       = '$kukarow[yhtio]'
+                  and lasku.tila          = 'U'
+                  and lasku.tapvm         >= '$startmonth'
+                  and lasku.tapvm         <= '$endmonth'
+                  and lasku.vienti        = 'E'
                   and lasku.tilaustyyppi != '9'
                   {$kolmikantakauppa}
                   GROUP BY 1,2";

--- a/raportit/asiakkaantilaukset.php
+++ b/raportit/asiakkaantilaukset.php
@@ -337,11 +337,11 @@ elseif ($astilnro != '' or $tilausviite != '') {
   else {
     $otunnus = $row["tunnus"];
   }
-  
+
   if ($row["jaksotettu"] <> 0) {
     $sopimus = abs($row["jaksotettu"]);
   }
-  
+
   $ytunnus   = $row["ytunnus"];
 
   if ($cleantoim == 'OSTO') {
@@ -450,7 +450,7 @@ if ($ytunnus != '') {
   $summaselli .= " lasku.asiakkaan_tilausnumero astilno, ";
 
   if ($otunnus > 0 or $laskunro > 0 or $sopimus > 0) {
-    
+
     if ($sopimus > 0) {
       $query = "(SELECT $yhtioekolisa lasku.tunnus tilaus, lasku.laskunro, concat_ws(' ', lasku.nimi, lasku.nimitark) asiakas, lasku.ytunnus, lasku.toimaika, lasku.laatija, $summaselli lasku.tila, lasku.alatila, lasku.hyvak1, lasku.hyvak2, lasku.h1time, lasku.h2time, lasku.luontiaika, lasku.yhtio
                  FROM lasku

--- a/raportit/asiakkaantilaukset.php
+++ b/raportit/asiakkaantilaukset.php
@@ -712,7 +712,7 @@ if ($ytunnus != '') {
           echo "<td valign='top' nowrap align='right' $class>$row[$i]</td>";
         }
         elseif (mysql_field_name($result, $i) == 'ytunnus') {
-          echo "<td valign='top' {$class}>",tarkistahetu($row[$i]),"</td>";
+          echo "<td valign='top' {$class}>", tarkistahetu($row[$i]), "</td>";
         }
         else {
           echo "<td valign='top' $class>$row[$i]</td>";

--- a/raportit/factoringstemmuutus.php
+++ b/raportit/factoringstemmuutus.php
@@ -114,8 +114,8 @@ if (isset($submit)) {
 
   $query = "SELECT *
             FROM factoring
-            WHERE yhtio        = '$kukarow[yhtio]'
-            AND tunnus         = '$sopimus'";
+            WHERE yhtio = '$kukarow[yhtio]'
+            AND tunnus  = '$sopimus'";
   $res = pupe_query($query);
 
   if (mysql_num_rows($res) == 1) {

--- a/raportit/kuukautisostot.php
+++ b/raportit/kuukautisostot.php
@@ -79,8 +79,8 @@ else {
     ${"apaiva{$i}"} = (int) date('Ymd', mktime(0, 0, 0, ${"kkaed{$i}"}, ${"ppaed{$i}"}, ${"vvaed{$i}"}));
     ${"lpaiva{$i}"} = (int) date('Ymd', mktime(0, 0, 0, ${"kkl{$i}"}, ${"ppl{$i}"}, ${"vvl{$i}"}));
   }
-  
-  $k = 0; 
+
+  $k = 0;
   // Vuosineljännekset
   for ($i = 1; $i < 5; $i++) {
     $j = $k + 1;
@@ -91,12 +91,12 @@ else {
     if (!isset(${"qkka{$i}"})) ${"qkka{$i}"} = ${"kkl{$k}"};
     if (!isset(${"qvva{$i}"})) ${"qvva{$i}"} = ${"vvl{$k}"};
     if (!isset(${"qppa{$i}"})) ${"qppa{$i}"} = ${"ppa{$k}"};
-  } 
+  }
   $qa1 = "$qvva1"."-"."$qkka1"."-"."$qppa1";
   $qa2 = "$qvva2"."-"."$qkka2"."-"."$qppa2";
   $qa3 = "$qvva3"."-"."$qkka3"."-"."$qppa3";
   $qa4 = "$qvva4"."-"."$qkka4"."-"."$qppa4";
-  
+
   $ql1 = "$qvvl1"."-"."$qkkl1"."-"."$qppl1";
   $ql2 = "$qvvl2"."-"."$qkkl2"."-"."$qppl2";
   $ql3 = "$qvvl3"."-"."$qkkl3"."-"."$qppl3";
@@ -2882,9 +2882,9 @@ function saldo_funktio($tuoteno, $varastot_yhtiot, $varastot, $paikoittain, $lis
 
 function myydyt_kappaleet($row_yhtio, $tuoteno, $apvm, $lpvm, $lisa, $ei_vienteja_lisa, $ei_asiakkaan_myynteja_lisa) {
   global $kukarow, $yhtiorow, $qa1, $qa2, $qa3, $qa4, $ql1, $ql2, $ql3, $ql4;
- 
+
   $selectlisa = "";
- 
+
   $selectlisa .= "sum(if (laskutettuaika >= '$qa1' and laskutettuaika <= '$ql1', kpl, 0)) as kpl_q1, ";
   $selectlisa .= "sum(if (laskutettuaika >= '$qa2' and laskutettuaika <= '$ql2.', kpl, 0)) as kpl_q2, ";
   $selectlisa .= "sum(if (laskutettuaika >= '$qa3' and laskutettuaika <= '$ql3', kpl, 0)) as kpl_q3, ";

--- a/raportit/matkallaolevat_laskuittain.php
+++ b/raportit/matkallaolevat_laskuittain.php
@@ -197,10 +197,10 @@ if ($tee == "aja" and $alisa != "" and $llisa != "") {
             sum(tiliointi.summa) AS matkalla
             FROM tiliointi
             JOIN lasku on (lasku.tunnus = tiliointi.ltunnus)
-            WHERE tiliointi.yhtio = '{$kukarow['yhtio']}'
-            AND tiliointi.tilino = '{$yhtiorow['matkalla_olevat']}'
-            AND tiliointi.tapvm >= '{$alisa}'
-            AND tiliointi.tapvm <= '{$llisa}'
+            WHERE tiliointi.yhtio  = '{$kukarow['yhtio']}'
+            AND tiliointi.tilino   = '{$yhtiorow['matkalla_olevat']}'
+            AND tiliointi.tapvm    >= '{$alisa}'
+            AND tiliointi.tapvm    <= '{$llisa}'
             AND tiliointi.korjattu = ''
             {$vo_laskurajaus_lisa}
             {$tapvm_laskurajaus_lisa}
@@ -295,9 +295,9 @@ if ($tee == "aja" and $alisa != "" and $llisa != "") {
         // Milloin rivit on viety saldoille keskimäärin
         $query = "SELECT DATE_FORMAT(FROM_UNIXTIME(AVG(UNIX_TIMESTAMP(laskutettuaika))),'%Y-%m-%d') AS laskutettuaika
                   FROM tilausrivi
-                  WHERE yhtio     = '{$kukarow['yhtio']}'
-                  AND uusiotunnus = {$keikrow['tunnus']}
-                  AND tyyppi      = 'O'
+                  WHERE yhtio         = '{$kukarow['yhtio']}'
+                  AND uusiotunnus     = {$keikrow['tunnus']}
+                  AND tyyppi          = 'O'
                   AND laskutettuaika != '0000-00-00'";
         $rivires = pupe_query($query);
         $rivirow = mysql_fetch_assoc($rivires);
@@ -306,9 +306,9 @@ if ($tee == "aja" and $alisa != "" and $llisa != "") {
         $query = "SELECT
                   round(sum(rivihinta), 2) va_arvo
                   FROM tilausrivi
-                  WHERE yhtio     = '{$kukarow['yhtio']}'
-                  AND uusiotunnus = {$keikrow['tunnus']}
-                  AND tyyppi      = 'O'
+                  WHERE yhtio        = '{$kukarow['yhtio']}'
+                  AND uusiotunnus    = {$keikrow['tunnus']}
+                  AND tyyppi         = 'O'
                   AND laskutettuaika <= '$llisa'";
         $varivires = pupe_query($query);
         $varivirow = mysql_fetch_assoc($varivires);

--- a/raportit/matkallaolevat_laskuittain.php
+++ b/raportit/matkallaolevat_laskuittain.php
@@ -167,16 +167,16 @@ $create_excel = (isset($excel) and $excel != "");
 
 if ($tee == "aja" and $alisa != "" and $llisa != "") {
   switch ($vo_laskurajaus) {
-    case 'vain':
-      // halutaan listata vain vaihto-omaisuuslaskuja
-      $vo_laskurajaus_lisa = "AND lasku.vienti in ('C','F','I')";
-      break;
-    case 'muut':
-      // ei haluta listata vaihto-omaisuuslaskuja
-      $vo_laskurajaus_lisa = "AND lasku.vienti not in ('C','F','I')";
-      break;
-    default:
-      $vo_laskurajaus_lisa = '';
+  case 'vain':
+    // halutaan listata vain vaihto-omaisuuslaskuja
+    $vo_laskurajaus_lisa = "AND lasku.vienti in ('C','F','I')";
+    break;
+  case 'muut':
+    // ei haluta listata vaihto-omaisuuslaskuja
+    $vo_laskurajaus_lisa = "AND lasku.vienti not in ('C','F','I')";
+    break;
+  default:
+    $vo_laskurajaus_lisa = '';
   }
 
   if ($rajaa_myos_lasku_tapvm == 'YES') {

--- a/raportit/myyntiseuranta.php
+++ b/raportit/myyntiseuranta.php
@@ -2722,7 +2722,7 @@ else {
               }
 
               if (!empty($kumulatiivinen_valittu)) {
-                $_kumulalk_parts = explode("-",$kumulatiivinen_alkupaiva);
+                $_kumulalk_parts = explode("-", $kumulatiivinen_alkupaiva);
                 $_kumulalk = $_kumulalk_parts[0].sprintf('%02d', $_kumulalk_parts[1]);
                 $_kumul_alkukuun_paivat = date('t', mktime(0, 0, 0, $_kumulalk_parts[1], 1, $_kumulalk_parts[0]));
 

--- a/raportit/naytatilaus.inc
+++ b/raportit/naytatilaus.inc
@@ -112,7 +112,7 @@ if ($laskurow["tila"] == "O") {
 echo "</tr>";
 
 echo "<tr>
-    <td>",tarkistahetu($laskurow['ytunnus']),"</td>
+    <td>", tarkistahetu($laskurow['ytunnus']), "</td>
     <td colspan='2'>$laskurow[nimi] $laskurow[nimitark]<br> $laskurow[osoite]<br> $laskurow[postino] $laskurow[postitp]<br>".maa($laskurow["maa"])."</td>";
 
 if ($verkkokauppa != "" and $muokkaa != "") {
@@ -359,7 +359,7 @@ if ($laskurow["tila"] != "O" and $laskurow["tila"] != "K") {
       $linkurl = substr($linkurl, 0, -4); // vika br pois
     }
     elseif (stripos(strtolower($laskurow["toimitustapa"]), "mypack") !== FALSE and !empty($rakirrow['rahtikirjanro'])) {
-      foreach(explode(" ", $rakirrow['rahtikirjanro']) as $mypnro) {
+      foreach (explode(" ", $rakirrow['rahtikirjanro']) as $mypnro) {
         $linkurl .= "<a target=newikkuna href='http://www.postnord.fi/fi/yritysasiakkaat/asiakaspalvelu/sahkoinen-asiointi/Sivut/Lahetysten-seuranta.aspx?view=item&itemid={$mypnro}'>{$mypnro}</a> ";
       }
     }

--- a/raportit/naytatilaus.inc
+++ b/raportit/naytatilaus.inc
@@ -256,9 +256,9 @@ if ($laskurow["tila"] != "O" and $laskurow["tila"] != "K") {
   if ($laskurow["tila"] == "U") {
     $query = "SELECT group_concat(lasku.tunnus) tunnukset
               FROM lasku
-              WHERE yhtio     = '$kukarow[yhtio]'
-              and tila        = 'L'
-              and laskunro    = '$laskurow[laskunro]'";
+              WHERE yhtio  = '$kukarow[yhtio]'
+              and tila     = 'L'
+              and laskunro = '$laskurow[laskunro]'";
     $otres = pupe_query($query);
     $otrow = mysql_fetch_assoc($otres);
 
@@ -393,7 +393,7 @@ if (($laskurow["tila"] == "L" or $laskurow["tila"] == "N") and $kukarow["extrane
             FROM tilausrivi
             WHERE tilausrivi.yhtio  = '{$kukarow['yhtio']}'
             AND tilausrivi.otunnus  = '{$laskurow['tunnus']}'
-            and tilausrivi.var not in ('P','J','O','S')
+            and tilausrivi.var      not in ('P','J','O','S')
             AND tilausrivi.tyyppi  != 'D'
             HAVING kerattyaika != '0000-00-00 00:00:00'";
   $kerattyaikares = pupe_query($query);
@@ -418,7 +418,7 @@ if (($laskurow["tila"] == "L" or $laskurow["tila"] == "N") and $kukarow["extrane
               FROM tilausrivi
               WHERE tilausrivi.yhtio  = '{$kukarow['yhtio']}'
               AND tilausrivi.otunnus  = '{$laskurow['tunnus']}'
-              and tilausrivi.var not in ('P','J','O','S')
+              and tilausrivi.var      not in ('P','J','O','S')
               AND tilausrivi.tyyppi  != 'D'
               HAVING toimitettuaika != '0000-00-00 00:00:00'";
     $toimitettuaikares = pupe_query($query);

--- a/raportit/saatanat.php
+++ b/raportit/saatanat.php
@@ -527,7 +527,7 @@ if ($tee == 'NAYTA' or $eiliittymaa == 'ON') {
             echo "$PHP_SELF////tee=$tee//sytunnus=$sytunnus//sanimi=$sanimi//yli=$yli//sappl=$sappl//sakkl=$sakkl//savvl=$savvl//grouppaus=$grouppaus//savalkoodi=$savalkoodi//valuutassako=$valuutassako///$row[latunnari]";
           }
 
-          echo "'>",tarkistahetu($row['ytunnus']),"</a>";
+          echo "'>", tarkistahetu($row['ytunnus']), "</a>";
           echo "</td>";
 
           if (substr_count($row['nimi'], '<br>') > 5) {

--- a/raportit/selaasopimuksia.php
+++ b/raportit/selaasopimuksia.php
@@ -101,7 +101,7 @@ while ($rivit = mysql_fetch_assoc($result)) {
 
   if (strpos($rivit["asiakas"], '!¡!') !== false) {
     list($_ytunnus, $_nimi) = explode('!¡!', $rivit["asiakas"]);
-    echo tarkistahetu($_ytunnus),"<br>{$_nimi}";
+    echo tarkistahetu($_ytunnus), "<br>{$_nimi}";
   }
   else {
     echo $rivit["asiakas"];

--- a/raportit/toimitetut_rivit.php
+++ b/raportit/toimitetut_rivit.php
@@ -58,9 +58,9 @@ if ($tee == 'aja') {
             FROM tilausrivi
             JOIN lasku ON (tilausrivi.yhtio = lasku.yhtio AND tilausrivi.otunnus = lasku.tunnus)
             LEFT JOIN asiakas ON (asiakas.yhtio = lasku.yhtio and asiakas.tunnus = lasku.liitostunnus)
-            WHERE tilausrivi.yhtio = '{$kukarow['yhtio']}'
-            AND tilausrivi.tyyppi = 'L'
-            AND tilausrivi.var not in ('P','J','O','S')
+            WHERE tilausrivi.yhtio        = '{$kukarow['yhtio']}'
+            AND tilausrivi.tyyppi         = 'L'
+            AND tilausrivi.var            not in ('P','J','O','S')
             AND tilausrivi.varattu+tilausrivi.kpl != 0
             AND tilausrivi.toimitettuaika > '0000-00-00 00:00:00'
             AND tilausrivi.toimitettuaika <= '$vva-$kka-$ppa 23:59:59'

--- a/raportit/toimitetut_rivit.php
+++ b/raportit/toimitetut_rivit.php
@@ -103,7 +103,7 @@ if ($tee == 'aja') {
   $worksheet->write($excelrivi, 7, t("Asiakasnro"), $format_bold);
   $worksheet->write($excelrivi, 8, t("Hyvitys"), $format_bold);
   $worksheet->write($excelrivi, 9, t("Sisäinen viesti"), $format_bold);
-  $worksheet->write($excelrivi,10, t("Tila"), $format_bold);
+  $worksheet->write($excelrivi, 10, t("Tila"), $format_bold);
   $excelrivi++;
 
   $summat = 0;
@@ -144,7 +144,7 @@ if ($tee == 'aja') {
     $worksheet->writeString($excelrivi, 7, $row['asiakasnro']);
     $worksheet->writeString($excelrivi, 8, $row['viesti']);
     $worksheet->writeString($excelrivi, 9, $row['sisviesti3']);
-    $worksheet->writeString($excelrivi,10, t("$laskutyyppi")." ".t("$alatila"));
+    $worksheet->writeString($excelrivi, 10, t("$laskutyyppi")." ".t("$alatila"));
     $excelrivi++;
 
     $summat += $row['rivihinta_verolli'];

--- a/raportit/topten.php
+++ b/raportit/topten.php
@@ -18,7 +18,7 @@ if (empty($aja_raportti)) {
   // Haetaan alku ja loppup‰iv‰m‰‰r‰t valinnan mukaan
   $pvmrajaus = hae_rajauksen_paivamaarat($pvmvalinta);
 
-  foreach($pvmrajaus as $key => $value) {
+  foreach ($pvmrajaus as $key => $value) {
     $$key = $value;
   }
 }
@@ -129,18 +129,18 @@ function hae_rajauksen_paivamaarat($pvmvalinta) {
   );
 
   switch ($pvmvalinta) {
-    case "tvv":
-      $alku = date('d-m-Y', strtotime('last monday'));
-      $loppu = date('d-m-Y', strtotime('next sunday'));
-      break;
-    case "tkk":
-      $alku = date('d-m-Y', strtotime('first day of this month'));
-      $loppu = date('d-m-Y', strtotime('last day of this month'));
-      break;
-    case "tvvv":
-      $alku = date('d-m-Y', strtotime('Jan 1'));
-      $loppu = date('d-m-Y', strtotime('Dec 31'));
-      break;
+  case "tvv":
+    $alku = date('d-m-Y', strtotime('last monday'));
+    $loppu = date('d-m-Y', strtotime('next sunday'));
+    break;
+  case "tkk":
+    $alku = date('d-m-Y', strtotime('first day of this month'));
+    $loppu = date('d-m-Y', strtotime('last day of this month'));
+    break;
+  case "tvvv":
+    $alku = date('d-m-Y', strtotime('Jan 1'));
+    $loppu = date('d-m-Y', strtotime('Dec 31'));
+    break;
   }
 
   $alku = explode('-', $alku);
@@ -222,28 +222,28 @@ function hae_data($tyyppi, $limitit, $rajaukset) {
   }
 
   switch ($tyyppi) {
-    case "tuotteet":
-      $haettu_data['otsikko'] = t('Tuotteet');
-      $limitti = in_array('tuote', $limitit) ? '' : ' LIMIT 10 ';
-      break;
-    case "asiakkaat":
-      $haettu_data['otsikko'] = t('Asiakkaat');
-      $nimikentta = " asiakas.nimi ";
-      $grouppauskentta = " asiakas.tunnus ";
-      $limitti = in_array('asiakas', $limitit) ? '' : ' LIMIT 10 ';
-      break;
-    case "asiakasryhmat":
-      $haettu_data['otsikko'] = t('Asiakasryhm‰t');
-      $nimikentta = " ifnull(avainsana.selitetark,'".t("Ei asiakasryhm‰‰")."') ";
-      $grouppauskentta = " asiakas.ryhma ";
-      $limitti = in_array('asiakasryhma', $limitit) ? '' : ' LIMIT 10 ';
-      break;
-    case "asiakasmyyjat":
-      $haettu_data['otsikko'] = t('Asiakasmyyj‰t');
-      $nimikentta = " ifnull(kuka.nimi,'".t("Ei asiakasmyyj‰‰")."') ";
-      $grouppauskentta = " asiakas.myyjanro ";
-      $limitti = in_array('asiakasmyyja', $limitit) ? '' : ' LIMIT 10 ';
-      break;
+  case "tuotteet":
+    $haettu_data['otsikko'] = t('Tuotteet');
+    $limitti = in_array('tuote', $limitit) ? '' : ' LIMIT 10 ';
+    break;
+  case "asiakkaat":
+    $haettu_data['otsikko'] = t('Asiakkaat');
+    $nimikentta = " asiakas.nimi ";
+    $grouppauskentta = " asiakas.tunnus ";
+    $limitti = in_array('asiakas', $limitit) ? '' : ' LIMIT 10 ';
+    break;
+  case "asiakasryhmat":
+    $haettu_data['otsikko'] = t('Asiakasryhm‰t');
+    $nimikentta = " ifnull(avainsana.selitetark,'".t("Ei asiakasryhm‰‰")."') ";
+    $grouppauskentta = " asiakas.ryhma ";
+    $limitti = in_array('asiakasryhma', $limitit) ? '' : ' LIMIT 10 ';
+    break;
+  case "asiakasmyyjat":
+    $haettu_data['otsikko'] = t('Asiakasmyyj‰t');
+    $nimikentta = " ifnull(kuka.nimi,'".t("Ei asiakasmyyj‰‰")."') ";
+    $grouppauskentta = " asiakas.myyjanro ";
+    $limitti = in_array('asiakasmyyja', $limitit) ? '' : ' LIMIT 10 ';
+    break;
   }
 
   $query = "SELECT {$nimikentta} nimi,

--- a/raportit/topten.php
+++ b/raportit/topten.php
@@ -252,29 +252,29 @@ function hae_data($tyyppi, $limitit, $rajaukset) {
             FROM lasku use index (yhtio_tila_tapvm)
             JOIN yhtio ON (yhtio.yhtio = lasku.yhtio)
             JOIN tilausrivi use index (uusiotunnus_index) ON (tilausrivi.yhtio = lasku.yhtio
-              AND tilausrivi.uusiotunnus = lasku.tunnus
-              AND tilausrivi.tyyppi = 'L'
-              AND tilausrivi.tuoteno != '{$yhtiorow['ennakkomaksu_tuotenumero']}')
+              AND tilausrivi.uusiotunnus   = lasku.tunnus
+              AND tilausrivi.tyyppi        = 'L'
+              AND tilausrivi.tuoteno      != '{$yhtiorow['ennakkomaksu_tuotenumero']}')
             JOIN tuote use index (tuoteno_index) ON (tuote.yhtio = tilausrivi.yhtio
-              AND tuote.tuoteno = tilausrivi.tuoteno
-              AND tuote.myynninseuranta = ''
+              AND tuote.tuoteno            = tilausrivi.tuoteno
+              AND tuote.myynninseuranta    = ''
               {$tuoterajaus})
             JOIN asiakas use index (PRIMARY) ON (asiakas.yhtio = lasku.yhtio
-              AND asiakas.tunnus = lasku.liitostunnus
-              AND asiakas.myynninseuranta = ''
+              AND asiakas.tunnus           = lasku.liitostunnus
+              AND asiakas.myynninseuranta  = ''
               {$myyjarajaus}
               {$ryhmarajaus})
             LEFT JOIN kuka ON (kuka.yhtio = asiakas.yhtio
-              AND kuka.myyja = asiakas.myyjanro
-              AND kuka.myyja > 0)
+              AND kuka.myyja               = asiakas.myyjanro
+              AND kuka.myyja               > 0)
             LEFT JOIN avainsana ON (avainsana.yhtio = lasku.yhtio
-              AND avainsana.laji = 'ASIAKASRYHMA'
-              AND avainsana.selite = asiakas.ryhma)
-            WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-            AND lasku.tila = 'U'
-            AND lasku.alatila = 'X'
-            AND lasku.tapvm >= '{$alkupvm}'
-            AND lasku.tapvm <= '{$loppupvm}'
+              AND avainsana.laji           = 'ASIAKASRYHMA'
+              AND avainsana.selite         = asiakas.ryhma)
+            WHERE lasku.yhtio              = '{$kukarow['yhtio']}'
+            AND lasku.tila                 = 'U'
+            AND lasku.alatila              = 'X'
+            AND lasku.tapvm                >= '{$alkupvm}'
+            AND lasku.tapvm                <= '{$loppupvm}'
             GROUP BY {$grouppauskentta}
             ORDER BY myyntinyt DESC
             {$limitti}";

--- a/raportit/varastotilasto.php
+++ b/raportit/varastotilasto.php
@@ -52,7 +52,7 @@ if ($toim == "KASSA" and !isset($painoinnappia)) {
   $listaustyyppi = "eimyyntia";
 }
 
-$sel = array_fill_keys(array($listaustyyppi), " SELECTED") + array_fill_keys(array('kappaleet', 'hinnat', 'kappaleet2','eimyyntia'), '');
+$sel = array_fill_keys(array($listaustyyppi), " SELECTED") + array_fill_keys(array('kappaleet', 'hinnat', 'kappaleet2', 'eimyyntia'), '');
 
 echo "<tr>";
 echo "<th>".t("Listaustyyppi")."</th>";

--- a/saapuminen_ulkoiseen_jarjestelmaan.php
+++ b/saapuminen_ulkoiseen_jarjestelmaan.php
@@ -199,7 +199,7 @@ if ($xml_chk and $ftp_chk) {
 
   if (file_put_contents($filename, $xml->asXML())) {
 
-    # L‰hetet‰‰n UTF-8 muodossa jos PUPE_UNICODE on true
+    // L‰hetet‰‰n UTF-8 muodossa jos PUPE_UNICODE on true
     $ftputf8 = PUPE_UNICODE;
 
     if ($_cli) {

--- a/saapumisen_kuittaus_ulkoisesta_jarjestelmasta.php
+++ b/saapumisen_kuittaus_ulkoisesta_jarjestelmasta.php
@@ -115,8 +115,8 @@ if ($handle = opendir($path)) {
 
       $tilausrivit = array();
 
-      # Poistetaan ostotilauksen kaikki kohdistukset saapumiselta
-      # koska aineistossa on OIKEAT saapuneet ostotilauksen rivit
+      // Poistetaan ostotilauksen kaikki kohdistukset saapumiselta
+      // koska aineistossa on OIKEAT saapuneet ostotilauksen rivit
       $query = "UPDATE tilausrivi SET
                 uusiotunnus     = 0
                 WHERE yhtio     = '{$yhtio}'
@@ -125,8 +125,8 @@ if ($handle = opendir($path)) {
                 AND uusiotunnus = '{$saapumistunnus}'";
       $updres = pupe_query($query);
 
-      # Loopataan rivit tilausrivit-arrayseen
-      # koska Pupesoftin tilausrivi voi tulla monella aineiston rivill‰
+      // Loopataan rivit tilausrivit-arrayseen
+      // koska Pupesoftin tilausrivi voi tulla monella aineiston rivill‰
       foreach ($xml->Lines->Line as $key => $line) {
 
         $rivitunnus = (int) $line->TransId;
@@ -149,9 +149,9 @@ if ($handle = opendir($path)) {
         $tuoteno = $data['tuoteno'];
         $kpl     = $data['kpl'];
 
-        # Jos sanomassa on kappaleita ja tiedet‰‰n saapuminen
-        # Kohdistetaan t‰m‰ rivi saapumiseen
-        # Aiemmin ollaan poistettu kaikki t‰m‰n saapumisen kohdistukset
+        // Jos sanomassa on kappaleita ja tiedet‰‰n saapuminen
+        // Kohdistetaan t‰m‰ rivi saapumiseen
+        // Aiemmin ollaan poistettu kaikki t‰m‰n saapumisen kohdistukset
         if ($kpl != 0 and $saapumistunnus != 0) {
           $uusiotunnuslisa = ", uusiotunnus = '{$saapumistunnus}' ";
         }
@@ -159,7 +159,7 @@ if ($handle = opendir($path)) {
           $uusiotunnuslisa = "";
         }
 
-        # P‰ivitet‰‰n varattu ja kohdistetaan rivi
+        // P‰ivitet‰‰n varattu ja kohdistetaan rivi
         $query = "UPDATE tilausrivi SET
                   varattu     = '{$kpl}'
                   {$uusiotunnuslisa}

--- a/saapumisen_kuittaus_ulkoisesta_jarjestelmasta.php
+++ b/saapumisen_kuittaus_ulkoisesta_jarjestelmasta.php
@@ -91,11 +91,11 @@ if ($handle = opendir($path)) {
 
       $query = "SELECT tunnus
                 FROM lasku
-                WHERE yhtio  = '{$yhtio}'
-                AND tila     = 'K'
+                WHERE yhtio     = '{$yhtio}'
+                AND tila        = 'K'
                 AND vanhatunnus = 0
-                AND laskunro = '{$saapumisnro}'
-                AND sisviesti3 = 'ei_vie_varastoon'";
+                AND laskunro    = '{$saapumisnro}'
+                AND sisviesti3  = 'ei_vie_varastoon'";
       $selectres = pupe_query($query);
       $selectrow = mysql_fetch_assoc($selectres);
 
@@ -161,23 +161,23 @@ if ($handle = opendir($path)) {
 
         # Päivitetään varattu ja kohdistetaan rivi
         $query = "UPDATE tilausrivi SET
-                  varattu         = '{$kpl}'
+                  varattu     = '{$kpl}'
                   {$uusiotunnuslisa}
-                  WHERE yhtio     = '{$yhtio}'
-                  AND tyyppi      = 'O'
-                  AND kpl         = 0
-                  AND otunnus     = '{$ostotilaus}'
-                  AND tuoteno     = '{$tuoteno}'
-                  AND tunnus      = '{$rivitunnus}'";
+                  WHERE yhtio = '{$yhtio}'
+                  AND tyyppi  = 'O'
+                  AND kpl     = 0
+                  AND otunnus = '{$ostotilaus}'
+                  AND tuoteno = '{$tuoteno}'
+                  AND tunnus  = '{$rivitunnus}'";
         $updres = pupe_query($query);
       }
 
       if (count($tilausrivit) > 0) {
         $query = "UPDATE lasku SET
-                  sisviesti3   = 'ok_vie_varastoon'
-                  WHERE yhtio  = '{$yhtio}'
-                  AND tila     = 'K'
-                  AND tunnus = '{$saapumistunnus}'";
+                  sisviesti3  = 'ok_vie_varastoon'
+                  WHERE yhtio = '{$yhtio}'
+                  AND tila    = 'K'
+                  AND tunnus  = '{$saapumistunnus}'";
         $updres = pupe_query($query);
 
         if (!empty($email)) {

--- a/saapumisien_kulut.php
+++ b/saapumisien_kulut.php
@@ -42,9 +42,9 @@ echo "<table>
     </td>
   </tr>";
 
-  $scheck = (!empty($saapumisittain)) ? "CHECKED": "";
+$scheck = (!empty($saapumisittain)) ? "CHECKED": "";
 
-  echo "<tr>
+echo "<tr>
     <th>".t("Listaa saapumiset")."</th>
     <td>
     <input type='checkbox' name='saapumisittain' $scheck>

--- a/sampofactoring.php
+++ b/sampofactoring.php
@@ -16,7 +16,7 @@ if ($tee == 'TARKISTA') {
 
 $query = "SELECT *
           FROM factoring
-          WHERE yhtio = '{$kukarow["yhtio"]}'
+          WHERE yhtio        = '{$kukarow["yhtio"]}'
           and factoringyhtio = 'SAMPO'
           {$factoring_tarkista_lisa}";
 $factoring_result = pupe_query($query);
@@ -59,14 +59,14 @@ if ($tee == "TOIMINNOT") {
   $query = "SELECT count(*) kpl, sum(arvo) arvo, sum(summa) summa
             FROM lasku USE INDEX (factoring)
             JOIN maksuehto ON (maksuehto.yhtio = lasku.yhtio
-              and maksuehto.tunnus = lasku.maksuehto
-              and maksuehto.factoring_id = '$factoring_id')
-            WHERE lasku.yhtio            = '$kukarow[yhtio]' and
-            lasku.tila                   = 'U' and
-            lasku.alatila                = 'X' and
-            lasku.summa                 != 0 and
-            lasku.factoringsiirtonumero  = '' and
-            lasku.valkoodi               = '$yhtiorow[valkoodi]'";
+              and maksuehto.tunnus        = lasku.maksuehto
+              and maksuehto.factoring_id  = '$factoring_id')
+            WHERE lasku.yhtio             = '$kukarow[yhtio]' and
+            lasku.tila                    = 'U' and
+            lasku.alatila                 = 'X' and
+            lasku.summa                  != 0 and
+            lasku.factoringsiirtonumero   = '' and
+            lasku.valkoodi                = '$yhtiorow[valkoodi]'";
   $result = pupe_query($query);
   $laskurow = mysql_fetch_array($result);
 
@@ -138,14 +138,14 @@ if ($tee == 'TULOSTA') {
   $query = "SELECT ifnull(group_concat(lasku.tunnus),0) tunnukset
             FROM lasku USE INDEX (factoring)
             JOIN maksuehto ON (maksuehto.yhtio = lasku.yhtio
-              and maksuehto.tunnus = lasku.maksuehto
-              and maksuehto.factoring_id = '$factoring_id')
-            WHERE lasku.yhtio            = '$kukarow[yhtio]' and
-            lasku.tila                   = 'U' and
-            lasku.alatila                = 'X' and
-            lasku.summa                 != 0 and
-            lasku.factoringsiirtonumero  = '$numero' and
-            lasku.valkoodi               = '$yhtiorow[valkoodi]'
+              and maksuehto.tunnus        = lasku.maksuehto
+              and maksuehto.factoring_id  = '$factoring_id')
+            WHERE lasku.yhtio             = '$kukarow[yhtio]' and
+            lasku.tila                    = 'U' and
+            lasku.alatila                 = 'X' and
+            lasku.summa                  != 0 and
+            lasku.factoringsiirtonumero   = '$numero' and
+            lasku.valkoodi                = '$yhtiorow[valkoodi]'
             order by laskunro";
   $result = pupe_query($query);
   $laskurow = mysql_fetch_array($result);

--- a/sveafactoring.php
+++ b/sveafactoring.php
@@ -75,7 +75,7 @@ if ($tee == 'TARKISTA') {
 
 $query = "SELECT *
           FROM factoring
-          WHERE yhtio = '{$kukarow["yhtio"]}'
+          WHERE yhtio        = '{$kukarow["yhtio"]}'
           and factoringyhtio = '{$factoringyhtio}'
           {$factoring_tarkista_lisa}";
 $factoring_result = pupe_query($query);
@@ -139,8 +139,8 @@ if ($tee == 'TOIMINNOT') {
   $query = "SELECT min(laskunro) eka, max(laskunro) vika
             FROM lasku use index (factoring)
             JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio
-              and lasku.maksuehto = maksuehto.tunnus
-              and maksuehto.factoring_id = '$factoring_id')
+              and lasku.maksuehto            = maksuehto.tunnus
+              and maksuehto.factoring_id     = '$factoring_id')
             WHERE lasku.yhtio                = '$kukarow[yhtio]'
             and lasku.tila                   = 'U'
             and lasku.alatila                = 'X'
@@ -285,13 +285,13 @@ if ($tee == 'TULOSTA') {
   $dquery = "SELECT lasku.yhtio
              FROM lasku
              JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio
-              and lasku.maksuehto = maksuehto.tunnus
-              and maksuehto.factoring = '$factoring_id')
-             WHERE lasku.yhtio   = '$kukarow[yhtio]'
-             and lasku.tila      = 'U'
-             and lasku.alatila   = 'X'
-             and lasku.summa    != 0
-             and lasku.valkoodi  = '$valkoodi'
+              and lasku.maksuehto      = maksuehto.tunnus
+              and maksuehto.factoring  = '$factoring_id')
+             WHERE lasku.yhtio         = '$kukarow[yhtio]'
+             and lasku.tila            = 'U'
+             and lasku.alatila         = 'X'
+             and lasku.summa          != 0
+             and lasku.valkoodi        = '$valkoodi'
              $where";
   $dresult = pupe_query($dquery);
 
@@ -336,13 +336,13 @@ if ($tee == 'TULOSTA') {
             lasku.liitostunnus
             FROM lasku
             JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio
-              and lasku.maksuehto = maksuehto.tunnus
-              and maksuehto.factoring = '$factoring_id')
-            WHERE lasku.yhtio   = '$kukarow[yhtio]'
-            and lasku.tila      = 'U'
-            and lasku.alatila   = 'X'
-            and lasku.summa    != 0
-            and lasku.valkoodi  = '$valkoodi'
+              and lasku.maksuehto      = maksuehto.tunnus
+              and maksuehto.factoring  = '$factoring_id')
+            WHERE lasku.yhtio          = '$kukarow[yhtio]'
+            and lasku.tila             = 'U'
+            and lasku.alatila          = 'X'
+            and lasku.summa           != 0
+            and lasku.valkoodi         = '$valkoodi'
             $where
             ORDER BY laskunro";
   $laskures = pupe_query($query);

--- a/synkronoi_sanakirja.php
+++ b/synkronoi_sanakirja.php
@@ -30,7 +30,7 @@ $kieliarray = array("se", "en", "de", "no", "dk", "ee");
 if ($tee == "TEE" or $tee == "UPDATE") {
 
   function sanakirja_echo($ekotus) {
-    GLOBAL $ei_ruudulle;
+    global $ei_ruudulle;
 
     if (empty($ei_ruudulle)) {
       echo "$ekotus";

--- a/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
+++ b/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
@@ -267,7 +267,7 @@ else {
           break;
         }
 
-        # L‰hetet‰‰n UTF-8 muodossa jos PUPE_UNICODE on true
+        // L‰hetet‰‰n UTF-8 muodossa jos PUPE_UNICODE on true
         $ftputf8 = PUPE_UNICODE;
 
         require "inc/ftp-send.inc";

--- a/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
+++ b/synkronoi_tuotteet_ulkoiseen_jarjestelmaan.php
@@ -48,8 +48,8 @@ else {
   $query = "SELECT tuote.*, ta.selite AS synkronointi, ta.tunnus AS ta_tunnus
             FROM tuote
             LEFT JOIN tuotteen_avainsanat AS ta ON (ta.yhtio = tuote.yhtio AND ta.tuoteno = tuote.tuoteno AND ta.laji = 'synkronointi')
-            WHERE tuote.yhtio    = '{$kukarow['yhtio']}'
-            AND tuote.ei_saldoa  = ''
+            WHERE tuote.yhtio   = '{$kukarow['yhtio']}'
+            AND tuote.ei_saldoa = ''
             {$wherelisa}
             HAVING (ta.tunnus IS NOT NULL AND ta.selite = '') OR
                     # jos avainsanaa ei ole olemassa ja status P niin ei haluta näitä tuotteita jatkossakaan

--- a/tervetuloa.php
+++ b/tervetuloa.php
@@ -263,19 +263,19 @@ if (!isset($tee) or $tee == '') {
 
   // Näytetään työmääräykset joissa käyttäjä on vastuuhenkilönä
   $tyojono2sql = "SELECT lasku.tunnus,
-                 lasku.nimi,
-                 lasku.toimaika,
-                 a2.selitetark tyostatus,
-                 a2.selitetark_2 tyostatusvari,
-                 a5.selitetark tyom_prioriteetti
-                 FROM lasku
-                 JOIN tyomaarays ON (tyomaarays.yhtio = lasku.yhtio AND tyomaarays.otunnus = lasku.tunnus AND tyomaarays.tyojono != '' AND tyomaarays.vastuuhenkilo = '{$kukarow["kuka"]}')
-                 LEFT JOIN avainsana a2 ON (a2.yhtio=tyomaarays.yhtio and a2.laji='TYOM_TYOSTATUS' and a2.selite=tyomaarays.tyostatus)
-                 LEFT JOIN avainsana a5 ON (a5.yhtio=tyomaarays.yhtio and a5.laji='TYOM_PRIORIT' and a5.selite=tyomaarays.prioriteetti)
-                 WHERE lasku.yhtio  = '{$kukarow["yhtio"]}'
-                 AND lasku.tila     in ('A','L','N','S','C')
-                 AND lasku.alatila != 'X'
-                 ORDER BY ifnull(a5.jarjestys, 9999), ifnull(a2.jarjestys, 9999), lasku.toimaika asc, a2.selitetark";
+                  lasku.nimi,
+                  lasku.toimaika,
+                  a2.selitetark tyostatus,
+                  a2.selitetark_2 tyostatusvari,
+                  a5.selitetark tyom_prioriteetti
+                  FROM lasku
+                  JOIN tyomaarays ON (tyomaarays.yhtio = lasku.yhtio AND tyomaarays.otunnus = lasku.tunnus AND tyomaarays.tyojono != '' AND tyomaarays.vastuuhenkilo = '{$kukarow["kuka"]}')
+                  LEFT JOIN avainsana a2 ON (a2.yhtio=tyomaarays.yhtio and a2.laji='TYOM_TYOSTATUS' and a2.selite=tyomaarays.tyostatus)
+                  LEFT JOIN avainsana a5 ON (a5.yhtio=tyomaarays.yhtio and a5.laji='TYOM_PRIORIT' and a5.selite=tyomaarays.prioriteetti)
+                  WHERE lasku.yhtio  = '{$kukarow["yhtio"]}'
+                  AND lasku.tila     in ('A','L','N','S','C')
+                  AND lasku.alatila != 'X'
+                  ORDER BY ifnull(a5.jarjestys, 9999), ifnull(a2.jarjestys, 9999), lasku.toimaika asc, a2.selitetark";
   $tyoresult2 = pupe_query($tyojono2sql);
 
   if (mysql_num_rows($tyoresult2) > 0) {

--- a/tilauskasittely/editilaus_in.inc
+++ b/tilauskasittely/editilaus_in.inc
@@ -1577,8 +1577,8 @@ while ($tietue = fgets($fd)) {
 
       // Katsotaan verkkokauppatapauksessa tilauksen valuutta
       if ($edi_tyyppi == 'magento'
-          and isset($verkkokauppa_hinnatedifailista) and $verkkokauppa_hinnatedifailista == "JOO"
-          and !empty($editilaus_valuuttakoodi)) {
+        and isset($verkkokauppa_hinnatedifailista) and $verkkokauppa_hinnatedifailista == "JOO"
+        and !empty($editilaus_valuuttakoodi)) {
         // escapetaan
         $valkoodi = mysql_real_escape_string($editilaus_valuuttakoodi);
 

--- a/tilauskasittely/editilaus_in.inc
+++ b/tilauskasittely/editilaus_in.inc
@@ -1585,7 +1585,7 @@ while ($tietue = fgets($fd)) {
         $query = "SELECT tunnus
                   FROM valuu
                   WHERE yhtio = '{$kukarow["yhtio"]}'
-                  AND nimi = '{$valkoodi}'";
+                  AND nimi    = '{$valkoodi}'";
         $valuu_result = pupe_query($query);
 
         if (mysql_num_rows($valuu_result) != 1) {
@@ -1690,17 +1690,17 @@ while ($tietue = fgets($fd)) {
       $id = mysql_insert_id($GLOBALS["masterlink"]);
 
       $query = "INSERT INTO laskun_lisatiedot SET
-                laskutus_nimi     = '$arow[laskutus_nimi]',
-                laskutus_nimitark = '$arow[laskutus_nimitark]',
-                laskutus_osoite   = '$arow[laskutus_osoite]',
-                laskutus_postitp  = '$arow[laskutus_postitp]',
-                laskutus_postino  = '$arow[laskutus_postino]',
-                laskutus_maa      = '$arow[laskutus_maa]',
+                laskutus_nimi       = '$arow[laskutus_nimi]',
+                laskutus_nimitark   = '$arow[laskutus_nimitark]',
+                laskutus_osoite     = '$arow[laskutus_osoite]',
+                laskutus_postitp    = '$arow[laskutus_postitp]',
+                laskutus_postino    = '$arow[laskutus_postino]',
+                laskutus_maa        = '$arow[laskutus_maa]',
                 noutopisteen_tunnus = '{$noutopisteen_tunnus}',
-                laatija           = '$edi_laatija',
-                luontiaika        = now(),
-                yhtio             = '$kukarow[yhtio]',
-                otunnus           = '$id'";
+                laatija             = '$edi_laatija',
+                luontiaika          = now(),
+                yhtio               = '$kukarow[yhtio]',
+                otunnus             = '$id'";
       $lisatiedot_result = pupe_query($query);
 
       if ($edi_tyyppi == 'futursoft' and $editilaus_tilaustyyppi == 3) {
@@ -2409,10 +2409,10 @@ while ($tietue = fgets($fd)) {
 
         if (!empty($ltoim_email)) {
           $saate_query = "SELECT tunnus
-                    FROM avainsana
-                    WHERE yhtio = '$kukarow[yhtio]'
-                    AND laji    = 'LASKUTUS_SAATE'
-                    AND selite  = 'Verkkokauppa'";
+                          FROM avainsana
+                          WHERE yhtio = '$kukarow[yhtio]'
+                          AND laji    = 'LASKUTUS_SAATE'
+                          AND selite  = 'Verkkokauppa'";
           $saate_res = pupe_query($saate_query);
 
           if ($saaterow = mysql_fetch_assoc($saate_res)) {

--- a/tilauskasittely/jtselaus.php
+++ b/tilauskasittely/jtselaus.php
@@ -1719,7 +1719,7 @@ if ($tee == "JATKA") {
 
                 $_nimitark = "";
                 if (!empty($jtrow["nimitark"])) {
-                 $_nimitark = "<br>".$jtrow["nimitark"];
+                  $_nimitark = "<br>".$jtrow["nimitark"];
                 }
 
                 if ($kukarow["extranet"] == "") {
@@ -1731,7 +1731,7 @@ if ($tee == "JATKA") {
 
                 $_toim_nimitark = "";
                 if (!empty($jtrow["toim_nimitark"])) {
-                 $_toim_nimitark = "<br>".$jtrow["toim_nimitark"];
+                  $_toim_nimitark = "<br>".$jtrow["toim_nimitark"];
                 }
 
                 echo "$jtrow[toim_nimi]$_toim_nimitark";

--- a/tilauskasittely/keikka.php
+++ b/tilauskasittely/keikka.php
@@ -74,7 +74,7 @@ if (!isset($toimipaikka))    $toimipaikka = $kukarow['toimipaikka'];
 
 $onkolaajattoimipaikat = ($yhtiorow['toimipaikkakasittely'] == "L" and $toimipaikat_res = hae_yhtion_toimipaikat($kukarow['yhtio']) and mysql_num_rows($toimipaikat_res) > 0) ? TRUE : FALSE;
 $onkologmaster = (!empty($ftp_logmaster_host) and !empty($ftp_logmaster_user) and !empty($ftp_logmaster_pass) and !empty($ftp_logmaster_path));
-$onkologmaster = ($onkologmaster and in_array($yhtiorow['ulkoinen_jarjestelma'], array('','S')));
+$onkologmaster = ($onkologmaster and in_array($yhtiorow['ulkoinen_jarjestelma'], array('', 'S')));
 
 if ($onkolaajattoimipaikat and isset($otunnus)) {
 

--- a/tilauskasittely/keraa.php
+++ b/tilauskasittely/keraa.php
@@ -2257,7 +2257,7 @@ if ($tee == 'P') {
               pupesoft_tulosta_lahete($params);
 
               if ($lahete_tulostus_paperille > 0) echo "<br>".t("Tulostettiin %s paperilähetettä", "", $lahete_tulostus_paperille).".";
-              #if ($lahete_tulostus_ruudulle > 0) echo "<br>".t("Tulostettiin %s lähetettä ruudulle", "", $lahete_tulostus_ruudulle).".";
+              //if ($lahete_tulostus_ruudulle > 0) echo "<br>".t("Tulostettiin %s lähetettä ruudulle", "", $lahete_tulostus_ruudulle).".";
               if ($lahete_tulostus_emailiin > 0) echo "<br>".t("Lähetettiin %s sähköistä lähetettä", "", $lahete_tulostus_emailiin).".";
               if ($lahete_tulostus_emailiin == 0 and $lahete_tulostus_paperille == 0 and $lahete_tulostus_ruudulle == 0) echo "<br>".t("Lähetteitä ei tulostettu").".";
             }

--- a/tilauskasittely/lahtojen_hallinta.php
+++ b/tilauskasittely/lahtojen_hallinta.php
@@ -3251,8 +3251,8 @@ function hae_suljetut_lahdot($toimitustavan_tunnukset, $ajax_request) {
             JOIN toimitustapa ON (toimitustapa.yhtio = lasku.yhtio
               AND toimitustapa.selite       = lasku.toimitustapa
               AND toimitustapa.tunnus       IN (".($ajax_request == 1 ?
-            $toimitustavan_tunnukset :
-            implode(',', $toimitustavan_tunnukset))."))
+    $toimitustavan_tunnukset :
+    implode(',', $toimitustavan_tunnukset))."))
             WHERE lahdot.yhtio              = '{$kukarow['yhtio']}'
             AND lahdot.aktiivi              = 'S'
             AND lahdot.pvm                  > date_sub(now(), INTERVAL 14 day)

--- a/tilauskasittely/lahtojen_hallinta.php
+++ b/tilauskasittely/lahtojen_hallinta.php
@@ -3251,8 +3251,8 @@ function hae_suljetut_lahdot($toimitustavan_tunnukset, $ajax_request) {
             JOIN toimitustapa ON (toimitustapa.yhtio = lasku.yhtio
               AND toimitustapa.selite       = lasku.toimitustapa
               AND toimitustapa.tunnus       IN (".($ajax_request == 1 ?
-    $toimitustavan_tunnukset :
-    implode(',', $toimitustavan_tunnukset))."))
+            $toimitustavan_tunnukset :
+            implode(',', $toimitustavan_tunnukset))."))
             WHERE lahdot.yhtio              = '{$kukarow['yhtio']}'
             AND lahdot.aktiivi              = 'S'
             AND lahdot.pvm                  > date_sub(now(), INTERVAL 14 day)

--- a/tilauskasittely/osoitelappu_hornbach_pdf.inc
+++ b/tilauskasittely/osoitelappu_hornbach_pdf.inc
@@ -238,7 +238,7 @@ else {
               aktiivinen_kuljetus toimittajanumero
               FROM toimitustapa
               WHERE yhtio = '$kukarow[yhtio]'
-              and selite = '$laskurow[toimitustapa]'";
+              and selite  = '$laskurow[toimitustapa]'";
     $toitares = pupe_query($query);
     $toitarow = mysql_fetch_assoc($toitares);
 

--- a/tilauskasittely/osoitelappu_intrade_pdf.inc
+++ b/tilauskasittely/osoitelappu_intrade_pdf.inc
@@ -313,7 +313,7 @@ else {
     $query = "SELECT *
               FROM toimitustapa
               WHERE yhtio = '$kukarow[yhtio]'
-              and selite = '$laskurow[toimitustapa]'";
+              and selite  = '$laskurow[toimitustapa]'";
     $toitares = pupe_query($query);
     $toitarow = mysql_fetch_assoc($toitares);
 

--- a/tilauskasittely/ostotilausrivien_hallinta.php
+++ b/tilauskasittely/ostotilausrivien_hallinta.php
@@ -165,11 +165,11 @@ if ($ytunnus != '') {
     if ($tee == "PAIVITARIVI") {
       foreach ($toimaikarivi as $tunnus => $toimaika) {
         if (strpos($toimaika, ".") !== false) {
-           $_aika = explode(".", $toimaika);
+          $_aika = explode(".", $toimaika);
 
-           if (count($_aika) == 3) {
-             $toimaika = "{$_aika["2"]}-{$_aika["1"]}-{$_aika["0"]}";
-           }
+          if (count($_aika) == 3) {
+            $toimaika = "{$_aika["2"]}-{$_aika["1"]}-{$_aika["0"]}";
+          }
         }
 
         $query = "UPDATE tilausrivi SET toimaika = '{$toimaika}' WHERE yhtio = '{$kukarow['yhtio']}' and tunnus = '{$tunnus}' and tyyppi = 'O'";

--- a/tilauskasittely/ostotilausten_rivien_kohdistus.inc
+++ b/tilauskasittely/ostotilausten_rivien_kohdistus.inc
@@ -1072,7 +1072,7 @@ if ($tila == 'tee_kohdistus') {
 
 $query = "SELECT DISTINCT varasto
           FROM tilausrivi
-          WHERE yhtio = '{$kukarow['yhtio']}'
+          WHERE yhtio     = '{$kukarow['yhtio']}'
           AND uusiotunnus = '{$otunnus}'";
 $varastocheckres = pupe_query($query);
 

--- a/tilauskasittely/ostotilausten_rivien_yhdistys.inc
+++ b/tilauskasittely/ostotilausten_rivien_yhdistys.inc
@@ -32,7 +32,7 @@ if ($tee == "teeyhdistys") {
 
           if (trim($suuntalava_row['suuntalavat']) != '') {
             foreach (explode(",", $suuntalava_row['suuntalavat']) as $_suuntalava) {
-              
+
               // Tsekataan ettei jo ole
               $query = "SELECT tunnus
                         FROM suuntalavat_saapuminen
@@ -40,7 +40,7 @@ if ($tee == "teeyhdistys") {
                         AND suuntalava = '{$_suuntalava}'
                         AND saapuminen = '{$otunnus}'";
               $check_res = pupe_query($query);
-              
+
               // Jos relaatiota ei ole niin luodaan se, muuten poistetaan
               // koska suuntalavat_saapuminen relaatiota ei saa olla kuin kerran
               // per saapuminen ja suuntalava

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -2467,7 +2467,7 @@ if ($tila == "" and !isset($jatka)) {
       $vasen++;
     }
 
-    if ($toim != "MYYNTITILI" AND $toim != "ENNAKKO") {
+    if ($toim != "MYYNTITILI" and $toim != "ENNAKKO") {
       $oikea_sarake[$oikea] = "<td>".t("Tilausta ei osatoimiteta").":</td><td><input type='checkbox' name='osatoimitus' $osath></td>";
       $oikea++;
     }
@@ -3023,9 +3023,9 @@ if ($tila == "" and !isset($jatka)) {
           // Tarkistetaan, onko valitulle työjonolle asetettu oletusvastuuhenkilö,
           // jos ei ole vielä valittu vastuuhenkilöä
           if (empty($srow[$kentta]) and isset($srow['tyojono'])) {
-             $oletus_result = t_avainsana("tyom_tyojono", "", "and avainsana.selite='{$srow['tyojono']}'");
-             $oletus_row = mysql_fetch_assoc($oletus_result);
-             $oletus_kuka = $oletus_row['selitetark_4'];
+            $oletus_result = t_avainsana("tyom_tyojono", "", "and avainsana.selite='{$srow['tyojono']}'");
+            $oletus_row = mysql_fetch_assoc($oletus_result);
+            $oletus_kuka = $oletus_row['selitetark_4'];
           }
 
           $query = "SELECT *

--- a/tilauskasittely/postiedi.inc
+++ b/tilauskasittely/postiedi.inc
@@ -11,7 +11,7 @@ if ($postiedihost != "" and $postiediuser != "" and $postiedipass != "" and $pos
   if (empty($postirow["ytunnus"])) {
     $postirow["ytunnus"] = '999999';
   }
-  
+
   // tehd‰‰n EDI-aineisto
   $ulos  = "";
   $ulos .= "ICHGSTART:$postirow[tunnus]\n";                    // tilauksen numero

--- a/tilauskasittely/rahtikirja_kirjetarra_pdf.inc
+++ b/tilauskasittely/rahtikirja_kirjetarra_pdf.inc
@@ -106,7 +106,7 @@ for ($tulostuskpl=1; $tulostuskpl<=$tulostakolli; $tulostuskpl++) {
   $pdf->draw_text(243, 370, $toitarow['sopimusnro'], $firstpage, $iso);
   $pdf->draw_text(241, 360, 'Posti Oy', $firstpage, $iso);
 
-  # Jaetaan kirje osiin vaakaviivoilla
+  // Jaetaan kirje osiin vaakaviivoilla
   $pdf->draw_rectangle(280, 8, 280, 290, $firstpage, $rectparam);
   $pdf->draw_rectangle(100, 8, 100, 290, $firstpage, $rectparam);
 

--- a/tilauskasittely/seb_factoring.php
+++ b/tilauskasittely/seb_factoring.php
@@ -7,7 +7,7 @@ echo "<font class='head'>".t("Lähetä factoringaineisto").":</font><hr>";
 // Otetaan ensimmäinen SEB -sopimus. Tämä softa ei tue useaa SEB-rahoitussopimusta.
 $query = "SELECT tunnus
           FROM factoring
-          WHERE yhtio = '$kukarow[yhtio]'
+          WHERE yhtio        = '$kukarow[yhtio]'
           and factoringyhtio = 'SEB'";
 $res = pupe_query($query);
 
@@ -23,8 +23,8 @@ else {
 $query = "SELECT lasku.*
           FROM lasku
           JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio
-            and lasku.maksuehto = maksuehto.tunnus
-            and maksuehto.factoring_id = '$factoring_id')
+            and lasku.maksuehto           = maksuehto.tunnus
+            and maksuehto.factoring_id    = '$factoring_id')
           WHERE lasku.yhtio               = '$kukarow[yhtio]'
           and lasku.tila                  = 'U'
           and lasku.alatila               = 'X'
@@ -60,9 +60,9 @@ while ($laskurow = mysql_fetch_array($res)) {
 
   $query = "SELECT *
             FROM factoring
-            WHERE yhtio        = '$kukarow[yhtio]'
-            and tunnus         = '$factoring_id'
-            and valkoodi       = '$laskurow[valkoodi]'";
+            WHERE yhtio  = '$kukarow[yhtio]'
+            and tunnus   = '$factoring_id'
+            and valkoodi = '$laskurow[valkoodi]'";
   $fres = pupe_query($query);
   $frow = mysql_fetch_array($fres);
 

--- a/tilauskasittely/selaa_tilauksia.php
+++ b/tilauskasittely/selaa_tilauksia.php
@@ -518,9 +518,9 @@ if (mysql_num_rows($result) > 0) {
     else {
       $i = 2;
     }
-    
+
     $summa = sprintf('%.02f', $summa);
-    
+
     if ($osuus_kululaskuista_yhteensa != "" or $osuus_eturahdista_yhteensa != "" or $osuus_pyoristyseroista_yhteensa != "" or $aputullimaara_yhteensa != "" or $rivinlisakulu_yhteensa != "" or $saapumisenkulut_yhteensa != "") {
       $i = 6;
       $summa = "";

--- a/tilauskasittely/syotarivi.inc
+++ b/tilauskasittely/syotarivi.inc
@@ -302,7 +302,7 @@ elseif (!$variaaritorivi and $kukarow["extranet"] == '' and ($toim == "RIVISYOTT
     echo "<th align='left'>", t("Omalle tilaukselle"), "</th>";
   }
 
-  if ($yhtiorow['tilausrivin_esisyotto'] == 'K' and $naytetaanko_kate and $rivitunnus == "" and in_array($toim, array('RIVISYOTTO','TARJOUS'))) {
+  if ($yhtiorow['tilausrivin_esisyotto'] == 'K' and $naytetaanko_kate and $rivitunnus == "" and in_array($toim, array('RIVISYOTTO', 'TARJOUS'))) {
     echo "<th align='left'>", t("Kate"), "</th>";
   }
 
@@ -451,7 +451,7 @@ elseif (!$variaaritorivi and $kukarow["extranet"] == '' and ($toim == "RIVISYOTT
     echo "</select></td>";
   }
 
-  if ($yhtiorow['tilausrivin_esisyotto'] == 'K' and $naytetaanko_kate and $rivitunnus == "" and in_array($toim, array('RIVISYOTTO','TARJOUS'))) {
+  if ($yhtiorow['tilausrivin_esisyotto'] == 'K' and $naytetaanko_kate and $rivitunnus == "" and in_array($toim, array('RIVISYOTTO', 'TARJOUS'))) {
     echo "<td><span id='kate_rivi_laskenta'></span></td>";
   }
 
@@ -501,7 +501,7 @@ elseif (!$variaaritorivi and $kukarow["extranet"] == '' and ($toim == "RIVISYOTT
     $nrospanni++;
   }
 
-  if ($yhtiorow['tilausrivin_esisyotto'] == 'K' and $naytetaanko_kate and $rivitunnus == "" and in_array($toim, array('RIVISYOTTO','TARJOUS'))) {
+  if ($yhtiorow['tilausrivin_esisyotto'] == 'K' and $naytetaanko_kate and $rivitunnus == "" and in_array($toim, array('RIVISYOTTO', 'TARJOUS'))) {
     $nrospanni++;
   }
 

--- a/tilauskasittely/tarkistarivi.inc
+++ b/tilauskasittely/tarkistarivi.inc
@@ -451,7 +451,7 @@ if (isset($myyntierahuom) and is_array($myyntierahuom) and in_array($row['tunnus
   $varaosavirhe .= $mimyhuom."<br>";
 }
 else {
-  if ($trow['myynti_era'] > 0 and $trow['myynti_era'] != 1 and $trow['myynti_era'] != $kpl_st and !in_array($yhtiorow['myyntiera_pyoristys'], array('K','S'))) {
+  if ($trow['myynti_era'] > 0 and $trow['myynti_era'] != 1 and $trow['myynti_era'] != $kpl_st and !in_array($yhtiorow['myyntiera_pyoristys'], array('K', 'S'))) {
     $mimyhuom = t("HUOM: Tuotteella on myyntierä"). " " . $trow['myynti_era'];
     $varaosakommentti .= $mimyhuom."<br>";
   }

--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -542,8 +542,8 @@ if (!function_exists("tee_jt_tilaus")) {
             // Tätä ei tehdä jos tilauksen maksuehto on "jaksotettu"
             $maksuehto_query = "SELECT tunnus
                                 FROM maksuehto
-                                where yhtio = '$kukarow[yhtio]'
-                                and tunnus  = '$otsikkorivi[maksuehto]'
+                                where yhtio     = '$kukarow[yhtio]'
+                                and tunnus      = '$otsikkorivi[maksuehto]'
                                 and jaksotettu != ''";
             $maksuehto_result = pupe_query($maksuehto_query);
 

--- a/tilauskasittely/tee_jt_tilaus.inc
+++ b/tilauskasittely/tee_jt_tilaus.inc
@@ -558,7 +558,7 @@ if (!function_exists("tee_jt_tilaus")) {
               $maksuehtorow = mysql_fetch_assoc($maksuehto_result);
 
               if ($maksuehtorow['jv'] != '') {
-                 $_maksuehto = $maksuehtorow["tunnus"];
+                $_maksuehto = $maksuehtorow["tunnus"];
               }
             }
 

--- a/tilauskasittely/teeulasku.inc
+++ b/tilauskasittely/teeulasku.inc
@@ -195,9 +195,9 @@ $lisa_viestit  = "";
 if (isset($mehtorow["factoring_id"])) {
   $query = "SELECT *
             FROM factoring
-            WHERE yhtio        = '$kukarow[yhtio]'
-            and tunnus         = '$mehtorow[factoring_id]'
-            and valkoodi       = '$lasrow[valkoodi]'";
+            WHERE yhtio  = '$kukarow[yhtio]'
+            and tunnus   = '$mehtorow[factoring_id]'
+            and valkoodi = '$lasrow[valkoodi]'";
   $fres = pupe_query($query);
 
   if (mysql_num_rows($fres) > 0) {

--- a/tilauskasittely/tilauksesta_myyntitilaus.inc
+++ b/tilauskasittely/tilauksesta_myyntitilaus.inc
@@ -619,7 +619,7 @@ if (!function_exists("tilauksesta_myyntitilaus")) {
       // Otetaan laskun alkuperäinen valuutta kuitenkin talteen ja plautetaan se lisaarivi.inc jälkeen.
       $valkoodi_lasku = $laskurow["valkoodi"];
       if (trim(strtoupper($laskurow["valkoodi"])) != trim(strtoupper($yhtiorow["valkoodi"]))) {
-       $laskurow["valkoodi"] = $yhtiorow["valkoodi"];
+        $laskurow["valkoodi"] = $yhtiorow["valkoodi"];
       }
 
       require 'lisaarivi.inc';

--- a/tilauskasittely/tilaus-valmis-siirtolista.inc
+++ b/tilauskasittely/tilaus-valmis-siirtolista.inc
@@ -599,7 +599,7 @@ else {
           $ulkoinen_jarjestelma_res = pupe_query($query);
           $varaston_row = mysql_fetch_assoc($ulkoinen_jarjestelma_res);
 
-          if ($laskurow['tila'] == 'G' and in_array($laskurow['alatila'], array('','J')) and in_array($varaston_row['ulkoinen_jarjestelma'], array('L','P')) and in_array($yhtiorow['ulkoinen_jarjestelma'], array('','K'))) {
+          if ($laskurow['tila'] == 'G' and in_array($laskurow['alatila'], array('', 'J')) and in_array($varaston_row['ulkoinen_jarjestelma'], array('L', 'P')) and in_array($yhtiorow['ulkoinen_jarjestelma'], array('', 'K'))) {
             posten_outbounddelivery($laskurow['tunnus'], $varaston_row['ulkoinen_jarjestelma']);
           }
         }

--- a/tilauskasittely/tilaus-valmis.inc
+++ b/tilauskasittely/tilaus-valmis.inc
@@ -2078,7 +2078,7 @@ else {
       }
 
       foreach ($varasto_chk_array as $_otunnus => $_ulkoinen_jarjestelma) {
-        if (in_array($yhtiorow['ulkoinen_jarjestelma'], array('','K')) and $laskurow['tila'] == 'N' and ($laskurow['alatila'] == '' or ($laskurow['alatila'] == 'A' and isset($tilausvalmiskutsuja) and $tilausvalmiskutsuja == "EDITILAUS")) and in_array($_ulkoinen_jarjestelma, array('L','P'))) {
+        if (in_array($yhtiorow['ulkoinen_jarjestelma'], array('', 'K')) and $laskurow['tila'] == 'N' and ($laskurow['alatila'] == '' or ($laskurow['alatila'] == 'A' and isset($tilausvalmiskutsuja) and $tilausvalmiskutsuja == "EDITILAUS")) and in_array($_ulkoinen_jarjestelma, array('L', 'P'))) {
           posten_outbounddelivery($_otunnus, $_ulkoinen_jarjestelma);
         }
       }

--- a/tilauskasittely/tilaus-valmis.inc
+++ b/tilauskasittely/tilaus-valmis.inc
@@ -2240,11 +2240,11 @@ else {
 
               $tulossa_query = "SELECT sum(varattu) tulossa_kpl
                                 FROM tilausrivi use index (yhtio_tyyppi_tuoteno_laskutettuaika)
-                                WHERE yhtio  = '{$kukarow['yhtio']}'
-                                AND tuoteno  = '{$jt_chk_row['tuoteno']}'
-                                AND tyyppi   = 'O'
+                                WHERE yhtio        = '{$kukarow['yhtio']}'
+                                AND tuoteno        = '{$jt_chk_row['tuoteno']}'
+                                AND tyyppi         = 'O'
                                 AND laskutettuaika = '0000-00-00'
-                                AND varasto = '{$jt_chk_row['varasto']}'";
+                                AND varasto        = '{$jt_chk_row['varasto']}'";
               $tulossa_result = pupe_query($tulossa_query);
               $tulossa_row = mysql_fetch_assoc($tulossa_result);
 

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -82,11 +82,11 @@ if ($yhtiorow['tilausrivin_esisyotto'] == 'K' and isset($ajax_toiminto) and trim
   }
 
   echo json_encode(array(
-    'hinta' => round($hinta, $yhtiorow['hintapyoristys']),
-    'netto' => $netto,
-    'ale' => $ale,
-    'kate' => $kate
-  ));
+      'hinta' => round($hinta, $yhtiorow['hintapyoristys']),
+      'netto' => $netto,
+      'ale' => $ale,
+      'kate' => $kate
+    ));
 
   exit;
 }
@@ -131,11 +131,11 @@ if ($yhtiorow['tilausrivin_esisyotto'] == 'K' and isset($ajax_toiminto) and trim
   }
 
   echo json_encode(array(
-    'hinta' => round($hinta, $yhtiorow['hintapyoristys']),
-    'netto' => $netto,
-    'ale' => $ale,
-    'kate' => $kate
-  ));
+      'hinta' => round($hinta, $yhtiorow['hintapyoristys']),
+      'netto' => $netto,
+      'ale' => $ale,
+      'kate' => $kate
+    ));
 
   exit;
 }
@@ -3515,7 +3515,7 @@ if ($tee == '') {
         echo "<input type='submit' name='liitaasiakasnappi' value='".t("Liitä asiakas")."'>";
       }
       else {
-        echo "<a href='{$palvelin2}raportit/asiakkaantilaukset.php?toim=MYYNTI&ytunnus={$laskurow['ytunnus']}&asiakasid={$laskurow['liitostunnus']}&lopetus={$tilmyy_lopetus}'>",tarkistahetu($laskurow['ytunnus']),"</a>";
+        echo "<a href='{$palvelin2}raportit/asiakkaantilaukset.php?toim=MYYNTI&ytunnus={$laskurow['ytunnus']}&asiakasid={$laskurow['liitostunnus']}&lopetus={$tilmyy_lopetus}'>", tarkistahetu($laskurow['ytunnus']), "</a>";
 
         if ($faktarow["asiakasnro"] != "") {
           echo " / $faktarow[asiakasnro]";
@@ -7839,14 +7839,14 @@ if ($tee == '') {
                   <a href='{$palvelin2}$tuotekyslinkki?".$tuotekyslinkkilisa."tee=Z&tuoteno=".urlencode($row["tuoteno"])."&toim_kutsu=$toim&lopetus=$tilmyy_lopetus//from=LASKUTATILAUS'
                      class='tooltip'
                      data-content-url='?toim={$toim}" .
-                       "&ajax_popup=true" .
-                       "&tuoteno={$row["tuoteno"]}" .
-                       "&yksikko={$row["yksikko"]}" .
-                       "&paikka={$row["paikka"]}" .
-                       "&keskihinta={$row["kehahin"]}" .
-                       "&valuutta={$row["valuutta"]}" .
-                       "&varasto={$laskurow["varasto"]}" .
-                       "&vanhatunnus={$laskurow["vanhatunnus"]}'>$row[tuoteno]</a>";
+            "&ajax_popup=true" .
+            "&tuoteno={$row["tuoteno"]}" .
+            "&yksikko={$row["yksikko"]}" .
+            "&paikka={$row["paikka"]}" .
+            "&keskihinta={$row["kehahin"]}" .
+            "&valuutta={$row["valuutta"]}" .
+            "&varasto={$laskurow["varasto"]}" .
+            "&vanhatunnus={$laskurow["vanhatunnus"]}'>$row[tuoteno]</a>";
         }
         else {
           echo "<td $class>$row[tuoteno]";

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -793,7 +793,7 @@ if ((int) $valitsetoimitus_vaihdarivi > 0 and $tilausnumero == $kukarow["kesken"
                      toimaika
                      FROM lasku
                      WHERE yhtio = '$kukarow[yhtio]'
-                     AND tunnus = $valitsetoimitus_vaihdarivi";
+                     AND tunnus  = $valitsetoimitus_vaihdarivi";
       $ajat = mysql_fetch_assoc(pupe_query($ajat_query));
 
       $aikalisa = ", kerayspvm = '{$ajat["kerayspvm"]}', toimaika = '{$ajat["toimaika"]}'";
@@ -803,7 +803,7 @@ if ((int) $valitsetoimitus_vaihdarivi > 0 and $tilausnumero == $kukarow["kesken"
       // Vaihdetaan rivin otunnus
       $query = "UPDATE tilausrivi
                 SET
-                otunnus = '$valitsetoimitus_vaihdarivi'
+                otunnus            = '$valitsetoimitus_vaihdarivi'
                 $aikalisa
                 WHERE yhtio        = '$kukarow[yhtio]'
                 and otunnus        = '$edtilausnumero'

--- a/tilauskasittely/tilaus_osto.php
+++ b/tilauskasittely/tilaus_osto.php
@@ -423,11 +423,11 @@ if ($tee != "" and $tee != "MUUOTAOSTIKKOA") {
 
       $query = "SELECT *
                 FROM tilausrivi
-                WHERE yhtio = '{$kukarow['yhtio']}'
-                AND otunnus = '{$laskurow['tunnus']}'
-                AND tyyppi = 'O'
+                WHERE yhtio   = '{$kukarow['yhtio']}'
+                AND otunnus   = '{$laskurow['tunnus']}'
+                AND tyyppi    = 'O'
                 AND hyllyalue = ''
-                AND hyllynro = ''
+                AND hyllynro  = ''
                 AND hyllyvali = ''
                 AND hyllytaso = ''";
       $result = pupe_query($query);

--- a/tilauskasittely/toimitusvahvistus_email.inc
+++ b/tilauskasittely/toimitusvahvistus_email.inc
@@ -4,7 +4,7 @@ if ($kieli == '') {
   $querykiel = "SELECT kieli
                 FROM asiakas
                 WHERE yhtio = '$kukarow[yhtio]'
-                and tunnus = '$laskurow[liitostunnus]'";
+                and tunnus  = '$laskurow[liitostunnus]'";
   $kielresult = pupe_query($querykiel);
   $kielrow = mysql_fetch_assoc($kielresult);
 
@@ -38,10 +38,10 @@ if ($toimitusvahvistus_email_lahetys) {
     $myyjaquery = "SELECT DISTINCT(kuka.eposti) myyjan_email
                    FROM lasku
                    JOIN kuka ON (lasku.yhtio = kuka.yhtio AND lasku.myyja = kuka.tunnus)
-                   WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-                   AND lasku.tunnus IN ({$otunnukset})
-                   AND lasku.myyja != ''
-                   AND kuka.eposti != ''
+                   WHERE lasku.yhtio  = '{$kukarow['yhtio']}'
+                   AND lasku.tunnus   IN ({$otunnukset})
+                   AND lasku.myyja   != ''
+                   AND kuka.eposti   != ''
                    LIMIT 1";
     $myyjaresult = pupe_query($myyjaquery);
     $myyjarow = mysql_fetch_assoc($myyjaresult);

--- a/tilauskasittely/toimitusvahvistus_email.inc
+++ b/tilauskasittely/toimitusvahvistus_email.inc
@@ -125,6 +125,6 @@ if ($toimitusvahvistus_email_lahetys) {
 
     if (pupesoft_sahkoposti($parametri)) {
       echo t("Sähköpostin lähetys onnistui").": {$email_kuka}<br />";
-    }    
+    }
   }
 }

--- a/tilauskasittely/tulosta_lahete.inc
+++ b/tilauskasittely/tulosta_lahete.inc
@@ -7,7 +7,7 @@ if ($kieli == '') {
   $querykiel = "SELECT kieli
                 FROM asiakas
                 WHERE yhtio = '$kukarow[yhtio]'
-                and tunnus = '$laskurow[liitostunnus]'";
+                and tunnus  = '$laskurow[liitostunnus]'";
   $kielresult = pupe_query($querykiel);
   $kielrow = mysql_fetch_assoc($kielresult);
 

--- a/tilauskasittely/tulosta_lahete.inc
+++ b/tilauskasittely/tulosta_lahete.inc
@@ -4405,4 +4405,3 @@ if (!function_exists('skippa_lahete_pdf')) {
     }
   }
 }
-

--- a/tilauskasittely/tulosta_lasku.inc
+++ b/tilauskasittely/tulosta_lasku.inc
@@ -119,10 +119,10 @@ if (!function_exists('alku')) {
               laskutus_postitp,
               laskutus_maa
               FROM laskun_lisatiedot
-              WHERE yhtio = '{$kukarow['yhtio']}'
+              WHERE yhtio        = '{$kukarow['yhtio']}'
               AND laskutus_nimi != ''
               AND CONCAT(laskutus_nimi, laskutus_osoite, laskutus_postino, laskutus_postitp, laskutus_maa) != '$laskurow[nimi]$laskurow[osoite]$laskurow[postino]$laskurow[postitp]$laskurow[maa]'
-              AND otunnus = '{$laskurow['tunnus']}'";
+              AND otunnus        = '{$laskurow['tunnus']}'";
     $laskutusosoite_result = pupe_query($query);
 
     $osoitekenttia = 2;
@@ -411,8 +411,8 @@ if (!function_exists('alku')) {
 
     //etsit‰‰n myyj‰n nimi
     $query = "SELECT nimi
-               from kuka
-               where tunnus='$laskurow[myyja]' and yhtio='$kukarow[yhtio]'";
+              from kuka
+              where tunnus='$laskurow[myyja]' and yhtio='$kukarow[yhtio]'";
     $myyresult = pupe_query($query);
     $myyrow = mysql_fetch_assoc($myyresult);
 
@@ -574,7 +574,7 @@ if (!function_exists('laskun_kommentit')) {
     $query = "SELECT tyomaarays.*
               FROM lasku
               JOIN tyomaarays ON lasku.yhtio=tyomaarays.yhtio and lasku.tunnus=tyomaarays.otunnus
-              WHERE lasku.yhtio = '$kukarow[yhtio]'
+              WHERE lasku.yhtio      = '$kukarow[yhtio]'
               and lasku.tilaustyyppi = 'A'
               and $where";
     $tyomres = pupe_query($query);
@@ -603,7 +603,7 @@ if (!function_exists('laskun_kommentit')) {
                 $query = "SELECT nimi
                           FROM kuka
                           WHERE yhtio = '$kukarow[yhtio]'
-                          and kuka = '".$tyomrow[$kentta]."'";
+                          and kuka    = '".$tyomrow[$kentta]."'";
                 $yresult = pupe_query($query);
                 $tmrow = mysql_fetch_assoc($yresult);
 
@@ -630,11 +630,11 @@ if (!function_exists('laskun_kommentit')) {
 
     if (in_array($laskutyyppi, array(1,4,8,21,22))) {
       $query = "SELECT ifnull(group_concat(distinct tunnus SEPARATOR ', '), 0) tilnot
-                    FROM lasku
-                    WHERE yhtio = '$kukarow[yhtio]'
-                    and laskunro = '$laskurow[laskunro]'
-                    and tila = 'L'
-                    and laskunro != 0";
+                FROM lasku
+                WHERE yhtio   = '$kukarow[yhtio]'
+                and laskunro  = '$laskurow[laskunro]'
+                and tila      = 'L'
+                and laskunro != 0";
       $result = pupe_query($query);
       $apulaskuro = mysql_fetch_assoc($result);
 
@@ -901,8 +901,8 @@ if (!function_exists('rivi_lasku')) {
 
       $query = "SELECT DISTINCT sarjanumero, parasta_ennen
                 FROM sarjanumeroseuranta
-                WHERE yhtio = '$kukarow[yhtio]'
-                and tuoteno = '$row[tuoteno]'
+                WHERE yhtio      = '$kukarow[yhtio]'
+                and tuoteno      = '$row[tuoteno]'
                 and $sarjanutunnus  in ($row[rivitunnukset])
                 and sarjanumero != ''
                 ORDER BY sarjanumero";
@@ -1151,7 +1151,7 @@ if (!function_exists('lisaa_tullinimike_ja_alkuperamaa')) {
       // Tsekataan onko t‰m‰ valmiste
       $query = "SELECT tunnus
                 FROM tuoteperhe
-                WHERE yhtio = '{$kukarow['yhtio']}'
+                WHERE yhtio    = '{$kukarow['yhtio']}'
                 AND isatuoteno = '{$row['tuoteno']}'
                 LIMIT 1";
       $alkuperamaa_res = pupe_query($query);
@@ -1898,7 +1898,7 @@ if (!function_exists('rivi_perhe')) {
                   sum((tilausrivi.hinta / {$laskurow["vienti_kurssi"]}) / if ('$yhtiorow[alv_kasittely]'  = '' AND tilausrivi.alv < 500, (1 + tilausrivi.alv / 100), 1) * (tilausrivi.varattu + tilausrivi.kpl) * {$query_ale_lisa}) rivihinta_valuutassa,
                   sum((tilausrivi.hinta / {$laskurow["vienti_kurssi"]}) * if ('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1 + tilausrivi.alv / 100), 1) * (tilausrivi.varattu + tilausrivi.kpl) * {$query_ale_lisa}) rivihinta_valuutassa_verollinen
                   FROM tilausrivi
-                  WHERE tilausrivi.yhtio = '$kukarow[yhtio]'
+                  WHERE tilausrivi.yhtio     = '$kukarow[yhtio]'
                   AND tilausrivi.uusiotunnus = '$row[uusiotunnus]'
                   AND tilausrivi.perheid     IN ($row[perheideet])
                   AND tilausrivi.perheid     > 0";
@@ -2008,7 +2008,7 @@ if (!function_exists('loppu')) {
                               asema
                               FROM kuka
                               WHERE yhtio = '{$kukarow['yhtio']}'
-                              AND tunnus = '{$laskurow['allekirjoittaja']}'";
+                              AND tunnus  = '{$laskurow['allekirjoittaja']}'";
       $allekirjoitus_result = pupe_query($allekirjoitus_query);
       $allekirjoitus_row = mysql_fetch_assoc($allekirjoitus_result);
 
@@ -2109,8 +2109,8 @@ if (!function_exists('loppu')) {
       if (isset($masrow["factoring_id"])) {
         $query = "SELECT *
                   FROM factoring
-                  WHERE yhtio = '$kukarow[yhtio]'
-                  and tunnus = '$masrow[factoring_id]'
+                  WHERE yhtio  = '$kukarow[yhtio]'
+                  and tunnus   = '$masrow[factoring_id]'
                   and valkoodi = '$laskurow[valkoodi]'";
         $fres = pupe_query($query);
         $frow = mysql_fetch_assoc($fres);
@@ -2240,7 +2240,7 @@ if (!function_exists('loppu')) {
       $query = "SELECT vat_numero
                 FROM yhtion_toimipaikat
                 WHERE yhtio = '{$kukarow["yhtio"]}'
-                AND tunnus = '{$laskurow["yhtio_toimipaikka"]}'";
+                AND tunnus  = '{$laskurow["yhtio_toimipaikka"]}'";
 
       $toimipaikka_result = pupe_query($query);
 
@@ -2641,7 +2641,7 @@ if (!function_exists('alvierittely')) {
       $query = "SELECT kassa, pankkikortti, luottokortti
                 FROM kassalipas
                 WHERE yhtio = '{$kukarow['yhtio']}'
-                AND tunnus = '{$laskurow['kassalipas']}'";
+                AND tunnus  = '{$laskurow['kassalipas']}'";
       $keijo = pupe_query($query);
       $ressukka = mysql_fetch_assoc($keijo);
 
@@ -2654,10 +2654,10 @@ if (!function_exists('alvierittely')) {
       if ($tilinolisa != "") {
         $query = "SELECT *
                   FROM tiliointi USE INDEX (tositerivit_index)
-                  WHERE yhtio = '$kukarow[yhtio]'
-                  AND ltunnus = '$laskurow[tunnus]'
+                  WHERE yhtio   = '$kukarow[yhtio]'
+                  AND ltunnus   = '$laskurow[tunnus]'
                   AND tilino    in ({$tilinolisa})
-                  AND korjattu = ''
+                  AND korjattu  = ''
                   AND tilino   != ''";
         $lasktilitre = pupe_query($query);
 
@@ -2754,9 +2754,9 @@ if (!function_exists('alvierittely')) {
       // Jos maksup‰‰te on enabloitu, tarvitaan myˆs maksup‰‰tetapahtumien kuitit
       $query = "SELECT ifnull(group_concat(distinct tunnus SEPARATOR ', '), 0) tilnot
                 FROM lasku
-                WHERE yhtio = '$kukarow[yhtio]'
-                and laskunro = '$laskurow[laskunro]'
-                and tila = 'L'
+                WHERE yhtio   = '$kukarow[yhtio]'
+                and laskunro  = '$laskurow[laskunro]'
+                and tila      = 'L'
                 and laskunro != 0";
       $result = pupe_query($query);
       $tilnorivi = mysql_fetch_assoc($result);
@@ -2885,16 +2885,16 @@ if (!function_exists("tulosta_lasku")) {
 
       $query = "SELECT *
                 FROM lasku
-                WHERE yhtio = '$kukarow[yhtio]'
-                and tila = 'U'
-                and alatila = 'X'
+                WHERE yhtio  = '$kukarow[yhtio]'
+                and tila     = 'U'
+                and alatila  = 'X'
                 and laskunro = '$lasku'";
     }
     else {
       $query = "SELECT *
                 FROM lasku
                 WHERE yhtio = '$kukarow[yhtio]'
-                and tunnus = '$lasku'";
+                and tunnus  = '$lasku'";
     }
 
     $laresult = pupe_query($query);
@@ -2914,7 +2914,7 @@ if (!function_exists("tulosta_lasku")) {
       $asiakas_apu_query = "SELECT *
                             FROM asiakas
                             WHERE yhtio = '$kukarow[yhtio]'
-                            and tunnus = '{$laskurow["liitostunnus"]}'";
+                            and tunnus  = '{$laskurow["liitostunnus"]}'";
     }
     else {
       $asiakas_apu_query = "SELECT max(asiakas.kieli) kieli,
@@ -2926,11 +2926,11 @@ if (!function_exists("tulosta_lasku")) {
                             FROM lasku
                             JOIN asiakas ON (asiakas.yhtio = lasku.yhtio
                             AND asiakas.tunnus = lasku.liitostunnus)
-                            WHERE lasku.yhtio = '{$kukarow['yhtio']}'
-                            AND lasku.tila = 'L'
-                            AND lasku.alatila = 'X'
+                            WHERE lasku.yhtio  = '{$kukarow['yhtio']}'
+                            AND lasku.tila     = 'L'
+                            AND lasku.alatila  = 'X'
                             AND lasku.laskunro = '{$laskurow['laskunro']}'
-                            AND lasku.tapvm = '{$laskurow["tapvm"]}'";
+                            AND lasku.tapvm    = '{$laskurow["tapvm"]}'";
     }
 
     $asiakas_apu_res = pupe_query($asiakas_apu_query);
@@ -2955,10 +2955,10 @@ if (!function_exists("tulosta_lasku")) {
 
     // haetaan maksuehdon tiedot
     $query = "SELECT pankkiyhteystiedot.*, maksuehto.*
-               FROM maksuehto
-               LEFT JOIN pankkiyhteystiedot on (pankkiyhteystiedot.yhtio = maksuehto.yhtio and pankkiyhteystiedot.tunnus = maksuehto.pankkiyhteystiedot)
-               WHERE maksuehto.yhtio = '$kukarow[yhtio]'
-               and maksuehto.tunnus = '{$laskurow["maksuehto"]}'";
+              FROM maksuehto
+              LEFT JOIN pankkiyhteystiedot on (pankkiyhteystiedot.yhtio = maksuehto.yhtio and pankkiyhteystiedot.tunnus = maksuehto.pankkiyhteystiedot)
+              WHERE maksuehto.yhtio = '$kukarow[yhtio]'
+              and maksuehto.tunnus  = '{$laskurow["maksuehto"]}'";
     $result = pupe_query($query);
     $masrow = mysql_fetch_assoc($result);
 
@@ -3145,9 +3145,9 @@ if (!function_exists("tulosta_lasku")) {
                   ((tuoteperhe.hintakerroin / {$laskurow["vienti_kurssi"]}) * if ('$yhtiorow[alv_kasittely]' != '' and {$row['alv']} < 500, (1+{$row['alv']}/100), 1) * tuoteperhe.kerroin * {$row['kpl']} * (1-{$row['aleyhteensa']}/100)) rivihinta_valuutassa_verollinen
                   FROM tuoteperhe
                   JOIN tuote ON (tuoteperhe.yhtio=tuote.yhtio and tuoteperhe.tuoteno=tuote.tuoteno)
-                  WHERE tuoteperhe.yhtio = '$kukarow[yhtio]'
+                  WHERE tuoteperhe.yhtio    = '$kukarow[yhtio]'
                   AND tuoteperhe.isatuoteno = '$row[tuoteno]'
-                  AND tuoteperhe.tyyppi = 'O'
+                  AND tuoteperhe.tyyppi     = 'O'
                   ORDER BY tuote.tuoteno";
         $tuoteperhe_result = pupe_query($query);
 
@@ -3374,7 +3374,7 @@ if (!function_exists("tulosta_lasku")) {
           $query = "SELECT *
                     FROM varastopaikat
                     WHERE yhtio = '$kukarow[yhtio]'
-                    AND tunnus = '$varasto'
+                    AND tunnus  = '$varasto'
                     ORDER BY alkuhyllyalue,alkuhyllynro";
         }
         else {
@@ -3400,7 +3400,7 @@ if (!function_exists("tulosta_lasku")) {
         $querykieli = "SELECT *
                        from kirjoittimet
                        where yhtio = '$kukarow[yhtio]'
-                       and tunnus = '$valittu_tulostin'";
+                       and tunnus  = '$valittu_tulostin'";
         $kires = pupe_query($querykieli);
         $kirow = mysql_fetch_assoc($kires);
 
@@ -3446,7 +3446,7 @@ if (!function_exists("tulosta_lasku")) {
           $querykieli = "SELECT *
                          from kirjoittimet
                          where yhtio = '$kukarow[yhtio]'
-                         and tunnus = '$valittu_kopio_tulostin'";
+                         and tunnus  = '$valittu_kopio_tulostin'";
           $kires = pupe_query($querykieli);
           $kirow = mysql_fetch_assoc($kires);
         }

--- a/tilauskasittely/tulosta_lasku.inc
+++ b/tilauskasittely/tulosta_lasku.inc
@@ -150,7 +150,7 @@ if (!function_exists('alku')) {
     }
     else {
 
-      if (in_array($laskutyyppi, array('21','22'))) {
+      if (in_array($laskutyyppi, array('21', '22'))) {
         $ostaja_kala = 768;
         $toim_kala = 710;
         $pohja = 577;
@@ -182,7 +182,7 @@ if (!function_exists('alku')) {
 
     //$pdf_lasku->draw_rectangle(674, 20,  611, 300, $page_lasku[$sivu], $rectparam);
 
-    if (in_array($laskutyyppi, array('21','22'))) {
+    if (in_array($laskutyyppi, array('21', '22'))) {
       $txt = t("Toimitusosoite", $kieli).":";
       $length = $pdf_lasku->strlen($txt, $pieni);
 
@@ -435,7 +435,7 @@ if (!function_exists('alku')) {
       $rivi_ind++;
     }
 
-    if (!in_array($laskutyyppi, array('6','8'))) {
+    if (!in_array($laskutyyppi, array('6', '8'))) {
       $pdf_lasku->draw_text(430, $otsik[$rivi_ind], t("Toimituspvm", $kieli), $page_lasku[$sivu], $pieni);
 
       //  Onko meillä monta toimituspäivää vai ei?
@@ -628,7 +628,7 @@ if (!function_exists('laskun_kommentit')) {
       $komm .= "\n";
     }
 
-    if (in_array($laskutyyppi, array(1,4,8,21,22))) {
+    if (in_array($laskutyyppi, array(1, 4, 8, 21, 22))) {
       $query = "SELECT ifnull(group_concat(distinct tunnus SEPARATOR ', '), 0) tilnot
                 FROM lasku
                 WHERE yhtio   = '$kukarow[yhtio]'
@@ -837,7 +837,7 @@ if (!function_exists('rivi_lasku')) {
       and $row['tuoteno'] != $yhtiorow["laskutuslisa_tuotenumero"]
       and trim($row['laskuviesti']) != ''
       and strpos($row["kommentti"], "$row[laskuviesti]") === FALSE
-      and !in_array($laskutyyppi, array(6,21,22))
+      and !in_array($laskutyyppi, array(6, 21, 22))
     ) {
       $row["kommentti"] = trim($row["laskuviesti"])."\n".$row["kommentti"];
     }
@@ -1075,7 +1075,7 @@ if (!function_exists('rivi_otsikot')) {
         $pdf_lasku->draw_text(450, $kala, t("Alennus", $kieli)."-%", $thispage, $pieni);
       }
 
-      if (in_array($laskutyyppi, array('21','22'))) {
+      if (in_array($laskutyyppi, array('21', '22'))) {
         list($ff_string, $ff_font) = pdf_fontfit(t("Yhteensä", $kieli).":", 50, $pdf_lasku, $pieni);
 
         $oikpos = $pdf_lasku->strlen($ff_string, $ff_font);
@@ -1094,11 +1094,11 @@ if (!function_exists('rivi_otsikot')) {
         $pdf_lasku->draw_text(35, $kala-9, t("Tilausnumero", $kieli)."/".t("Lisätietoja", $kieli), $thispage, $pieni);
       }
 
-      if (!in_array($laskutyyppi, array('21','22'))) {
+      if (!in_array($laskutyyppi, array('21', '22'))) {
         $pdf_lasku->draw_text(340, $kala-9, t("Yksikkö", $kieli), $thispage, $pieni);
       }
 
-      if (!in_array($laskutyyppi, array('6','21','22'))) {
+      if (!in_array($laskutyyppi, array('6', '21', '22'))) {
         $pdf_lasku->draw_text(390, $kala-9, t("Toimituspvm", $kieli), $thispage, $pieni);
       }
 
@@ -1263,7 +1263,7 @@ if (!function_exists('rivi_original')) {
       //Alennus
       $alennukset_yhteensa = generoi_alekentta_php($row, 'M', 'plain');
 
-      if ($alennukset_yhteensa != 0 and !in_array($laskutyyppi, array(21,22))) {
+      if ($alennukset_yhteensa != 0 and !in_array($laskutyyppi, array(21, 22))) {
         $pdf_lasku->draw_text(450, $kala, $alennukset_yhteensa, $thispage, $norm);
       }
 
@@ -1278,7 +1278,7 @@ if (!function_exists('rivi_original')) {
         $pdf_lasku->draw_text(535-$oikpos, $kala, hintapyoristys($row["rivihinta"], 0, $laskurow['_loppunollat']), $thispage, $norm);
       }
 
-      if (!in_array($laskutyyppi, array(21,22))) {
+      if (!in_array($laskutyyppi, array(21, 22))) {
         //Arvonlisävero
         if ($row["alv"] >= 600) {
           $pdf_lasku->draw_text(550, $kala, t("K.V.", $kieli), $thispage, $norm);
@@ -1304,7 +1304,7 @@ if (!function_exists('rivi_original')) {
     // Ensimmäinen rivi piirretty
     $kala = $kala - 10;
 
-    if (!in_array($laskutyyppi, array('21','22'))) {
+    if (!in_array($laskutyyppi, array('21', '22'))) {
       //Yksikkö
       $_yks = t_avainsana("Y", $kieli, "and avainsana.selite='$row[yksikko]'", "", "", "selitetark");
 
@@ -1313,15 +1313,15 @@ if (!function_exists('rivi_original')) {
     }
 
     //Toimitusaika
-    if (substr($row["toimitettuaika"], 0, 10) != "0000-00-00" and !in_array($laskutyyppi, array(6,21,22))) {
+    if (substr($row["toimitettuaika"], 0, 10) != "0000-00-00" and !in_array($laskutyyppi, array(6, 21, 22))) {
       $oikpos = $pdf_lasku->strlen(tv1dateconv(substr($row["toimitettuaika"], 0, 10)), $pieni);
       $pdf_lasku->draw_text(435-$oikpos, $kala, tv1dateconv(substr($row["toimitettuaika"], 0, 10)), $thispage, $pieni);
     }
 
     // Näytetäänkö verollinen rivihinta
-    $_pii_verolli = (!in_array($laskutyyppi, array(5,19,21,22)));
+    $_pii_verolli = (!in_array($laskutyyppi, array(5, 19, 21, 22)));
 
-    if (in_array($laskutyyppi, array(21,22))) {
+    if (in_array($laskutyyppi, array(21, 22))) {
       $_pii_verolli = (empty($laskurow['vienti']));
     }
 
@@ -1329,7 +1329,7 @@ if (!function_exists('rivi_original')) {
       $_pii_verolli = (empty($row['perheid']) or $row['tunnus'] == $row['perheid']);
     }
 
-    $_pii_verolli = ($_pii_verolli AND $row["alv"] < 500);
+    $_pii_verolli = ($_pii_verolli and $row["alv"] < 500);
 
     // Verollinen rivihinta
     if ($_pii_verolli) {
@@ -2535,7 +2535,7 @@ if (!function_exists('alvierittely')) {
 
     $yhteensa_teksti = kyseessa_eramaksu($laskurow) ? "Yhteensä" : "Lasku Yhteensä";
 
-    if (in_array($laskutyyppi, array(21,22))) {
+    if (in_array($laskutyyppi, array(21, 22))) {
       $kala -= 30;
       $pdf_lasku->draw_text(360, $kala, t($yhteensa_teksti, $kieli).":", $thispage, $boldi);
     }
@@ -2553,7 +2553,7 @@ if (!function_exists('alvierittely')) {
     elseif ($laskurow["valkoodi"] != '' and trim(strtoupper($laskurow["valkoodi"])) != trim(strtoupper($yhtiorow["valkoodi"]))) {
       $summa_valuutassa = $kassa_ale != '' ? ($laskurow["summa_valuutassa"]+$laskurow["pyoristys_valuutassa"]) * (1-$kassa_ale/100) : $laskurow["summa_valuutassa"]+$laskurow["pyoristys_valuutassa"];
 
-      if (in_array($laskutyyppi, array(21,22))) {
+      if (in_array($laskutyyppi, array(21, 22))) {
         $oikpos = $pdf_lasku->strlen(sprintf('%.2f', $summa_valuutassa), $boldi);
         $pdf_lasku->draw_text(535-$oikpos, $kala, sprintf('%.2f', $summa_valuutassa), $thispage, $boldi);
         $pdf_lasku->draw_text(550, $kala, $laskurow["valkoodi"], $thispage, $boldi);
@@ -2584,7 +2584,7 @@ if (!function_exists('alvierittely')) {
     else {
       $summa = $kassa_ale != '' ? ($laskurow["summa"]+$laskurow["pyoristys"]) * (1-$kassa_ale/100) : $laskurow["summa"]+$laskurow["pyoristys"];
 
-      if (in_array($laskutyyppi, array(21,22))) {
+      if (in_array($laskutyyppi, array(21, 22))) {
         $oikpos = $pdf_lasku->strlen(sprintf('%.2f', $summa), $boldi);
         $pdf_lasku->draw_text(535-$oikpos, $kala, sprintf('%.2f', $summa), $thispage, $boldi);
         $pdf_lasku->draw_text(550, $kala, $laskurow["valkoodi"], $thispage, $boldi);
@@ -3049,7 +3049,7 @@ if (!function_exists("tulosta_lasku")) {
     }
 
     if ($laskutyyppi == 21 or $laskutyyppi == 22) {
-       $laskurow['_loppunollat'] = "NONE";
+      $laskurow['_loppunollat'] = "NONE";
     }
 
     // haetaan tilauksen kaikki rivit
@@ -3129,8 +3129,8 @@ if (!function_exists("tulosta_lasku")) {
       }
 
       if ($laskutyyppi == 21 or $laskutyyppi == 22) {
-         $row['kpl'] = $row['kpl'] * 1;
-         $row['tilkpl'] = $row['tilkpl'] * 1;
+        $row['kpl'] = $row['kpl'] * 1;
+        $row['tilkpl'] = $row['tilkpl'] * 1;
       }
 
       if ($yhtiorow["pura_osaluettelot"] != "") {
@@ -3173,8 +3173,8 @@ if (!function_exists("tulosta_lasku")) {
             $lisarow["kpl"] = $tuoteperhe_row["kerroin"]*$row["kpl"];
 
             if ($laskutyyppi == 21 or $laskutyyppi == 22) {
-               $lisarow['kpl'] = $lisarow['kpl'] * 1;
-               $lisarow['tilkpl'] = $lisarow['tilkpl'] * 1;
+              $lisarow['kpl'] = $lisarow['kpl'] * 1;
+              $lisarow['tilkpl'] = $lisarow['tilkpl'] * 1;
             }
 
             $laskurows[] = $lisarow;

--- a/tilauskasittely/tulostakopio.php
+++ b/tilauskasittely/tulostakopio.php
@@ -2206,9 +2206,9 @@ if ($tee == "TULOSTA" or $tee == 'NAYTATILAUS') {
         //haetaan kaikki tälle klöntille kuuluvat otsikot
         $query = "SELECT GROUP_CONCAT(DISTINCT tunnus ORDER BY tunnus SEPARATOR ',') tunnukset
                   FROM lasku
-                  WHERE yhtio      = '{$kukarow['yhtio']}'
-                  AND tila         = '{$laskurow['tila']}'
-                  AND kerayslista  = '{$laskurow['kerayslista']}'
+                  WHERE yhtio     = '{$kukarow['yhtio']}'
+                  AND tila        = '{$laskurow['tila']}'
+                  AND kerayslista = '{$laskurow['kerayslista']}'
                   HAVING tunnukset IS NOT NULL";
         $toimresult = pupe_query($query);
 
@@ -2228,7 +2228,7 @@ if ($tee == "TULOSTA" or $tee == 'NAYTATILAUS') {
                 kieli
                 FROM asiakas
                 WHERE tunnus = '$laskurow[liitostunnus]'
-                and yhtio = '$kukarow[yhtio]'";
+                and yhtio    = '$kukarow[yhtio]'";
       $result = pupe_query($query);
       $asrow = mysql_fetch_assoc($result);
 

--- a/tilauskasittely/tulostakopio.php
+++ b/tilauskasittely/tulostakopio.php
@@ -1084,7 +1084,7 @@ if ($tee == "ETSILASKU") {
 
     echo "<th valign='top'>";
 
-    if (!in_array($toim, array("VASTAANOTTORAPORTTI","PURKU"))) {
+    if (!in_array($toim, array("VASTAANOTTORAPORTTI", "PURKU"))) {
       echo "<a href='{$hreffi}&jarj=lasku.tunnus'>", t("Tilausnro"), "</a><br>";
     }
 
@@ -1130,7 +1130,7 @@ if ($tee == "ETSILASKU") {
 
       echo "<$ero valign='top'>";
 
-      if ($row['tila'] != "U" and !in_array($toim, array("VASTAANOTTORAPORTTI","PURKU"))) {
+      if ($row['tila'] != "U" and !in_array($toim, array("VASTAANOTTORAPORTTI", "PURKU"))) {
         echo $row['tunnus'];
       }
 
@@ -1141,7 +1141,7 @@ if ($tee == "ETSILASKU") {
         echo "<br>$row[laskunro]";
       }
       echo "</$ero>";
-      echo "<$ero valign='top'>",tarkistahetu($row['ytunnus']),"<br>$row[nimi]<br>$row[nimitark]</$ero>";
+      echo "<$ero valign='top'>", tarkistahetu($row['ytunnus']), "<br>$row[nimi]<br>$row[nimitark]</$ero>";
       echo "<$ero valign='top'>".tv1dateconv($row["pvm"])."<br>".tv1dateconv($row["toimaika"])."</$ero>";
       echo "<$ero valign='top'>$row[laatija]</$ero>";
 

--- a/tilauskasittely/tuote_selaus_haku.php
+++ b/tilauskasittely/tuote_selaus_haku.php
@@ -1823,7 +1823,7 @@ function hae_oletusasiakas($laskurow) {
   global $kukarow;
 
   $query = "SELECT *,
-                   toimipaikka AS yhtio_toimipaikka
+            toimipaikka AS yhtio_toimipaikka
             FROM asiakas
             WHERE yhtio='$kukarow[yhtio]'
             AND tunnus='$kukarow[oletus_asiakas]'";

--- a/tilauskasittely/tuotetiedot.inc
+++ b/tilauskasittely/tuotetiedot.inc
@@ -77,11 +77,11 @@ function tilattu($tuoteno, $tyyppi) {
 
   $query = "SELECT sum(tilausrivi.varattu + tilausrivi.jt) AS tilattu
             FROM tilausrivi
-            WHERE tilausrivi.yhtio = '{$kukarow["yhtio"]}'
-            AND tilausrivi.tyyppi = '{$tyyppi}'
-            AND tilausrivi.tuoteno = '{$tuoteno}'
-            AND tilausrivi.laskutettuaika = '0000-00-00'
-            AND tilausrivi.var != 'P'";
+            WHERE tilausrivi.yhtio         = '{$kukarow["yhtio"]}'
+            AND tilausrivi.tyyppi          = '{$tyyppi}'
+            AND tilausrivi.tuoteno         = '{$tuoteno}'
+            AND tilausrivi.laskutettuaika  = '0000-00-00'
+            AND tilausrivi.var            != 'P'";
   $result = pupe_query($query);
   $tilausrivirow = mysql_fetch_assoc($result);
 
@@ -97,10 +97,10 @@ function hae_halytysraja($tuoteno, $paikka) {
 
   $query = "SELECT halytysraja
             FROM tuotepaikat
-            WHERE yhtio = '{$kukarow['yhtio']}'
-            AND tuoteno = '{$tuoteno}'
+            WHERE yhtio   = '{$kukarow['yhtio']}'
+            AND tuoteno   = '{$tuoteno}'
             AND hyllyalue = '{$_hyllyalue}'
-            AND hyllynro = '{$_hyllynro}'
+            AND hyllynro  = '{$_hyllynro}'
             AND hyllyvali = '{$_hyllyvali}'
             AND hyllytaso = '{$_hyllytaso}'";
   $result = pupe_query($query);

--- a/tilauskasittely/uudelleenluo_laskuaineisto.php
+++ b/tilauskasittely/uudelleenluo_laskuaineisto.php
@@ -260,9 +260,9 @@ if (isset($tee) and ($tee == "GENEROI" or $tee == "NAYTATILAUS") and $laskunumer
     if (isset($masrow["factoring_id"])) {
       $query = "SELECT *
                 FROM factoring
-                WHERE yhtio        = '$kukarow[yhtio]'
-                and tunnus         = '$masrow[factoring_id]'
-                and valkoodi       = '$lasrow[valkoodi]'";
+                WHERE yhtio  = '$kukarow[yhtio]'
+                and tunnus   = '$masrow[factoring_id]'
+                and valkoodi = '$lasrow[valkoodi]'";
       $fres = pupe_query($query);
       $frow = mysql_fetch_assoc($fres);
     }

--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -524,7 +524,7 @@ else {
 
       while ($lasku_chk_row = mysql_fetch_assoc($lasku_chk_res)) {
 
-        # Mikäli halutaan laskuttaa tulevaisuuteen niin kaikki tilauksen tuotteet täytyy olla saldottomia
+        // Mikäli halutaan laskuttaa tulevaisuuteen niin kaikki tilauksen tuotteet täytyy olla saldottomia
         if ($syotetty > $tanaan and $yhtiorow['laskutus_tulevaisuuteen'] == 'S') {
           $lasklisa .= " and lasku.tunnus not in ({$lasku_chk_row['tunnukset']}) ";
           $tulos_ulos .= "<br>\n".t("Tuotevirheet").":<br>\n".t("Tilausta")." {$lasku_chk_row['tunnukset']} ".t("ei voida laskuttaa, koska tilauksien kaikki tuotteet eivät olleet saldottomia")."!<br>\n";

--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -42,10 +42,10 @@ if (!function_exists("tarkista_jaksotetut_laskutunnukset")) {
 
       $query = "SELECT count(*) yhteensa
                 FROM lasku
-                WHERE yhtio = '{$kukarow['yhtio']}'
-                AND tila != 'D'
+                WHERE yhtio     = '{$kukarow['yhtio']}'
+                AND tila       != 'D'
                 AND jaksotettu != 0
-                AND jaksotettu = '{$key}'";
+                AND jaksotettu  = '{$key}'";
       $result = pupe_query($query);
       $row = mysql_fetch_assoc($result);
       $tarkastettu_maara = $row['yhteensa'];
@@ -1946,13 +1946,13 @@ else {
           $query = "SELECT DISTINCT factoring.sopimusnumero, factoring.factoringyhtio, factoring.viitetyyppi
                     FROM lasku
                     JOIN maksuehto ON (maksuehto.yhtio = lasku.yhtio
-                      and maksuehto.tunnus = lasku.maksuehto
+                      and maksuehto.tunnus   = lasku.maksuehto
                       and maksuehto.factoring_id is not null)
                     JOIN factoring ON (factoring.yhtio = maksuehto.yhtio
-                      and factoring.tunnus = maksuehto.factoring_id
+                      and factoring.tunnus   = maksuehto.factoring_id
                       and factoring.valkoodi = lasku.valkoodi)
-                    WHERE lasku.yhtio = '$kukarow[yhtio]'
-                    and lasku.tunnus in ($tunnukset)";
+                    WHERE lasku.yhtio        = '$kukarow[yhtio]'
+                    and lasku.tunnus         in ($tunnukset)";
           $fres = pupe_query($query);
           $frow = mysql_fetch_assoc($fres);
 
@@ -2121,9 +2121,9 @@ else {
           if (isset($masrow["factoring_id"])) {
             $query = "SELECT *
                       FROM factoring
-                      WHERE yhtio        = '$kukarow[yhtio]'
-                      and tunnus         = '$masrow[factoring_id]'
-                      and valkoodi       = '$lasrow[valkoodi]'";
+                      WHERE yhtio  = '$kukarow[yhtio]'
+                      and tunnus   = '$masrow[factoring_id]'
+                      and valkoodi = '$lasrow[valkoodi]'";
             $fres = pupe_query($query);
             $frow = mysql_fetch_assoc($fres);
           }

--- a/tilauskasittely/verkkolasku_finvoice.inc
+++ b/tilauskasittely/verkkolasku_finvoice.inc
@@ -56,7 +56,7 @@ if (!function_exists('finvoice_otsik')) {
 
     // Trustkapitalilla pit‰ olla TULOSTUSPALVELU
     if ($senderintermediator == '003723327487' and $yhtiorow['verkkolasku_lah'] == 'trustpoint') {
-        $tulostuspalvelu  = "TULOSTUSPALVELU";
+      $tulostuspalvelu  = "TULOSTUSPALVELU";
     }
 
     //  Aloitellaan aineiston luontia. Kaikki tiedot pit‰‰ olla kunnossa, tai chn 112 "Pupesoft-Finvoice: Verkkolasku Pupesoftista-Pupesoftiin"

--- a/tilauskasittely/verkkolasku_finvoice_201.inc
+++ b/tilauskasittely/verkkolasku_finvoice_201.inc
@@ -55,7 +55,7 @@ if (!function_exists('finvoice_otsik')) {
     }
     // Trustkapitalilla pit‰ olla TULOSTUSPALVELU
     if ($senderintermediator == '003723327487' and $yhtiorow['verkkolasku_lah'] == 'trustpoint') {
-        $tulostuspalvelu  = "TULOSTUSPALVELU";
+      $tulostuspalvelu  = "TULOSTUSPALVELU";
     }
     //  Aloitellaan aineiston luontia. Kaikki tiedot pit‰‰ olla kunnossa, tai chn 112 "Pupesoft-Finvoice: Verkkolasku Pupesoftista-Pupesoftiin"
     if (($senderpartyid != "" and $senderintermediator != "" and $tulostuspalvelu != "") or $lasrow["chn"] == "112") {

--- a/tilauskasittely/vientitilauksen_lisatiedot.php
+++ b/tilauskasittely/vientitilauksen_lisatiedot.php
@@ -148,7 +148,7 @@ if ($tapa == "tuonti" and $tee != "") {
 
     if ($toim == "TYOMAARAYS") {
       echo "<tr>";
-      echo "<th>",t("Tullinimike"),"</th>";
+      echo "<th>", t("Tullinimike"), "</th>";
       echo "<td>";
       echo "<br>";
       echo livesearch_kentta("paaformi", 'TULLINIMIKEHAKU', 'tullikoodi', 140, $laskurow['tullikoodi'], 'EISUBMIT', '', '', 'ei_break_all');
@@ -156,7 +156,7 @@ if ($tapa == "tuonti" and $tee != "") {
       echo "</tr>";
 
       echo "<tr>";
-      echo "<th>",t("Tulliarvo"),"</th>";
+      echo "<th>", t("Tulliarvo"), "</th>";
       echo "<td>";
       echo "<br>";
       echo "<input type='text' name='tulliarvo' value='{$laskurow['tulliarvo']}' />";
@@ -990,7 +990,7 @@ elseif ($tee == '') {
       }
       echo "<td>$teksti</td>";
 
-      if ((in_array($tilrow['alatila'], array('E','J')) or ($tilrow['alatila'] == 'D' and $tilrow['jaksotettu'] != 0))
+      if ((in_array($tilrow['alatila'], array('E', 'J')) or ($tilrow['alatila'] == 'D' and $tilrow['jaksotettu'] != 0))
         and $tilrow['vienti'] == 'K'
         and $tilrow['maa_maara'] != ''
         and $tilrow['kuljetusmuoto'] > 0
@@ -1000,7 +1000,7 @@ elseif ($tee == '') {
         and $tilrow['poistumistoimipaikka_koodi'] != '') {
         echo "<td><font color='#00FF00'>".t("OK")."</font></td>";
       }
-      elseif (((in_array($tilrow['alatila'], array('E','J')) or ($tilrow['alatila'] == 'D' and $tilrow['jaksotettu'] != 0)) or $toim == "TYOMAARAYS")
+      elseif (((in_array($tilrow['alatila'], array('E', 'J')) or ($tilrow['alatila'] == 'D' and $tilrow['jaksotettu'] != 0)) or $toim == "TYOMAARAYS")
         and $tilrow['vienti'] == 'E'
         and $tilrow['maa_maara'] != ''
         and $tilrow['kuljetusmuoto'] > 0

--- a/tilauskasittely/vientitilauksen_lisatiedot.php
+++ b/tilauskasittely/vientitilauksen_lisatiedot.php
@@ -61,16 +61,16 @@ if ($tapa == "tuonti" and $tee != "") {
 
     if ($toim == "TYOMAARAYS") {
       $query = "UPDATE tyomaarays SET
-                tullikoodi                       = '$tullikoodi',
-                tulliarvo                        = '$tulliarvo',
-                maa_maara                        = '$maa_maara',
-                maa_lahetys                      = '$maa_lahetys',
-                maa_alkupera                     = '$maa_alkupera',
-                kauppatapahtuman_luonne          = '$kauppatapahtuman_luonne',
-                kuljetusmuoto                    = '$kuljetusmuoto',
-                bruttopaino                      = '$bruttopaino'
-                WHERE otunnus                    in ($otunnus)
-                and yhtio                        = '$kukarow[yhtio]'";
+                tullikoodi              = '$tullikoodi',
+                tulliarvo               = '$tulliarvo',
+                maa_maara               = '$maa_maara',
+                maa_lahetys             = '$maa_lahetys',
+                maa_alkupera            = '$maa_alkupera',
+                kauppatapahtuman_luonne = '$kauppatapahtuman_luonne',
+                kuljetusmuoto           = '$kuljetusmuoto',
+                bruttopaino             = '$bruttopaino'
+                WHERE otunnus           in ($otunnus)
+                and yhtio               = '$kukarow[yhtio]'";
       $result = pupe_query($query);
     }
     else {
@@ -367,21 +367,21 @@ elseif ($tee != "") {
       //päivitetään alatila vain jos tilaus ei vielä ole laskutettu
       $query = "UPDATE lasku
                 SET alatila = 'E'
-                WHERE yhtio = '$kukarow[yhtio]'
-                and tunnus  = '$otun'
-                and tila    = 'L'
+                WHERE yhtio    = '$kukarow[yhtio]'
+                and tunnus     = '$otun'
+                and tila       = 'L'
                 and jaksotettu = 0
-                and alatila NOT IN ('X', 'J')";
+                and alatila    NOT IN ('X', 'J')";
       $result = pupe_query($query);
 
       //päivitetään alatila vain jos tilauksella on maksupositioita
       $query = "UPDATE lasku SET
-                alatila = 'J'
-                WHERE yhtio = '{$kukarow['yhtio']}'
-                and tunnus  = '{$otun}'
-                and tila    = 'L'
+                alatila        = 'J'
+                WHERE yhtio    = '{$kukarow['yhtio']}'
+                and tunnus     = '{$otun}'
+                and tila       = 'L'
                 and jaksotettu > 0
-                and alatila NOT IN ('X', 'J', 'D')";
+                and alatila    NOT IN ('X', 'J', 'D')";
       $result = pupe_query($query);
     }
 

--- a/tilauskasittely/yllapitosopimukset.php
+++ b/tilauskasittely/yllapitosopimukset.php
@@ -411,12 +411,12 @@ if (mysql_num_rows($result) > 0) {
 
     echo "<tr class='aktiivi'>";
     echo "<td valign='top'>$row[laskutunnus]</td>";
-    echo "<td valign='top'>",tarkistahetu($row["ytunnus"]),"</td>";
+    echo "<td valign='top'>", tarkistahetu($row["ytunnus"]), "</td>";
     echo "<td valign='top'>";
 
     if (strpos($row["nimi"], '!¡!') !== false) {
       list($_ytunnus, $_nimi) = explode('!¡!', $row["nimi"]);
-      echo tarkistahetu($_ytunnus),"<br>{$_nimi}";
+      echo tarkistahetu($_ytunnus), "<br>{$_nimi}";
     }
     else {
       echo $row["nimi"];

--- a/tuote.php
+++ b/tuote.php
@@ -1236,12 +1236,12 @@ if (isset($ajax)) {
               LEFT JOIN tilausrivin_lisatiedot ON (tilausrivin_lisatiedot.yhtio=tilausrivi.yhtio and tilausrivin_lisatiedot.tilausrivitunnus=tilausrivi.tunnus)
               JOIN lasku use index (PRIMARY) ON lasku.yhtio = tilausrivi.yhtio and lasku.tunnus = tilausrivi.otunnus {$toimipaikkarajaus}
               LEFT JOIN varastopaikat ON (varastopaikat.yhtio = lasku.yhtio
-                AND varastopaikat.tunnus     = lasku.varasto)
+                AND varastopaikat.tunnus    = lasku.varasto)
               LEFT JOIN lasku as lasku2 ON lasku2.yhtio = tilausrivi.yhtio and lasku2.tunnus = tilausrivi.uusiotunnus
               LEFT JOIN asiakas ON asiakas.yhtio = lasku.yhtio and asiakas.tunnus = lasku.liitostunnus
-              WHERE tilausrivi.yhtio         = '$kukarow[yhtio]'
-              and tilausrivi.tyyppi          in ('L','E','G','V','W','M','O')
-              and tilausrivi.tuoteno         = '$tuoteno'
+              WHERE tilausrivi.yhtio        = '$kukarow[yhtio]'
+              and tilausrivi.tyyppi         in ('L','E','G','V','W','M','O')
+              and tilausrivi.tuoteno        = '$tuoteno'
               and tilausrivi.laskutettuaika = '0000-00-00'
               and ((tilausrivi.var != 'P' and tilausrivi.varattu + tilausrivi.jt != 0) or (tilausrivi.var = 'P' and lasku.tila != 'D' and lasku.alatila NOT IN ('X', 'V')))
               ORDER BY pvm, tunnus";

--- a/tuoteperhe.php
+++ b/tuoteperhe.php
@@ -546,10 +546,10 @@ if ($tee == 'TALLENNAFAKTA' and $oikeurow['paivitys'] == '1') {
     $query = "SELECT tuoteperhe.tunnus
               FROM tuoteperhe
               join tuote using(yhtio, tuoteno)
-              WHERE tuoteperhe.yhtio = '$kukarow[yhtio]'
-              and tuoteperhe.tyyppi = '$hakutyyppi'
+              WHERE tuoteperhe.yhtio    = '$kukarow[yhtio]'
+              and tuoteperhe.tyyppi     = '$hakutyyppi'
               and tuoteperhe.isatuoteno = '$isatuoteno'
-              AND tuote.kehahin = 0";
+              AND tuote.kehahin         = 0";
     $result = pupe_query($query);
 
     if (mysql_num_rows($result) > 0) {
@@ -788,9 +788,9 @@ if (($hakutuoteno != '' or $isatuoteno != '') and $tee == "") {
       if ($toim == "PERHE") {
         $query = "SELECT *
                   FROM tuoteperhe
-                  WHERE yhtio     = '$kukarow[yhtio]'
-                  AND tyyppi      = '$hakutyyppi'
-                  AND isatuoteno  = '$isatuoteno'
+                  WHERE yhtio    = '$kukarow[yhtio]'
+                  AND tyyppi     = '$hakutyyppi'
+                  AND isatuoteno = '$isatuoteno'
                   ORDER BY isatuoteno, tuoteno
                   LIMIT 1";
         $ressu = pupe_query($query);

--- a/tyomaarays/tyomaarays.inc
+++ b/tyomaarays/tyomaarays.inc
@@ -503,8 +503,8 @@ if (($toim == "TYOMAARAYS" or $toim == "TYOMAARAYS_ASENTAJA") and $tee == 'VALMI
               FROM lasku
               JOIN tyomaarays ON (tyomaarays.yhtio = lasku.yhtio AND tyomaarays.otunnus = lasku.tunnus)
               LEFT JOIN laskun_lisatiedot ON (laskun_lisatiedot.yhtio = lasku.yhtio and laskun_lisatiedot.otunnus = lasku.tunnus)
-              WHERE lasku.tunnus  = '$kukarow[kesken]'
-              AND lasku.yhtio     = '$kukarow[yhtio]'";
+              WHERE lasku.tunnus = '$kukarow[kesken]'
+              AND lasku.yhtio    = '$kukarow[yhtio]'";
     $result = pupe_query($query);
     $laskurow = mysql_fetch_assoc($result);
 

--- a/tyomaarays/tyomaarays.inc
+++ b/tyomaarays/tyomaarays.inc
@@ -92,7 +92,7 @@ if ($tee ==  "VALMIS" or $tee == "LEPAA") {
         <input type='hidden' name='tyomtyyppi' value='$tyomtyyppi'>
         <input type='submit' value='".t("Näytä työmääräys").": $laskurow[tunnus]' onClick=\"js_openFormInNewWindow('tulostakopioform_tm_$laskurow[tunnus]', ''); return false;\"></form><br>";
 
-        $lopetus = "";
+    $lopetus = "";
   }
 
   if (!empty($komento["Huoltosaate"]) and $komento["Huoltosaate"] == "-88") {
@@ -105,7 +105,7 @@ if ($tee ==  "VALMIS" or $tee == "LEPAA") {
         <input type='hidden' name='kieli' value='$kieli'>
         <input type='submit' value='".t("Näytä huoltosaate").": $laskurow[tunnus]' onClick=\"js_openFormInNewWindow('tulostakopioform_hs_$laskurow[tunnus]', ''); return false;\"></form><br>";
 
-        $lopetus = "";
+    $lopetus = "";
   }
 
   if (!empty($komento["Reklamaatio"]) and $komento["Reklamaatio"] == "-88") {
@@ -118,7 +118,7 @@ if ($tee ==  "VALMIS" or $tee == "LEPAA") {
         <input type='hidden' name='kieli' value='$kieli'>
         <input type='submit' value='".t("Näytä reklamaatio").": $laskurow[tunnus]' onClick=\"js_openFormInNewWindow('tulostakopioform_rm_$laskurow[tunnus]', ''); return false;\"></form><br>";
 
-        $lopetus = "";
+    $lopetus = "";
   }
 
   if (!empty($komento["Takuu"]) and $komento["Takuu"] == "-88") {
@@ -131,7 +131,7 @@ if ($tee ==  "VALMIS" or $tee == "LEPAA") {
         <input type='hidden' name='kieli' value='$kieli'>
         <input type='submit' value='".t("Näytä takuu").": $laskurow[tunnus]' onClick=\"js_openFormInNewWindow('tulostakopioform_tk_$laskurow[tunnus]', ''); return false;\"></form><br>";
 
-        $lopetus = "";
+    $lopetus = "";
   }
 
   if (!empty($komento["Lähete"]) and $komento["Lähete"] == "-88") {
@@ -144,7 +144,7 @@ if ($tee ==  "VALMIS" or $tee == "LEPAA") {
         <input type='hidden' name='kieli' value='$kieli'>
         <input type='submit' value='".t("Näytä lähete").": $laskurow[tunnus]' onClick=\"js_openFormInNewWindow('tulostakopioform_la_$laskurow[tunnus]', ''); return false;\"></form><br>";
 
-        $lopetus = "";
+    $lopetus = "";
   }
 
   if ($toim == "REKLAMAATIO" and !empty($komento["Lähete"]) and $komento["Lähete"] != "-88") {

--- a/unifaun_resend.php
+++ b/unifaun_resend.php
@@ -38,7 +38,7 @@ if ($php_cli) {
 // Sallitaan vain yksi instanssi t‰st‰ skriptist‰ kerrallaan
 pupesoft_flock();
 
-# L‰hetet‰‰n UTF-8 muodossa jos PUPE_UNICODE on true
+// L‰hetet‰‰n UTF-8 muodossa jos PUPE_UNICODE on true
 $ftputf8 = PUPE_UNICODE;
 
 // PrintServer

--- a/uudelleenlaheta-postnord.php
+++ b/uudelleenlaheta-postnord.php
@@ -19,7 +19,7 @@ if ($tee == "laheta" and $tilaukset != "") {
             AND lasku.tunnus  in ($tilaukset)";
   $res  = pupe_query($query);
 
-  if (mysql_num_rows($result) > 0 and in_array($yhtiorow['ulkoinen_jarjestelma'], array('','K'))) {
+  if (mysql_num_rows($result) > 0 and in_array($yhtiorow['ulkoinen_jarjestelma'], array('', 'K'))) {
     while ($laskurow = mysql_fetch_assoc($res)) {
       echo t("Uudelleenl‰hetet‰‰n LogMaster-ker‰yssanoma").": $laskurow[tunnus]<br>";
       posten_outbounddelivery($laskurow["tunnus"], $laskurow['ulkoinen_jarjestelma']);

--- a/ylaframe.php
+++ b/ylaframe.php
@@ -67,48 +67,50 @@ $query = "SELECT *
           WHERE yhtio      = '{$kukarow['yhtio']}'
           AND laji         = 'PIKAVALINTA'
           AND liitostunnus = '{$kukarow['tunnus']}'
+          AND selitetark  != ''
           ORDER BY selite+0";
 $result = pupe_query($query);
-$row = mysql_fetch_assoc($result);
 
-$tallennetut = unserialize($row['selitetark']);
+if ($row = mysql_fetch_assoc($result)) {
+  $tallennetut = unserialize($row['selitetark']);
 
-foreach ($tallennetut["skriptit"] as $i => $skripti) {
-  $kuvake    = $tallennetut["kuvakkeet"][$i];
-  $teksti    = $tallennetut["tekstit"][$i];
+  foreach ($tallennetut["skriptit"] as $i => $skripti) {
+    $kuvake    = $tallennetut["kuvakkeet"][$i];
+    $teksti    = $tallennetut["tekstit"][$i];
 
-  list($goso, $go, $golisa) = explode("###", $skripti);
+    list($goso, $go, $golisa) = explode("###", $skripti);
 
-  if ($goso == "LASKIN") {
-    echo "<script>
-    $(document).ready(function (e) {
-      $('#avaa_laskin').click(function (e) {
+    if ($goso == "LASKIN") {
+      echo "<script>
+      $(document).ready(function (e) {
+        $('#avaa_laskin').click(function (e) {
 
-        var mouseX = window.screenX+e.pageX+40;
-        var mouseY = window.screenY+e.pageY;
-        var w_height = 360;
+          var mouseX = window.screenX+e.pageX+40;
+          var mouseY = window.screenY+e.pageY;
+          var w_height = 360;
 
-        var ua = navigator.userAgent.toLowerCase();
+          var ua = navigator.userAgent.toLowerCase();
 
-        if (ua.indexOf('safari') != -1 && ua.indexOf('chrome') <= -1) {
-          w_height = 400;
-        }
+          if (ua.indexOf('safari') != -1 && ua.indexOf('chrome') <= -1) {
+            w_height = 400;
+          }
 
-        var laskin = window.open('{$palvelin2}CalcSS3', 'Pupesoft-laskin' ,'toolbar=0,scrollbars=0,location=0,statusbar=0,menubar=0,resizable=0,left='+mouseX+',top='+mouseY+',width=280,height='+w_height);
-        laskin.focus();
-      });
-    });</script>";
+          var laskin = window.open('{$palvelin2}CalcSS3', 'Pupesoft-laskin' ,'toolbar=0,scrollbars=0,location=0,statusbar=0,menubar=0,resizable=0,left='+mouseX+',top='+mouseY+',width=280,height='+w_height);
+          laskin.focus();
+        });
+      });</script>";
 
-    echo "<td class='ylapalkki'><img id='avaa_laskin' src='{$palvelin2}pics/facelift/icons/$kuvake'><br><a>$teksti</a></td>";
-  }
-  else {
-    $skriptilisa = "?goso=$goso&go=$go";
-
-    if (!empty($golisa)) {
-      $skriptilisa .= "?toim=".$golisa;
+      echo "<td class='ylapalkki'><img id='avaa_laskin' src='{$palvelin2}pics/facelift/icons/$kuvake'><br><a>$teksti</a></td>";
     }
+    else {
+      $skriptilisa = "?goso=$goso&go=$go";
 
-    echo "<td class='ylapalkki'><a class='puhdas' target='_top' href='{$palvelin2}$skriptilisa'><img src='{$palvelin2}pics/facelift/icons/$kuvake'><br>$teksti</a></td>";
+      if (!empty($golisa)) {
+        $skriptilisa .= "?toim=".$golisa;
+      }
+
+      echo "<td class='ylapalkki'><a class='puhdas' target='_top' href='{$palvelin2}$skriptilisa'><img src='{$palvelin2}pics/facelift/icons/$kuvake'><br>$teksti</a></td>";
+    }
   }
 }
 

--- a/yllapito.php
+++ b/yllapito.php
@@ -633,10 +633,10 @@ if ($upd == 1) {
 
           if ($paivita_myos_kanavointitieto != "") {
             $query = "UPDATE lasku SET
-                      chn            = '{$otsikrow['chn']}',
-                      verkkotunnus   = '{$otsikrow['verkkotunnus']}'
-                      WHERE yhtio    = '{$kukarow['yhtio']}'
-                      and tunnus     = '{$laskuorow['tunnus']}'";
+                      chn          = '{$otsikrow['chn']}',
+                      verkkotunnus = '{$otsikrow['verkkotunnus']}'
+                      WHERE yhtio  = '{$kukarow['yhtio']}'
+                      and tunnus   = '{$laskuorow['tunnus']}'";
             $updaresult = pupe_query($query);
           }
           else {


### PR DESCRIPTION
Käsitellään pakollisuudet MySQL aliaksista oikein. Ovat pakollisia ja ei saa olla tyhjiä, mutta eivät kuulu olla avaintietoja joilla rivit yksilöidään.

Codestyle tähän samaan branchiin