### PR TITLE
LogMaster max 22 merkkiä

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -27987,7 +27987,7 @@ if (!function_exists('posten_outbounddelivery')) {
       $line->addAttribute('No', $_line_i);
 
       $line->addChild('TransId', substr($looprow['tilausrivin_tunnus'], 0, 20));
-      $line->addChild('ItemNumber', utf8_encode(substr($looprow[$posten_itemnumberfield], 0, 20)));
+      $line->addChild('ItemNumber', utf8_encode(substr($looprow[$posten_itemnumberfield], 0, 22)));
       $line->addChild('CustItemNumber', 0);
       $line->addChild('ItemName', 0);
       $line->addChild('ItemText', 0);


### PR DESCRIPTION
LogMasterissa tuotekoodi max 22 merkkiä (tai 25 mutta kolme tarvitaan sisäiseen käyttöön).