### PR TITLE
Yksittäinen hyvitysrivi myyntitilauksella

### DIFF
--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -3343,7 +3343,7 @@ if ($toimittamatta > 0 or trim($var) != '' or $rivityyppi == 'O') {
               jaksotettu      = '$jaksotettu'";
 
     if ($trow['ei_saldoa'] != '' and $yhtiorow["kerataanko_saldottomat"] == '') {
-      $query .= ", kerattyaika = now()";
+      $query .= ", keratty = '$kukarow[kuka]', kerattyaika = now()";
     }
 
     $result = pupe_query($query);

--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -3343,7 +3343,7 @@ if ($toimittamatta > 0 or trim($var) != '' or $rivityyppi == 'O') {
               jaksotettu      = '$jaksotettu'";
 
     if ($trow['ei_saldoa'] != '' and $yhtiorow["kerataanko_saldottomat"] == '') {
-      $query .= ", keratty = '$kukarow[kuka]', kerattyaika = now()";
+      $query .= ", keratty = 'saldoton', kerattyaika = now()";
     }
 
     $result = pupe_query($query);


### PR DESCRIPTION
Merkitään yksittäinen hyvitysrivi kerätyksi myyntitilauksella niin, että päivitetään myös keratty-tieto.

Jos näin ei tehdä ja maksusopimus-tilauksella on yksittäinen hyvitysrivi, loppulaskutus ei onnistunut, vaikka muut rivit olisi merkitty toimitetuksi