### PR TITLE
Logmaster: QoL muutoksia

### DIFF
--- a/extranet/extranet_siirto.sh
+++ b/extranet/extranet_siirto.sh
@@ -84,6 +84,7 @@ index.php
 ylaframe.php
 pikavalinnat.php
 korvaavat.class.php
+rajapinnat/logmaster/logmaster-functions.php
 raportit/asiakasinfo.php
 raportit/naytatilaus.inc
 raportit/osasto_tuotemerkeittain.php

--- a/rajapinnat/logmaster/logmaster-functions.php
+++ b/rajapinnat/logmaster/logmaster-functions.php
@@ -409,6 +409,8 @@ if (!function_exists('logmaster_outbounddelivery')) {
 
 if (!function_exists('logmaster_check_params')) {
   function logmaster_check_params($toim) {
+    global $kukarow, $yhtiorow;
+
     $onkologmaster  = LOGMASTER_RAJAPINTA;
     $onkologmaster &= (in_array($yhtiorow['ulkoinen_jarjestelma'], array('', 'K')));
     $onkologmaster &= (in_array($toim, array('RIVISYOTTO','PIKATILAUS')));

--- a/rajapinnat/logmaster/logmaster-functions.php
+++ b/rajapinnat/logmaster/logmaster-functions.php
@@ -436,7 +436,7 @@ if (!function_exists('logmaster_verify_order')) {
     $onkologmaster &= (in_array($toim, array('RIVISYOTTO','PIKATILAUS')));
 
     if ($onkologmaster === false) {
-      return false;
+      return array();
     }
 
     # Tarkistetaan onko Logmasteriin meneviä tilausrivejä
@@ -446,7 +446,7 @@ if (!function_exists('logmaster_verify_order')) {
     $varastotunnukset = logmaster_warehouses();
 
     if ($varastotunnukset === false) {
-      return false;
+      return array();
     }
 
     $query = "SELECT lasku.*, maksuehto.jv

--- a/rajapinnat/logmaster/logmaster-functions.php
+++ b/rajapinnat/logmaster/logmaster-functions.php
@@ -477,18 +477,15 @@ if (!function_exists('logmaster_verify_order')) {
               AND tilausrivi.varasto IN ({$varastotunnukset})";
     $logmaster_rivi_res = pupe_query($query);
 
-    if (mysql_num_rows($logmaster_rivi_res) > 0) {
+    while ($logmaster_rivi_row = mysql_fetch_assoc($logmaster_rivi_res)) {
+      if ($logmaster_rivi_row['sarjanumeroseuranta'] != '') {
+        $errors[] = t("VIRHE: Sarjanumeroseurannassa olevia tuotteita ei sallita ulkoisessa varastossa")."!";
+      }
 
-      while ($logmaster_rivi_row = mysql_fetch_assoc($logmaster_rivi_res)) {
-        if ($logmaster_rivi_row['sarjanumeroseuranta'] != '') {
-          $errors[] = t("VIRHE: Sarjanumeroseurannassa olevia tuotteita ei sallita ulkoisessa varastossa")."!";
-        }
+      $logmaster_kpl = $logmaster_rivi_row['varattu'] + $logmaster_rivi_row['kpl'];
 
-        $logmaster_kpl = $logmaster_rivi_row['varattu'] + $logmaster_rivi_row['kpl'];
-
-        if (fmod($logmaster_kpl, 1) != 0) {
-          $errors[] = t("VIRHE: Ulkoinen varasto tukee vain kokonaislukuja")."!";
-        }
+      if (fmod($logmaster_kpl, 1) != 0) {
+        $errors[] = t("VIRHE: Ulkoinen varasto tukee vain kokonaislukuja")."!";
       }
     }
 

--- a/rajapinnat/logmaster/logmaster-functions.php
+++ b/rajapinnat/logmaster/logmaster-functions.php
@@ -446,13 +446,29 @@ if (!function_exists('logmaster_warehouses')) {
 }
 
 if (!function_exists('logmaster_fetch_rows')) {
-  function logmaster_fetch_rows($tunnus) {
+  function logmaster_fetch_rows($tunnus, $otunnus = 0) {
     global $kukarow;
 
     $varastotunnukset = logmaster_warehouses();
 
     if ($varastotunnukset === false) {
       return false;
+    }
+
+    $wherelisa = '';
+    $tunnus    = (int) $tunnus;
+    $otunnus   = (int) $otunnus;
+
+    if (empty($tunnus) and empty($otunnus)) {
+      return false;
+    }
+
+    if (!empty($tunnus)) {
+      $wherelisa = " AND tilausrivi.tunnus  = '{$tunnus}' ";
+    }
+
+    if (!empty($otunnus)) {
+      $wherelisa = " AND tilausrivi.otunnus  = '{$otunnus}' ";
     }
 
     $query = "SELECT tilausrivi.*, tuote.sarjanumeroseuranta
@@ -463,7 +479,7 @@ if (!function_exists('logmaster_fetch_rows')) {
                 tuote.ei_saldoa = ''
               )
               WHERE tilausrivi.yhtio  = '{$kukarow['yhtio']}'
-              AND tilausrivi.tunnus  = '{$tunnus}'
+              {$wherelisa}
               AND tilausrivi.var     != 'J'
               AND tilausrivi.varasto IN ({$varastotunnukset})";
     $logmaster_res = pupe_query($query);
@@ -530,7 +546,7 @@ if (!function_exists('logmaster_verify_order')) {
     $laskurow = mysql_fetch_assoc($laskures);
 
     # Tarkistetaan onko Logmasteriin meneviä tilausrivejä
-    $logmaster_rivi_res = logmaster_fetch_rows($tunnus);
+    $logmaster_rivi_res = logmaster_fetch_rows(0, $tunnus);
 
     if ($logmaster_rivi_res === false) {
       return array();

--- a/rajapinnat/logmaster/logmaster-functions.php
+++ b/rajapinnat/logmaster/logmaster-functions.php
@@ -419,7 +419,7 @@ if (!function_exists('logmaster_warehouses')) {
     $varastores = pupe_query($query);
     $varastorow = mysql_fetch_assoc($varastores);
 
-    return !empty($varastorow['tunnukset']) ? $varastorow['tunnukset'] : false;
+    return empty($varastorow['tunnukset']) ? false : $varastorow['tunnukset'];
   }
 }
 

--- a/rajapinnat/logmaster/outbound_delivery.php
+++ b/rajapinnat/logmaster/outbound_delivery.php
@@ -70,6 +70,10 @@ $query = "SELECT DISTINCT lasku.tunnus
             maksuehto.yhtio = lasku.yhtio AND
             maksuehto.tunnus = lasku.maksuehto
           )
+          LEFT JOIN kuka ON (
+            kuka.yhtio = lasku.yhtio AND
+            kuka.kesken = lasku.tunnus
+          )
           WHERE lasku.yhtio = '{$kukarow['yhtio']}'
           AND (
             (lasku.tila = 'N' AND lasku.alatila = 'A') OR
@@ -82,19 +86,11 @@ $query = "SELECT DISTINCT lasku.tunnus
           )
           AND NOW() >= DATE_ADD(lasku.h1time, INTERVAL 15 MINUTE)
           AND lasku.lahetetty_ulkoiseen_varastoon IS NULL
-          AND (maksuehto.jv IS NULL OR maksuehto.jv = '')";
+          AND (maksuehto.jv IS NULL OR maksuehto.jv = '')
+          AND kuka.kesken IS NULL";
 $laskures = pupe_query($query);
 
 while ($laskurow = mysql_fetch_assoc($laskures)) {
-
-  // katsotaan onko muilla aktiivisena
-  $result = tilaus_aktiivinen_kayttajalla($laskurow['tunnus']);
-
-  if (mysql_num_rows($result) != 0) {
-    pupesoft_log('logmaster_outbound_delivery', "Tilaus on aktiivisena k‰ytt‰j‰ll‰ {$row['nimi']} ({$row['kuka']}). Tilausta ei voi t‰ll‰ hetkell‰ l‰hett‰‰.");
-    continue;
-  }
-
   $filename = logmaster_outbounddelivery($laskurow['tunnus']);
 
   if ($filename === false) {

--- a/rajapinnat/logmaster/resend_logmaster.php
+++ b/rajapinnat/logmaster/resend_logmaster.php
@@ -47,9 +47,7 @@ if ($tee == "laheta" and $tilaukset != "") {
       $palautus = logmaster_send_file($filename);
 
       if ($palautus == 0) {
-        if (is_null($laskurow['lahetetty_ulkoiseen_varastoon'])) {
-          logmaster_sent_timestamp($laskurow['tunnus']);
-        }
+        logmaster_sent_timestamp($laskurow['tunnus']);
 
         pupesoft_log('logmaster_outbound_delivery', "Siirretiin tilaus {$laskurow['tunnus']}.");
         echo t("Siirretiin tilaus %d", '', $laskurow['tunnus'])."<br>";

--- a/rajapinnat/logmaster/resend_logmaster.php
+++ b/rajapinnat/logmaster/resend_logmaster.php
@@ -47,6 +47,10 @@ if ($tee == "laheta" and $tilaukset != "") {
       $palautus = logmaster_send_file($filename);
 
       if ($palautus == 0) {
+        if (is_null($laskurow['lahetetty_ulkoiseen_varastoon'])) {
+          logmaster_sent_timestamp($laskurow['tunnus']);
+        }
+
         pupesoft_log('logmaster_outbound_delivery', "Siirretiin tilaus {$laskurow['tunnus']}.");
         echo t("Siirretiin tilaus %d", '', $laskurow['tunnus'])."<br>";
       }

--- a/rajapinnat/logmaster/stock_report.php
+++ b/rajapinnat/logmaster/stock_report.php
@@ -84,13 +84,14 @@ while (false !== ($file = readdir($handle))) {
   $saldoeroja = array();
 
   foreach ($xml->InvCounting->Line as $line) {
-    $eankoodi = $line->ItemNumber;
-    $kpl = (float) $line->Quantity;
+    $item_number               = $line->ItemNumber;
+    $kpl                       = (float) $line->Quantity;
+    $logmaster_itemnumberfield = logmaster_field('ItemNumber');
 
     $query = "SELECT tuoteno, nimitys
               FROM tuote
               WHERE yhtio  = '{$kukarow['yhtio']}'
-              AND eankoodi = '{$eankoodi}'";
+              AND {$logmaster_itemnumberfield} = '{$item_number}'";
     $tuoteres = pupe_query($query);
     $tuoterow = mysql_fetch_assoc($tuoteres);
 
@@ -121,7 +122,7 @@ while (false !== ($file = readdir($handle))) {
 
     if ($a != $b) {
       $saldoeroja[] = array(
-        "item"      => $line->ItemNumber,
+        "item"      => $item_number,
         "logmaster" => $kpl,
         "nimitys"   => $tuoterow['nimitys'],
         "pupe"      => $hyllyssa,

--- a/rajapinnat/logmaster/tracking_code.php
+++ b/rajapinnat/logmaster/tracking_code.php
@@ -60,7 +60,8 @@ while (false !== ($file = readdir($handle))) {
     continue;
   }
 
-  $filehandle = fopen($full_filepath, "r");
+  $filehandle     = fopen($full_filepath, "r");
+  $seurantakoodit = array();
 
   while ($tietue = fgets($filehandle)) {
     // Tyhjät rivit skipataan
@@ -93,6 +94,14 @@ while (false !== ($file = readdir($handle))) {
       continue;
     }
 
+    $seurantakoodit[$tilausnumero][] = $seurantakoodi;
+  }
+
+  foreach ($seurantakoodit as $tilausnumero => $koodit) {
+
+    $koodit        = array_unique($koodit);
+    $seurantakoodi = implode(' ', $koodit);
+
     $query = "UPDATE rahtikirjat SET
               rahtikirjanro  = trim(concat(rahtikirjanro, ' ', '{$seurantakoodi}')),
               tulostettu     = now()
@@ -117,6 +126,7 @@ while (false !== ($file = readdir($handle))) {
       'otunnukset' => $tilausnumero,
       'kilotyht' => $kilotrow['kilotyht']
     );
+
     paivita_rahtikirjat_tulostetuksi_ja_toimitetuksi($params);
 
     pupesoft_log('logmaster_tracking_code', "Tilauksen {$tilausnumero} seurantakoodisanoma käsitelty");

--- a/tilauskasittely/lahetteen_tulostusjono.php
+++ b/tilauskasittely/lahetteen_tulostusjono.php
@@ -1391,7 +1391,7 @@ if ($tee2 == '') {
     echo t("Rivejä yhteensä")."</th>";
     echo "<th>".$riveja_yht."</th>";
 
-    $spanni = ($yhtiorow["pakkaamolokerot"] != "" or $logistiikka_yhtio != '') ? 4 : 3;
+    $spanni = 4;
 
     if ($toim == "VASTAANOTA_REKLAMAATIO") {
       $spanni++;

--- a/tilauskasittely/lahetteen_tulostusjono.php
+++ b/tilauskasittely/lahetteen_tulostusjono.php
@@ -1333,6 +1333,17 @@ if ($tee2 == '') {
 
         if ($onkologmaster_varasto) {
           echo t("Ulkoisen varaston tilaus");
+
+          $keskenres = tilaus_aktiivinen_kayttajalla($tilrow['otunnus']);
+
+          if (mysql_num_rows($keskenres) != 0) {
+            $keskenrow = mysql_fetch_assoc($keskenres);
+
+            echo "<br>";
+            echo "<font class='error'>";
+            echo t("Tilaus on kesken käyttäjällä %s (%s)", "", $keskenrow['nimi'], $keskenrow['kuka']);
+            echo "</font>";
+          }
         }
         else {
           echo "<input type='submit' value='".t("Tulosta")."'>";

--- a/tilauskasittely/tarkistarivi.inc
+++ b/tilauskasittely/tarkistarivi.inc
@@ -132,6 +132,16 @@ if (isset($alkupera_trow) and $yhtiorow["korvaavat_hyvaksynta"] != "" and $alkup
   $saako_hyvaksya++;
 }
 
+$logmaster_errors = logmaster_verify_row($row['tunnus'], $toim);
+
+foreach ($logmaster_errors as $error) {
+  echo "<font class='error'>";
+  echo "{$error}<br><br>";
+  echo "</font>";
+  $tilausok++;
+  $riviok++;
+}
+
 if ($kukarow['extranet'] != '' and $trow['sarjanumeroseuranta'] != '' and $row['varattu'] != 1) {
   $varaosavirhe .= t("HUOM: T‰m‰ on sarjanumeroseurannallinen tuote. Kappalem‰‰r‰ pit‰‰ olla 1")."!<br>";
   $riviok++;

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -3486,7 +3486,17 @@ if ($tee == '') {
     }
   }
 
-  if (!logmaster_verify_order($tunnus, $toim)) {
+  $logmaster_errors = logmaster_verify_order($tunnus, $toim);
+
+  if (is_array($logmaster_errors) and count($logmaster_errors) > 0) {
+    echo "<font class='error'>";
+
+    foreach ($logmaster_errors as $error) {
+      echo "{$error}<br><br>";
+    }
+
+    echo "</font>";
+
     $tilausok++;
   }
 

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -3486,6 +3486,10 @@ if ($tee == '') {
     }
   }
 
+  if (!logmaster_verify_order($tunnus, $toim)) {
+    $tilausok++;
+  }
+
   $_tm_saldoaikalisa = "";
 
   if (!empty($yhtiorow["saldo_kasittely"])) {

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -37,7 +37,9 @@ if (@include "../inc/parametrit.inc");
 elseif (@include "parametrit.inc");
 else exit;
 
-require "rajapinnat/logmaster/logmaster-functions.php";
+if (@include "rajapinnat/logmaster/logmaster-functions.php");
+elseif (@include "logmaster-functions.php");
+else exit;
 
 if ($yhtiorow['tilausrivin_esisyotto'] == 'K' and isset($ajax_toiminto) and trim($ajax_toiminto) == 'esisyotto_kate') {
 
@@ -3488,15 +3490,6 @@ if ($tee == '') {
     }
   }
 
-  $logmaster_errors = logmaster_verify_order($tunnus, $toim);
-
-  foreach ($logmaster_errors as $error) {
-    echo "<font class='error'>";
-    echo "{$error}<br><br>";
-    echo "</font>";
-    $tilausok++;
-  }
-
   $_tm_saldoaikalisa = "";
 
   if (!empty($yhtiorow["saldo_kasittely"])) {
@@ -5488,6 +5481,15 @@ if ($tee == '') {
     $toimaika       = "";
     $tuoteno       = "";
     $var = "";
+  }
+
+  $logmaster_errors = logmaster_verify_order($laskurow['tunnus'], $toim);
+
+  foreach ($logmaster_errors as $error) {
+    echo "<font class='error'>";
+    echo "{$error}<br><br>";
+    echo "</font>";
+    $tilausok++;
   }
 
   $numres_saatavt  = 0;

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -37,6 +37,8 @@ if (@include "../inc/parametrit.inc");
 elseif (@include "parametrit.inc");
 else exit;
 
+require "rajapinnat/logmaster/logmaster-functions.php";
+
 if ($yhtiorow['tilausrivin_esisyotto'] == 'K' and isset($ajax_toiminto) and trim($ajax_toiminto) == 'esisyotto_kate') {
 
   $lquery = "SELECT *
@@ -3488,15 +3490,10 @@ if ($tee == '') {
 
   $logmaster_errors = logmaster_verify_order($tunnus, $toim);
 
-  if (count($logmaster_errors) > 0) {
+  foreach ($logmaster_errors as $error) {
     echo "<font class='error'>";
-
-    foreach ($logmaster_errors as $error) {
-      echo "{$error}<br><br>";
-    }
-
+    echo "{$error}<br><br>";
     echo "</font>";
-
     $tilausok++;
   }
 

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -3488,7 +3488,7 @@ if ($tee == '') {
 
   $logmaster_errors = logmaster_verify_order($tunnus, $toim);
 
-  if (is_array($logmaster_errors) and count($logmaster_errors) > 0) {
+  if (count($logmaster_errors) > 0) {
     echo "<font class='error'>";
 
     foreach ($logmaster_errors as $error) {


### PR DESCRIPTION
- "Logmaster-functions"-tiedosto siirretään myös extranettiin
- Näytetään "Tulosta keräyslista"-näkymässä kenellä ulkoisen varaston tilaus on kesken
- Stock report käyttää nyt logmaster_field-funktiota
- Tracking code -ohjelmaa muutettu niin että päivitetään yhden rahtikirjan seurantakoodit kerralla
- Korjattu "Tulosta keräyslista"-taulukon yhteensä-rivi
- Lähtevän sanoman uudelleen lähetys päivittää aikaleiman jos sitä ei ole asetettu
- Ulkoisen järjestelmän tilauksella:
 - Maksuehto ei saa olla jälkivaatimus
 - Ei saa sisältää sarjanumeroseurannassa olevia tuotteita
 - Rivien kappalemäärät täytyy olla kokonaislukuja