### PR TITLE
QoL: Bugikorjauksia

### DIFF
--- a/crm/asiakasmemo.php
+++ b/crm/asiakasmemo.php
@@ -1111,6 +1111,13 @@ if ($ytunnus != '' and $tee == '') {
   $res = pupe_query($query);
 
   while ($memorow = mysql_fetch_array($res)) {
+
+    $liitetiedostot = listaaliitetiedostot($memorow['tunnus'], $memorow['tyyppi']);
+
+    if ($liitetiedostot != '') {
+      echo "<tr><th colspan='2'>".t("Liitetiedosto")."</th><td colspan='4'>".$liitetiedostot."</td></tr>";
+    }
+
     if ($memorow["tapa"] == "asiakasanalyysi") {
       echo "<tr>
         <th>$memorow[tyyppi]</th><th>$memorow[laatija]</th><th>$memorow[laatija]@$memorow[paivamaara]
@@ -1223,12 +1230,6 @@ if ($ytunnus != '' and $tee == '') {
     }
 
     echo "</td></tr>";
-
-    $liitetiedostot = listaaliitetiedostot($memorow['tunnus'], $memorow['tyyppi']);
-
-    if ($liitetiedostot != '') {
-      echo "<tr><th colspan='2'>".t("Liitetiedosto")."</th><td colspan='4'>".$liitetiedostot."</td></tr>";
-    }
   }
 
   echo "</table>";

--- a/rahtikirja_custom.php
+++ b/rahtikirja_custom.php
@@ -251,6 +251,9 @@ if ((isset($tulosta) or isset($tulostakopio)) and $otsikkonro > 0) {
     }
   }
 
+  $osoitelappurow['viitelah'] = $data['viitelah'][0];
+  $osoitelappurow['viitevas'] = $data['viitevas'][0];
+
   // haetaan varaston osoitetiedot, k‰ytet‰‰n niit‰ l‰hetystietoina
   $query = "SELECT nimi, nimitark, osoite, postino, postitp, maa
             FROM varastopaikat
@@ -928,6 +931,8 @@ function pupe_rahtikirja_fetch($otsikkonro) {
     'kollityht'      => 0,
     'kuutiotyht'    => 0,
     'lavametriyht'    => 0,
+    'viitelah' => '',
+    'viitevas' => '',
     'tyhjanrahtikirjan_otsikkotiedot' => array(),
   );
 
@@ -948,6 +953,8 @@ function pupe_rahtikirja_fetch($otsikkonro) {
     $data['kuutiot'][$i]       = $rahtikirja['kuutiot'];
     $data['lavametri'][$i]     = $rahtikirja['lavametri'];
     $data['toimitustapa'][$i]   = $rahtikirja['toimitustapa'];
+    $data['viitelah'][$i] = $rahtikirja['viitelah'];
+    $data['viitevas'][$i] = $rahtikirja['viitevas'];
     $data['tyhjanrahtikirjan_otsikkotiedot'][$i] = $rahtikirja['tyhjanrahtikirjan_otsikkotiedot'];
 
     // lis‰t‰‰n totaaleja

--- a/raportit/asiakkaantilaukset.php
+++ b/raportit/asiakkaantilaukset.php
@@ -125,7 +125,7 @@ if ($tee == "NAYTA" and $til != "") {
 js_popup();
 enable_ajax();
 
-if ($tee != 'NAYTATILAUS' and $ytunnus == '' and $otunnus == '' and $laskunro == '' and $sopimus == '' and $kukarow['kesken'] != 0 and $til != '') {
+if ($tee != 'NAYTATILAUS' and empty($vaihda) and $ytunnus == '' and $otunnus == '' and $laskunro == '' and $sopimus == '' and $kukarow['kesken'] != 0 and $til != '') {
 
   $query = "SELECT ytunnus, liitostunnus
             FROM lasku

--- a/raportit/asiakkaantilaukset.php
+++ b/raportit/asiakkaantilaukset.php
@@ -833,7 +833,7 @@ else {
   echo "<form action = 'asiakkaantilaukset.php' method = 'post'>
     <input type='hidden' name='toim' value='$toim'>
     <input type='hidden' name='lopetus' value='$lopetus'>";
-  echo "<br><input type='submit' value='".t("Tee uusi haku")."'>";
+  echo "<br><input name='vaihda' type='submit' value='".t("Tee uusi haku")."'>";
   echo "</form>";
 }
 

--- a/raportit/asiakkaantilaukset.php
+++ b/raportit/asiakkaantilaukset.php
@@ -125,7 +125,7 @@ if ($tee == "NAYTA" and $til != "") {
 js_popup();
 enable_ajax();
 
-if ($tee != 'NAYTATILAUS' and empty($vaihda) and $ytunnus == '' and $otunnus == '' and $laskunro == '' and $sopimus == '' and $kukarow['kesken'] != 0 and $til != '') {
+if ($tee != 'NAYTATILAUS' and empty($vaihda) and $ytunnus == '' and $tilausviite == '' and $astilnro == '' and $otunnus == '' and $laskunro == '' and $sopimus == '' and $kukarow['kesken'] != 0 and $til != '') {
 
   $query = "SELECT ytunnus, liitostunnus
             FROM lasku

--- a/tilauskasittely/rahtikirja_pdf.inc
+++ b/tilauskasittely/rahtikirja_pdf.inc
@@ -55,6 +55,9 @@ elseif ($osoitelappurow["toim_nimi"] != '') {
   // tänne tullaan, jos ollaan oltu rahtikirja_custom.phpssä
   $postirow = $osoitelappurow;
   $rakir_row = $osoitelappurow;
+
+  $viitelah = $osoitelappurow['viitelah'];
+  $viitevas = $osoitelappurow['viitevas'];
 }
 else {
   $query = "SELECT asiakas.*, rahtikirjat.merahti, rahtikirjat.rahtisopimus

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -6418,6 +6418,7 @@ if ($tee == '') {
                $kehahin_select kehahin,
                tuote.sarjanumeroseuranta,
                tuote.yksikko,
+               tilausrivi.yksikko AS tilausrivin_yksikko,
                tuote.status,
                tuote.ei_saldoa,
                tuote.vakkoodi,
@@ -8141,7 +8142,7 @@ if ($tee == '') {
           }
           elseif (in_array($toim, array('VALMISTAVARASTOON', 'VALMISTAASIAKKAALLE', 'RIVISYOTTO', 'PIKATILAUS'))) {
             echo "<td {$class} align='right' nowrap>";
-            echo "{$kpl_ruudulle} ".strtolower($row["yksikko"]);
+            echo "{$kpl_ruudulle} ".strtolower($row["tilausrivin_yksikko"]);
 
             if ($sahkoinen_tilausliitanta and isset($vastaavat_html) and trim($vastaavat_html) != '' and isset($vastaavat_table2) and trim($vastaavat_table2) != '' and isset($paarivin_saldokysely) and $paarivin_saldokysely and in_array($row['var'], array('U', 'T'))) {
               echo "<br />", $vastaavat_table2;


### PR DESCRIPTION
- Tilaus-myynti näyttää nyt tilausrivin yksikön tuote yksikön sijaan.
- Asiakasmemon lisättyjen memomerkintöjen liitetiedoston esitystapaa korjattu.
- Asiakkaan tilaukset "Vaihda asiakas"- ja "Tee uusi haku"-nappi korjattu. Antaa jatkossa tehdä uuden haun, mutta päävalikosta tultaessa ohjelmaan muistaa vielä kesken olevan myyntitilauksen asiakkuuden.
- Tyhjän rahtikirjan "Lähettäjän viite" ja "Vastaanottajan viite" kentät osataan näyttää PDF:llä