### PR TITLE
Myyntitilaus: luottoraja ylittynyt-teksti

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -5627,8 +5627,8 @@ if ($tee == '') {
   }
   elseif ($_mika_toim and $_kat_jv) {
 
-    if (!empty($laskurow['luottoraja'])) {
-      if (!empty($asiakasrow['luottoraja'])) {
+    if ((float) $laskurow['luottoraja'] != 0) {
+      if ((float) $asiakasrow['luottoraja'] != 0) {
 
         $query_ale_lisa = generoi_alekentta('M');
 


### PR DESCRIPTION
HUOM: Luottoraja ylittynyt teksti saattoi tulla myyntitilaukselle, vaikka luottoraja ei olisi ollut edes käytössä asiakkaalla. Tämä on nyt korjattu ja teksti ei tule enää virheellisesti näkyviin.