### PR TITLE
Ostolaskun perustus & swift-koodit

### DIFF
--- a/inc/muutosite.inc
+++ b/inc/muutosite.inc
@@ -135,7 +135,7 @@ if ($kukarow['taso'] != 1) {
 
     $kommentti = "(" . $kukarow['nimi'] . "@" . date('Y-m-d') .") ".t('Laskun maksutili muutettiin. Vanha oli %s.', '', $ultilno)."<br>" . $trow['comments'];
 
-    if ($ibanmaa == "FI") {
+    if ($ibanmaa == "FI" or substr($ultilno, 0, 2) == "FI") {
       // Haetaan uuden tilinumeron mukainen swift koodi
       include "inc/pankkitiedot.inc";
       $vastaus = pankkitiedot($ultilno, '');
@@ -208,6 +208,13 @@ if ($kukarow['taso'] != 1) {
     $trow = mysql_fetch_assoc($result);
 
     $kommentti = "($kukarow[nimi]@".date('Y-m-d').") ".t("Laskun maksutili muutettiin. Vanha oli").": $trow[pankki_haltija], $trow[ultilno], $trow[swift], $trow[pankki1], $trow[pankki2], $trow[pankki3], $trow[pankki4], $trow[sisviesti1].<br>$trow[comments]";
+
+    if ($ibanmaa == "FI" or substr($ultilno, 0, 2) == "FI") {
+      // Haetaan uuden tilinumeron mukainen swift koodi
+      include "inc/pankkitiedot.inc";
+      $vastaus = pankkitiedot($ultilno, '');
+      $swift = $vastaus['swift'];
+    }
 
     //P‰ivitet‰‰n lasku
     $query = "UPDATE lasku SET

--- a/inc/muutosite.inc
+++ b/inc/muutosite.inc
@@ -102,13 +102,13 @@ if ($kukarow['taso'] != 1) {
 
     require "inc/pankkitilinoikeellisuus.php";
 
-    if ($pankkitili == '') {
+    if ($pankkitili == '' and $ultilno == '') {
       echo "<font class='error'>".t("Pankkitili on virheellinen")."</font><br>";
       $tee='E';
       $tila='';
     }
     else {
-      $tili=$pankkitili;
+      $tili = $pankkitili;
     }
 
     if ($trow['ultilno_maa'] != "") $ibanmaa = $trow['ultilno_maa'];
@@ -135,9 +135,16 @@ if ($kukarow['taso'] != 1) {
 
     $kommentti = "(" . $kukarow['nimi'] . "@" . date('Y-m-d') .") ".t('Laskun maksutili muutettiin. Vanha oli %s.', '', $ultilno)."<br>" . $trow['comments'];
 
-    //P‰ivitet‰‰n lasku
+    if ($ibanmaa == "FI") {
+      // Haetaan uuden tilinumeron mukainen swift koodi
+      include "inc/pankkitiedot.inc";
+      $vastaus = pankkitiedot($ultilno, '');
+      $swift = $vastaus['swift'];
+    }
+
+    // P‰ivitet‰‰n lasku
     $query = "UPDATE lasku
-              SET tilinumero = '$tili',
+              SET tilinumero = '',
               ultilno      = '$ultilno',
               swift        = '$swift',
               comments     = '$kommentti'

--- a/inc/pankkitiedot.inc
+++ b/inc/pankkitiedot.inc
@@ -79,11 +79,6 @@ if (!function_exists("pankkitiedot")) {
         $pankki["pankkilaitos"] = "Danske Bank";
         $pankki["swift"] = "DABAFIHX";
         break;
-      case (6) : // Tapiola Pankki
-        $pankki["rahalaitos"] = '  ';
-        $pankki["pankkilaitos"] = "Tapiola Pankki";
-        $pankki["swift"] = "TAPIFI22";
-        break;
       case (7) : // DNB Bank ASA
         $pankki["rahalaitos"] = '  ';
         $pankki["pankkilaitos"] = "DNB Bank ASA";
@@ -94,6 +89,7 @@ if (!function_exists("pankkitiedot")) {
         $pankki["pankkilaitos"] = "Swedbank";
         $pankki["swift"] = "SWEDFIHH";
         break;
+      case (6) : // S-Pankki
       case (9) : // S-Pankki
         $pankki["rahalaitos"] = '  ';
         $pankki["pankkilaitos"] = "S-Pankki";

--- a/inc/toimitarkista.inc
+++ b/inc/toimitarkista.inc
@@ -122,7 +122,7 @@ if (!function_exists("toimitarkista")) {
       else $ibanmaa = $tmp_maakoodi;
 
       $swift_virhe = FALSE;
-      if (strtoupper($ibanmaa) == "FI") {
+      if (strtoupper($ibanmaa) == "FI" or substr($tmp_iban, 0, 2) == "FI") {
         // Haetaan swift tarkistusta varten
         include "inc/pankkitiedot.inc";
         $vastaus = pankkitiedot($tmp_iban, '');

--- a/inc/toimitarkista.inc
+++ b/inc/toimitarkista.inc
@@ -78,6 +78,7 @@ if (!function_exists("toimitarkista")) {
     if ($fieldname == "ultilno") {
 
       if ($t[$i] == '') $t[$i] = $tmp_iban;
+      if ($tmp_iban == '') $tmp_iban = $t[$i];
 
       // Vaaditaan isot kirjaimet
       $t[$i] = strtoupper(trim($t[$i]));
@@ -120,9 +121,20 @@ if (!function_exists("toimitarkista")) {
       if ($tmp_ultilno_maa != "") $ibanmaa = $tmp_ultilno_maa;
       else $ibanmaa = $tmp_maakoodi;
 
+      $swift_virhe = FALSE;
+      if (strtoupper($ibanmaa) == "FI") {
+        // Haetaan swift tarkistusta varten
+        include "inc/pankkitiedot.inc";
+        $vastaus = pankkitiedot($tmp_iban, '');
+
+        if ($t[$i] != $vastaus['swift']) {
+          $swift_virhe = TRUE;
+        }
+      }
+
       if ($t[$i] != '') {
         // Jos SEPA-maa, tarkistetaan BIC
-        if (tarkista_sepa($ibanmaa) and tarkista_bic($t[$i]) === FALSE) {
+        if ($swift_virhe or (tarkista_sepa($ibanmaa) and tarkista_bic($t[$i]) === FALSE)) {
           $virhe[$i] = t("Virheellinen BIC!")." $t[$i]";
         }
       }

--- a/ulask.php
+++ b/ulask.php
@@ -806,19 +806,29 @@ if ($tee == 'I') {
 
   // IBAN / BBAN
   if ($trow['ultilno'] != "") {
-    // Haetaan swift jos se puuttuu
-    if (empty($trow["swift"])) {
+    $swift_ok = TRUE;
+
+    if (strtoupper($ibanmaa) == "FI") {
+      // Haetaan swift tarkistusta varten tai jos sitä ei ole syötetty ollenkaan
       include "inc/pankkitiedot.inc";
       $vastaus = pankkitiedot($trow['ultilno'], '');
-      $trow["swift"] = $vastaus['swift'];
+
+      // Jos swift on tyhjä niin laitetaan haettu tilalle
+      if (empty($trow["swift"])) {
+        $trow["swift"] = $vastaus['swift'];
+      }
+
+      if ($trow["swift"] != $vastaus['swift']) {
+        $swift_ok = FALSE;
+      }
     }
 
     // Vaaditaan isot kirjaimet
     $trow['ultilno'] = strtoupper($trow['ultilno']);
     $trow['swift']   = strtoupper($trow['swift']);
 
-    // Jos SEPA-maa, tarkistetaan IBAN
-    if (tarkista_sepa($ibanmaa) and tarkista_iban($trow['ultilno']) == $trow['ultilno']) {
+    // Jos SEPA-maa, tarkistetaan IBAN ja SWIFT-koodi
+    if (tarkista_sepa($ibanmaa) and tarkista_iban($trow['ultilno']) == $trow['ultilno'] and $swift_ok) {
       $pankkitiliok = TRUE;
     }
     elseif (!tarkista_sepa($ibanmaa) and tarkista_bban($trow['ultilno']) !== FALSE) {
@@ -828,6 +838,7 @@ if ($tee == 'I') {
 
   if (!$pankkitiliok) {
     $errormsg .= "<font class='error'>".t("Pankkitili puuttuu tai on virheellinen")."!</font><br>";
+    $errormsg .= "<font class='error'>".t("Tarkista myös SWIFT-koodi")."!</font><br>";
     $tee = 'E';
   }
 }

--- a/ulask.php
+++ b/ulask.php
@@ -806,6 +806,13 @@ if ($tee == 'I') {
 
   // IBAN / BBAN
   if ($trow['ultilno'] != "") {
+    // Haetaan swift jos se puuttuu
+    if (empty($trow["swift"])) {
+      include "inc/pankkitiedot.inc";
+      $vastaus = pankkitiedot($trow['ultilno'], '');
+      $trow["swift"] = $vastaus['swift'];
+    }
+
     // Vaaditaan isot kirjaimet
     $trow['ultilno'] = strtoupper($trow['ultilno']);
     $trow['swift']   = strtoupper($trow['swift']);


### PR DESCRIPTION
Perustettaessa ostolasku ilman toimittajatietoja sai laskun perustettua ilman swift-koodia. Nyt on muutettu niin, että mikäli IBAN muotoisen tilinumero ilman swift-koodia syöttää, niin osataan swift koodia muodostaa automaattisesti. 

Päivitetty samalla swift-koodit ajantasaisiksi (rahalaitostunnus 36 on S-pankki eli swift SBANFIHH).