### PR TITLE
Tuloutus: sarja- ja eränumerot

### DIFF
--- a/tilauskasittely/sarjanumeroseuranta.php
+++ b/tilauskasittely/sarjanumeroseuranta.php
@@ -1329,9 +1329,11 @@ if (is_resource($sarjaresiso) and mysql_num_rows($sarjaresiso) > 0) {
         $lisat_res = pupe_query($query);
         $lisat_row = mysql_fetch_assoc($lisat_res);
 
-        // Lukitaan sarjanumero
-        $sarjarow["osto_laskaika"] = date("Y-m-d");
-        $sarjarow["myyntirivitunnus"] = $lisat_row["tunnus"];
+        if ($lisat_row != "") {
+          // Lukitaan sarjanumero
+          $sarjarow["osto_laskaika"] = date("Y-m-d");
+          $sarjarow["myyntirivitunnus"] = $lisat_row["tunnus"];
+        }
       }
 
       if ($sarjarow["era_kpl"] < 0) {

--- a/tilauskasittely/sarjanumeroseuranta.php
+++ b/tilauskasittely/sarjanumeroseuranta.php
@@ -1459,7 +1459,8 @@ if (is_resource($sarjaresiso) and mysql_num_rows($sarjaresiso) > 0) {
           (($from == "riviosto" or $from == "kohdista") and $ostonhyvitysrivi != "ON" and $sarjarow["osto_laskaika"] > '0000-00-00' and ($sarjarow["siirtorivitunnus"] > 0 or $sarjarow["myyntirivitunnus"] > 0)) or
           ($valmiste_raakaine == "RAAKA-AINE" and ($sarjarow["myynti_toimitettuaika"] > "0000-00-00 00:00:00" or $sarjarow["myynti_laskaika"] > "0000-00-00")) or
           ($valmiste_raakaine == "VALMISTE" and ($sarjarow["osto_toimitettuaika"] > "0000-00-00 00:00:00" or $sarjarow["osto_laskaika"] > "0000-00-00")) or
-          ($from == "SIIRTOTYOMAARAYS" and $sarjarow["ostorivitunnus"] == 0)) {
+          ($from == "SIIRTOTYOMAARAYS" and $sarjarow["ostorivitunnus"] == 0) or
+          ($from == "kohdista" and $sarjarow["osto_laskaika"] > "0000-00-00")) {
           $dis = "DISABLED";
         }
         else {


### PR DESCRIPTION
Aiemmin jo tuloutettujen eränumerollisten ja sarjanumerollisten tuotteiden eränumeroita tai sarjanumeroita saattoi irroittaa saapumisten riveiltä. Nyt tämä on estetty, joten jos tuotteet on jo tuloutettu ei eränumeroa tai sarjanumeroa saa enää rivistä irroitettua.
