### PR TITLE
Toimitustavat: nimen vaihtaminen

### DIFF
--- a/inc/toimitustapatarkista.inc
+++ b/inc/toimitustapatarkista.inc
@@ -81,7 +81,7 @@ if (!function_exists("toimitustapatarkista")) {
                   toimitustapa='$toita'
                   where toimitustapa='$trow[$i]'
                   and yhtio='$kukarow[yhtio]'
-                  and tila = 'L' and alatila in ('A','C')";
+                  and tila = 'L' and alatila != 'X'";
         $updre = pupe_query($query);
 
         echo ", ".mysql_affected_rows()." ".t("myyntitilaus otsikkoa");
@@ -99,7 +99,7 @@ if (!function_exists("toimitustapatarkista")) {
                   toimitustapa='$toita'
                   where toimitustapa='$trow[$i]'
                   and yhtio='$kukarow[yhtio]'
-                  and tila = 'G' and alatila in ('','J','KJ','A','C','T','P')";
+                  and tila = 'G' and alatila NOT IN ('V', 'X')";
         $updre = pupe_query($query);
 
         echo ", ".mysql_affected_rows()." ".t("siirtolista otsikkoa");

--- a/inc/toimitustapatarkista.inc
+++ b/inc/toimitustapatarkista.inc
@@ -126,7 +126,7 @@ if (!function_exists("toimitustapatarkista")) {
                   toimitustapa='$toita'
                   where toimitustapa='$trow[$i]'
                   and yhtio='$kukarow[yhtio]'
-                  and tila = 'V' and alatila in ('','K','J','A','C')";
+                  and tila = 'V' and alatila != 'V'";
         $updre = pupe_query($query);
 
         echo ", ".mysql_affected_rows()." ".t("valmistus otsikkoa");


### PR DESCRIPTION
Toimitustavan nimen vaihtaminen ei päivittänyt uutta nimeä kaikissa tiloissa oleville tilauksille tai siirtolistoille. Korjattu nyt niin, että kaikkien paitsi laskutettujen tilausten kohdalla ja kaikkien paitsi vastaanotettujen siirtolistojen kohdalla päivitetään toimitustavan nimi.