### PR TITLE
Rahtikirjat: kollimäärät

### DIFF
--- a/rahtikirja.php
+++ b/rahtikirja.php
@@ -171,7 +171,13 @@ if ($tee == 'add' and $id == 'dummy' and $mista == 'rahtikirja-tulostus.php') {
   }
   else {
     $toim = 'lisaa';
-    echo "<font class='error'>".t("Kollien määrä on pakollinen")."</font><br>";
+
+    if ($kollit[$i] == '' and strpos($kilot[$i], "/") === FALSE) {
+      echo "<font class='error'>".t("Kollien määrä on pakollinen")."</font><br>";
+    }
+    else {
+      echo "<font class='error'>".t("Syötä kilot, kuutiot tai lavametrit")."</font><br>";
+    }
   }
 }
 

--- a/rahtikirja.php
+++ b/rahtikirja.php
@@ -124,7 +124,7 @@ if ($tee == 'add' and $id == 'dummy' and $mista == 'rahtikirja-tulostus.php') {
 
   // katotaan ollaanko syötetty jotain
   for ($i = 0; $i < count($pakkaus); $i++) {
-    if (($kilot[$i] != '' or $kollit[$i] != '' or $kuutiot[$i] != '' or $lavametri[$i] != '') and $subnappi != '') {
+    if (($kollit[$i] != '' or strpos($kilot[$i], "/") !== FALSE) and ($kilot[$i] != '' or $kuutiot[$i] != '' or $lavametri[$i] != '') and $subnappi != '') {
       $tutkimus++;
     }
   }
@@ -414,7 +414,7 @@ if ($rahtikirjan_esisyotto != "" and $tee == "add" and $yhtiorow["rahtikirjojen_
 
   // katotaan ollaanko syötetty jotain
   for ($i = 0; $i < count($pakkaus); $i++) {
-    if (($kilot[$i] != '' or $kollit[$i] != '' or $kuutiot[$i] != '' or $lavametri[$i] != '') and $subnappi != '') {
+    if (($kollit[$i] != '' or strpos($kilot[$i], "/") !== FALSE) and ($kilot[$i] != '' or $kuutiot[$i] != '' or $lavametri[$i] != '') and $subnappi != '') {
       $kilot[$i]    = str_replace(',', '.', $kilot[$i]);
       $kollit[$i]     = str_replace(',', '.', $kollit[$i]);
       $kuutiot[$i]  = str_replace(',', '.', $kuutiot[$i]);
@@ -478,7 +478,7 @@ if ($tee == 'add') {
 
   // katotaan ollaanko syötetty jotain
   for ($i = 0; $i < count($pakkaus); $i++) {
-    if (($kilot[$i] != '' or $kollit[$i] != '' or $kuutiot[$i] != '' or $lavametri[$i] != '') and $subnappi != '') {
+    if (($kollit[$i] != '' or strpos($kilot[$i], "/") !== FALSE) and ($kilot[$i] != '' or $kuutiot[$i] != '' or $lavametri[$i] != '') and $subnappi != '') {
       $tutkimus++;
     }
   }

--- a/rahtikirja.php
+++ b/rahtikirja.php
@@ -484,9 +484,15 @@ if ($tee == 'add') {
     }
   }
 
-  if ($tutkimus == 0 and $kollit[$i] == '' and strpos($kilot[$i], "/") === FALSE) {
+  if ($tutkimus == 0) {
     $toim = 'lisaa';
-    echo "<font class='error'>".t("Kollien määrä on pakollinen")."</font><br>";
+
+    if ($kollit[$i] == '' and strpos($kilot[$i], "/") === FALSE) {
+      echo "<font class='error'>".t("Kollien määrä on pakollinen")."</font><br>";
+    }
+    else {
+      echo "<font class='error'>".t("Syötä kilot, kuutiot tai lavametrit")."</font><br>";
+    }
   }
 
   // jos ollaan muokkaamassa rivejä poistetaan eka vanhat rahtikirjatiedot..

--- a/rahtikirja.php
+++ b/rahtikirja.php
@@ -171,6 +171,7 @@ if ($tee == 'add' and $id == 'dummy' and $mista == 'rahtikirja-tulostus.php') {
   }
   else {
     $toim = 'lisaa';
+    echo "<font class='error'>".t("Kollien m‰‰r‰ on pakollinen")."</font><br>";
   }
 }
 
@@ -483,6 +484,11 @@ if ($tee == 'add') {
     }
   }
 
+  if ($tutkimus == 0 and $kollit[$i] == '' and strpos($kilot[$i], "/") === FALSE) {
+    $toim = 'lisaa';
+    echo "<font class='error'>".t("Kollien m‰‰r‰ on pakollinen")."</font><br>";
+  }
+
   // jos ollaan muokkaamassa rivej‰ poistetaan eka vanhat rahtikirjatiedot..
   if ($tutkimus > 0 and $tunnukset != "") {
 
@@ -622,7 +628,7 @@ if ($tee == 'add') {
 
       if ($k_rahtikulut > 0) {
 
-        $rahtituotenumerot = "'{$yhtiorow['rahti_tuotenumero']}'"; 
+        $rahtituotenumerot = "'{$yhtiorow['rahti_tuotenumero']}'";
         $rahtituotenumerot = lisaa_vaihtoehtoinen_rahti_merkkijonoon($rahtituotenumerot);
 
         $query = "UPDATE tilausrivi
@@ -3020,7 +3026,7 @@ if (($id == 'dummy' and $mista == 'rahtikirja-tulostus.php') or $id != 0) {
 
         $rahtituotenumerot = "'{$yhtiorow['rahti_tuotenumero']}'";
         $rahtituotenumerot = lisaa_vaihtoehtoinen_rahti_merkkijonoon($rahtituotenumerot);
-        
+
         $query = "SELECT
                   round(sum(tilausrivi.hinta / if('$yhtiorow[alv_kasittely]'  = '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.jt) * {$query_ale_lisa}),2) arvo,
                   round(sum(tilausrivi.hinta * if('$yhtiorow[alv_kasittely]' != '' and tilausrivi.alv < 500, (1+tilausrivi.alv/100), 1) * (tilausrivi.varattu+tilausrivi.jt) * {$query_ale_lisa}),2) summa


### PR DESCRIPTION
Rahtikirjan tietojen syötössä pystyi jättämään kollimäärä kohdan tyhjäksi. Tämä aiheutti ongelmia rahtikirjan muokkauksessa ja rahtikirjan heti-tulostuksessa. Korjattu nyt niin, että rahtikirjan tietojen syötössä on kollimäärä syötettävä tai kilot /-syntaksilla.