### PR TITLE
Tuotepaikkojen muutos: varastopaikan poistaminen

### DIFF
--- a/iltasiivo.php
+++ b/iltasiivo.php
@@ -791,6 +791,18 @@ if (mysql_num_rows($poistettavat_tuotepaikat) > 0) {
     $avoimet_rivit[] = $avoinrivi['id'];
   }
 
+  // Haetaan inventointilistalla olevat käsittelemättömät rivit
+  $query = "SELECT LOWER(CONCAT(tuoteno, hyllyalue, hyllynro, hyllytaso, hyllyvali)) AS id
+            FROM inventointilistarivi
+            WHERE yhtio = '{$kukarow['yhtio']}'
+            AND tila = 'A'
+            AND aika IS NULL";
+  $avoinrivi_result = pupe_query($query);
+
+  while ($avoinrivi = mysql_fetch_assoc($avoinrivi_result)) {
+    $avoimet_rivit[] = $avoinrivi['id'];
+  }
+
   // Haetaan avoimet tilausrivit arrayseen (siirtolistojen kohdepaikka)
   $query = "SELECT LOWER(CONCAT(tilausrivi.tuoteno, tilausrivin_lisatiedot.kohde_hyllyalue, tilausrivin_lisatiedot.kohde_hyllynro, tilausrivin_lisatiedot.kohde_hyllytaso, tilausrivin_lisatiedot.kohde_hyllyvali)) AS id
             FROM tilausrivi

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -1170,16 +1170,12 @@ if ($tee == 'M') {
 
         $reklacheck = (mysql_num_rows($reklares) > 0);
 
-        // Tarkistetaan onko paikalla tilausrivejä
-        $query = "SELECT lasku.tunnus
-                  FROM lasku
-                  JOIN tilausrivi ON (
-                    tilausrivi.yhtio       = lasku.yhtio AND
-                    tilausrivi.otunnus     = lasku.tunnus
-                  )
-                  WHERE lasku.yhtio        = '{$kukarow['yhtio']}'
-                  AND lasku.tila           IN ('L', 'N')
-                  AND lasku.alatila        IN ('', 'A', 'B', 'BD', 'C', 'D', 'E', 'F', 'G', 'J', 'K', 'KA', 'T', 'U', 'V')
+        // Tarkistetaan onko paikalla avoimi JT-rivejä
+        $query = "SELECT tilausrivi.tunnus
+                  FROM tilausrivi
+                  WHERE tilausrivi.yhtio        = '{$kukarow['yhtio']}'
+                  AND tilausrivi.tyyppi    = 'L'
+                  AND tilausrivi.var       = 'J'
                   AND tilausrivi.hyllyalue = '{$saldorow['hyllyalue']}'
                   AND tilausrivi.hyllynro  = '{$saldorow['hyllynro']}'
                   AND tilausrivi.hyllyvali = '{$saldorow['hyllyvali']}'
@@ -1250,7 +1246,7 @@ if ($tee == 'M') {
         }
 
         if ($rivicheck) {
-          $poistoteksti .= "<br>(".t("Tuotepaikalla avoimia tilausrivejä").")";
+          $poistoteksti .= "<br>(".t("Tuotepaikalla avoimia jälkitoimitusrivejä").")";
         }
 
         echo "<td><input type = 'checkbox' name='flagaa_poistettavaksi[$saldorow[tunnus]]' value='$saldorow[tunnus]' $chk> {$poistoteksti}

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -131,7 +131,7 @@ if ($tee == 'MUUTA') {
   //Haetaan edellisen tuote statuksen oletuspaikat
   if ($kutsuja == 'tuotetarkista.inc') {
     $kaikki_oletuspaikat = hae_kaikki_oletuspaikat_try_tai_status($tem_try_vanha, $tem_status_vanha);
-echo "134 ",var_dump($poista),"<br><br>";
+
     foreach ($poista as $poistettava) {
       //Jos poistettavaa paikkaa ei löydy kaikista_oletuspaikoista,
       //tarkoittaa se, että kyseessä on manuaalisesti lisätty tuotepaikka.

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -247,11 +247,11 @@ if ($tee == 'MUUTA') {
                       WHERE yhtio = '{$kukarow["yhtio"]}'
                       AND tunnus  = '{$jtrivi["tunnus"]}'";
             pupe_query($query);
-echo "241 $query <br><br>";
+
           }
 
         }
-echo "245 done! <br><br><br>";
+
         $query = "INSERT into tapahtuma set
                   yhtio     = '$kukarow[yhtio]',
                   tuoteno   = '$tuoteno',
@@ -267,7 +267,7 @@ echo "245 done! <br><br><br>";
                   laatija   = '$kukarow[kuka]',
                   laadittu  = now()";
         pupe_query($query);
-echo "$query <br><br>";
+
         $query = "DELETE FROM tuotepaikat
                   WHERE tuoteno = '$tuoteno'
                   and yhtio     = '$kukarow[yhtio]'

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -1241,7 +1241,6 @@ if ($tee == 'M') {
         $reklares = pupe_query($query);
 
         $reklacheck = (mysql_num_rows($reklares) > 0);
-
       }
       else {
         $reklacheck = false;

--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -180,6 +180,78 @@ if ($tee == 'MUUTA') {
           echo "<font class='message'>$poisto_texti</font>";
         }
 
+        // Tarkistetaan onko paikalla avoimia JT-rivejä
+        // ja päivitetään avoimet JT-rivit toiselle paikalle, mikäli niitä löytyy
+        $query = "SELECT tilausrivi.varasto,
+                  tilausrivi.tunnus
+                  FROM tilausrivi
+                  WHERE tilausrivi.yhtio   = '{$kukarow['yhtio']}'
+                  AND tilausrivi.tyyppi    = 'L'
+                  AND tilausrivi.var       = 'J'
+                  AND tilausrivi.hyllyalue = '{$hyllyalue[$poistetaan]}'
+                  AND tilausrivi.hyllynro  = '{$hyllynro[$poistetaan]}'
+                  AND tilausrivi.hyllyvali = '{$hyllyvali[$poistetaan]}'
+                  AND tilausrivi.hyllytaso = '{$hyllytaso[$poistetaan]}'
+                  AND tilausrivi.tuoteno   = '{$tuoteno}'";
+        $rivires = pupe_query($query);
+
+        while ($jtrivi = mysql_fetch_assoc($rivires)) {
+          // Haetaan ensin nykyisen paikan tunnus,
+          // jotta voidaan helposti varmistaa ettei olla laittamassa takaisin samalle paikalle
+          $query = "SELECT tunnus
+                    FROM tuotepaikat
+                    WHERE yhtio   = '{$kukarow['yhtio']}'
+                    AND varasto   = '{$jtrivi['varasto']}'
+                    AND hyllyalue = '{$hyllyalue[$poistetaan]}'
+                    AND hyllynro  = '{$hyllynro[$poistetaan]}'
+                    AND hyllyvali = '{$hyllyvali[$poistetaan]}'
+                    AND hyllytaso = '{$hyllytaso[$poistetaan]}'";
+          $nykyvarasto_tunnus = mysql_fetch_assoc(pupe_query($query));
+
+          // Laitetaan ensisijaisesti avoin JT-rivi saman varaston vanhimmalle paikalle
+          $query = "SELECT varasto,
+                    hyllyalue,
+                    hyllynro,
+                    hyllyvali,
+                    hyllytaso
+                    FROM tuotepaikat
+                    WHERE yhtio = '{$kukarow['yhtio']}'
+                    AND varasto = '{$jtrivi["varasto"]}'
+                    AND tunnus != '{$nykyvarasto_tunnus["tunnus"]}'
+                    AND tuoteno   = '{$tuoteno}'
+                    ORDER BY tunnus";
+          $uusivarasto_res = pupe_query($query);
+
+          // Jos samasta varastosta ei paikkaa löydy, niin laitetaan JT-rivi oletuspaikalle
+          if (mysql_num_rows($uusivarasto_res) == 0) {
+            $query = "SELECT varasto,
+                      hyllyalue,
+                      hyllynro,
+                      hyllyvali,
+                      hyllytaso
+                      FROM tuotepaikat
+                      WHERE yhtio = '{$kukarow['yhtio']}'
+                      AND oletus != ''
+                      AND tuoteno = '{$tuoteno}'";
+            $uusivarasto_res = pupe_query($query);
+          }
+
+          // Päivitetään uusi paikka avoimelle JT-riville
+          if ($uusivarasto = mysql_fetch_assoc($uusivarasto_res)) {
+            $query = "UPDATE tilausrivi
+                      SET varasto = '{$uusivarasto["varasto"]}',
+                      hyllyalue   = '{$uusivarasto["hyllyalue"]}',
+                      hyllynro    = '{$uusivarasto["hyllynro"]}',
+                      hyllyvali   = '{$uusivarasto["hyllyvali"]}',
+                      hyllytaso   = '{$uusivarasto["hyllytaso"]}'
+                      WHERE yhtio = '{$kukarow["yhtio"]}'
+                      AND tunnus  = '{$jtrivi["tunnus"]}'";
+            pupe_query($query);
+echo "241 $query <br><br>";
+          }
+
+        }
+echo "245 done! <br><br><br>";
         $query = "INSERT into tapahtuma set
                   yhtio     = '$kukarow[yhtio]',
                   tuoteno   = '$tuoteno',
@@ -195,7 +267,7 @@ if ($tee == 'MUUTA') {
                   laatija   = '$kukarow[kuka]',
                   laadittu  = now()";
         pupe_query($query);
-
+echo "$query <br><br>";
         $query = "DELETE FROM tuotepaikat
                   WHERE tuoteno = '$tuoteno'
                   and yhtio     = '$kukarow[yhtio]'
@@ -1170,25 +1242,9 @@ if ($tee == 'M') {
 
         $reklacheck = (mysql_num_rows($reklares) > 0);
 
-        // Tarkistetaan onko paikalla avoimi JT-rivejä
-        $query = "SELECT tilausrivi.tunnus
-                  FROM tilausrivi
-                  WHERE tilausrivi.yhtio        = '{$kukarow['yhtio']}'
-                  AND tilausrivi.tyyppi    = 'L'
-                  AND tilausrivi.var       = 'J'
-                  AND tilausrivi.hyllyalue = '{$saldorow['hyllyalue']}'
-                  AND tilausrivi.hyllynro  = '{$saldorow['hyllynro']}'
-                  AND tilausrivi.hyllyvali = '{$saldorow['hyllyvali']}'
-                  AND tilausrivi.hyllytaso = '{$saldorow['hyllytaso']}'
-                  AND tilausrivi.tuoteno   = '{$saldorow["tuoteno"]}'";
-        $rivires = pupe_query($query);
-
-        $rivicheck = (mysql_num_rows($rivires) > 0);
-
       }
       else {
         $reklacheck = false;
-        $rivicheck = false;
       }
 
       echo "<tr>";
@@ -1235,7 +1291,7 @@ if ($tee == 'M') {
       if ($saldorow["saldo"] != 0 and $saldorow["oletus"] != "") {
         echo "<td></td>";
       }
-      elseif ($saldorow["saldo"] != 0 or $hyllyssa != 0 or $myytavissa != 0 or $reklacheck or !empty($saldorow["inventointilistatunnus"]) or $rivicheck) {
+      elseif ($saldorow["saldo"] != 0 or $hyllyssa != 0 or $myytavissa != 0 or $reklacheck or !empty($saldorow["inventointilistatunnus"])) {
 
         if ($reklacheck) {
           $poistoteksti .= "<br>(".t("Reklamaatio varaa tuotepaikkaa").")";
@@ -1243,10 +1299,6 @@ if ($tee == 'M') {
 
         if (!empty($saldorow["inventointilistatunnus"])) {
           $poistoteksti .= "<br>(".t("Tuotepaikka käsittelemättömänä inventointilistalla").")";
-        }
-
-        if ($rivicheck) {
-          $poistoteksti .= "<br>(".t("Tuotepaikalla avoimia jälkitoimitusrivejä").")";
         }
 
         echo "<td><input type = 'checkbox' name='flagaa_poistettavaksi[$saldorow[tunnus]]' value='$saldorow[tunnus]' $chk> {$poistoteksti}


### PR DESCRIPTION
Tuotepaikkojen poistamisessa oli kaksi tilannetta, joissa sai käytössä olevan tuotepaikan poistettua. Nämä molemmat tilanteet on nyt korjattu niin, ettei poistaminen tälläisessä tapauksessa onnistu heti.

- Tuotepaikka oli käsittelemättömänä inventointilistalla

- Tuotepaikalla oli avoimia jälkitoimitusrivejä