### PR TITLE
Sallitaan EIH-1.4.0 verkkolasku EU maihin.

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -24243,7 +24243,7 @@ if  (!function_exists('verkkolaskuputkeen')) {
     }
 
     // EU-viennit eivät mene verkkolaskuputkeen, paitsi jos CHN tai verkkolasku_vienti sallii verkkolaskutuksen
-    if ($lasrow["vienti"] == "E" and $yhtiorow['verkkolasku_vienti'] == "" and $lasrow["chn"] != "020" and $lasrow["chn"] != "030") {
+    if ($lasrow["vienti"] == "E" and $yhtiorow['verkkolasku_vienti'] == "" and $lasrow["chn"] != "020" and $lasrow["chn"] != "030" and $lasrow["chn"] != "111") {
       if ($info) {
         echo t("EU-vientiä");
       }


### PR DESCRIPTION
Itella EDI: EIH-1.4 sähköinen lasku -verkkolasku voidaan jatkossa lähettää myös EU-alueen asiakkaalle kotimaisten lisäksi.