### PR TITLE
* Hintalappujen tulostus (6.2x2.9cm)

### DIFF
--- a/tilauskasittely/tulosta_hintalaput.inc
+++ b/tilauskasittely/tulosta_hintalaput.inc
@@ -18,8 +18,14 @@ require_once "barcode/c128cobject.php";
 
 
 function tulosta_hintalaput($tuotteet, $params = array()) {
-  $kpl  = isset($params["kpl"]) ? $params["kpl"] : false;
-  $koko = isset($params["koko"]) ? $params["koko"] :'4.9x3cm';
+  $kpl           = isset($params["kpl"])           ? $params["kpl"]           : false;
+  $koko          = isset($params["koko"])          ? $params["koko"]          :'4.9x3cm';
+  $barcode_field = isset($params["barcode_field"]) ? $params["barcode_field"] :'tuoteno';
+
+  $barcode_map = array(
+    'tuoteno'  => 'code128',
+    'eankoodi' => 'ean',
+  );
 
   $pdf = new pdffile();
 
@@ -40,13 +46,20 @@ function tulosta_hintalaput($tuotteet, $params = array()) {
 
   switch ($koko) {
   case '6.2x2.9cm':
-    $viivakoodi_leveys       = 600;
-    $viivakoodi_vasen        = 2;
-    $viivakoodi_teksti_vasen = 2;
-    $viivakoodin_asetukset   = array("scale" => array("x" => 0.1, "y" => 0.1));
-    $kompensaatio            = -2;
-    $hinta_x                 = 140;
-    $yksikko_x               = 168;
+    if ($barcode_field == 'tuoteno') {
+      $viivakoodi_vasen        = 2;
+      $viivakoodi_teksti_vasen = 2;
+    }
+    else {
+      $viivakoodi_vasen        = -5;
+      $viivakoodi_teksti_vasen = 60;
+    }
+
+    $viivakoodi_leveys     = 600;
+    $viivakoodin_asetukset = array("scale" => array("x" => 0.1, "y" => 0.1));
+    $kompensaatio          = -2;
+    $hinta_x               = 140;
+    $yksikko_x             = 168;
     break;
   default:
     $viivakoodi_leveys       = 360;
@@ -61,8 +74,8 @@ function tulosta_hintalaput($tuotteet, $params = array()) {
   foreach ($tuotteet as $tuote) {
     $nimitys            = explode("\n", wordwrap($tuote['nimitys'], 28));
     $hinta              = hintapyoristys($tuote['myyntihinta']);
-    $viivakoodi         = viivakoodi($tuote['tuoteno'], "code128", $viivakoodi_leveys, 60);
-    $viivakoodin_teksti = $tuote['tuoteno'];
+    $viivakoodi         = viivakoodi($tuote[$barcode_field], $barcode_map[$barcode_field], $viivakoodi_leveys, 60);
+    $viivakoodin_teksti = $tuote[$barcode_field];
     $kuva               = $pdf->jfif_embed($viivakoodi);
 
     if ($kpl) {

--- a/tilauskasittely/tulosta_hintalaput.inc
+++ b/tilauskasittely/tulosta_hintalaput.inc
@@ -38,22 +38,32 @@ function tulosta_hintalaput($tuotteet, $params = array()) {
     "font"   => "Helvetica-Bold"
   );
 
-  foreach ($tuotteet as $tuote) {
-    $nimitys = explode("\n", wordwrap($tuote['nimitys'], 28));
-    $hinta   = hintapyoristys($tuote['myyntihinta']);
-
-    $viivakoodi              = viivakoodi($tuote['tuoteno'], "code128", 360, 60);
-    $viivakoodin_teksti      = $tuote['tuoteno'];
-    $viivakoodi_teksti_vasen = 50;
+  switch ($koko) {
+  case '6.2x2.9cm':
+    $viivakoodi_leveys       = 600;
+    $viivakoodi_vasen        = 2;
+    $viivakoodi_teksti_vasen = 2;
+    $viivakoodin_asetukset   = array("scale" => array("x" => 0.1, "y" => 0.1));
+    $kompensaatio            = -2;
+    $hinta_x                 = 140;
+    $yksikko_x               = 168;
+    break;
+  default:
+    $viivakoodi_leveys       = 360;
     $viivakoodi_vasen        = 17;
+    $viivakoodi_teksti_vasen = 50;
+    $viivakoodin_asetukset   = array("scale" => array("x" => 0.1, "y" => 0.1));
+    $kompensaatio            = 0;
+    $hinta_x                 = 100;
+    $yksikko_x               = 129;
+  }
 
-    $viivakoodin_asetukset = array(
-      "scale" => array(
-        "x" => 0.1,
-        "y" => 0.1
-      )
-    );
-    $kuva                  = $pdf->jfif_embed($viivakoodi);
+  foreach ($tuotteet as $tuote) {
+    $nimitys            = explode("\n", wordwrap($tuote['nimitys'], 28));
+    $hinta              = hintapyoristys($tuote['myyntihinta']);
+    $viivakoodi         = viivakoodi($tuote['tuoteno'], "code128", $viivakoodi_leveys, 60);
+    $viivakoodin_teksti = $tuote['tuoteno'];
+    $kuva               = $pdf->jfif_embed($viivakoodi);
 
     if ($kpl) {
       $montako_tulostetaan = $kpl;
@@ -70,16 +80,16 @@ function tulosta_hintalaput($tuotteet, $params = array()) {
 
       // Kuva ensin, jotta ei mene tekstin päälle
       $pdf->image_place($kuva, 15, $viivakoodi_vasen, $page, $viivakoodin_asetukset);
-      $pdf->draw_text(0, 77, $nimitys[0], $page, $text_normal);
-      $pdf->draw_text(0, 68, $nimitys[1], $page, $text_normal);
-      $pdf->draw_text(0, 59, $nimitys[2], $page, $text_normal);
+      $pdf->draw_text(0, 77 + $kompensaatio, $nimitys[0], $page, $text_normal);
+      $pdf->draw_text(0, 68 + $kompensaatio, $nimitys[1], $page, $text_normal);
+      $pdf->draw_text(0, 59 + $kompensaatio, $nimitys[2], $page, $text_normal);
 
       $hinta         = str_replace(".", ",", $hinta);
       $hinnan_leveys = $pdf->strlen($hinta, $text_normal);
-      $pdf->draw_text(100 - $hinnan_leveys, 50, $hinta . " EUR", $page, $text_bold);
+      $pdf->draw_text($hinta_x - $hinnan_leveys, 50, $hinta . " EUR", $page, $text_bold);
 
       $yksikon_leveys = $pdf->strlen($tuote['yksikko'], $text_normal);
-      $pdf->draw_text(129 - $yksikon_leveys, 40, $tuote['yksikko'], $page, $text_normal);
+      $pdf->draw_text($yksikko_x - $yksikon_leveys, 40, $tuote['yksikko'], $page, $text_normal);
       $pdf->draw_text($viivakoodi_teksti_vasen, 8, $viivakoodin_teksti, $page, $text_normal);
     }
   }

--- a/tilauskasittely/tulosta_hintalaput.inc
+++ b/tilauskasittely/tulosta_hintalaput.inc
@@ -9,7 +9,8 @@ require_once "barcode/c128cobject.php";
  * @param array   $tuotteet Array tuotteista, joiden hintalaput tulostetaan
  * @param array   $params   Configuraation array. Esimerkki:
  *   array(
- *     "kpl" => 1
+ *     "kpl"  => 1,
+ *     "koko" => '4.9x3cm',
  *   );
  *
  * @return array Tiedostonimi ja kaunisnimi
@@ -17,7 +18,8 @@ require_once "barcode/c128cobject.php";
 
 
 function tulosta_hintalaput($tuotteet, $params = array()) {
-  $kpl = isset($params["kpl"]) ? $params["kpl"] : false;
+  $kpl  = isset($params["kpl"]) ? $params["kpl"] : false;
+  $koko = isset($params["koko"]) ? $params["koko"] :'4.9x3cm';
 
   $pdf = new pdffile();
 
@@ -64,7 +66,7 @@ function tulosta_hintalaput($tuotteet, $params = array()) {
     }
 
     for ($i = 0; $i < $montako_tulostetaan; $i++) {
-      $page = $pdf->new_page('4.9x3cm');
+      $page = $pdf->new_page($koko);
 
       // Kuva ensin, jotta ei mene tekstin päälle
       $pdf->image_place($kuva, 15, $viivakoodi_vasen, $page, $viivakoodin_asetukset);

--- a/tulosta_tuotetarrat.php
+++ b/tulosta_tuotetarrat.php
@@ -210,7 +210,8 @@ if (($tee == 'Z' or $tee == 'H') and $ulos == '') {
     if ($malli == "Hintalappu PDF") {
       $tuotteet = array($trow);
       $params   = array(
-        "kpl" => $tulostakappale
+        "kpl"  => $tulostakappale,
+        "koko" => $koko,
       );
 
       require "tilauskasittely/tulosta_hintalaput.inc";
@@ -243,7 +244,7 @@ if (!isset($nayta_pdf)) {
 
   $tarrat = $toim == "HINTA" ? "hintalaput" : "tuotetarrat";
 
-  $colspan = $toim == 'HINTA' ? "2" : "5";
+  $colspan = $toim == 'HINTA' ? "3" : "5";
 
   echo
   "<tr><th colspan='{$colspan}'><center>" .
@@ -253,7 +254,10 @@ if (!isset($nayta_pdf)) {
   echo "<th>".t("Tuotenumero")."</th>";
   echo "<th>".t("KPL")."</th>";
 
-  if ($toim != 'HINTA') {
+  if ($toim == 'HINTA') {
+    echo "<th><label for='koko'>" . t('Koko') . "</label></th>";
+  }
+  else {
     echo "<th>" . t("Kirjoitin") . "</th>";
     echo "<th>" . t("Malli") . "</th>";
     echo "<th><label for='viivakoodityyppi_1'>" . t("Viivakoodityyppi") . "</label></th>";
@@ -267,7 +271,15 @@ if (!isset($nayta_pdf)) {
   echo "<td><input type='text' name='tuoteno' size='20' maxlength='60' value='$tuoteno'></td>";
   echo "<td><input type='text' name='tulostakappale' size='3' value='$tulostakappale'></td>";
 
-  if ($toim != "HINTA") {
+  if ($toim == 'HINTA') {
+    echo "<td>";
+    echo "<select id='koko' name='koko'>";
+    echo "<option value='4.9x3cm'>49 x 30 mm</option>";
+    echo "<option value='6.2x2.9cm'>62 x 29 mm</option>";
+    echo "</select>";
+    echo "</td>";
+  }
+  else {
     echo "<td><select name='kirjoitin'>";
     echo "<option value=''>" . t("Ei kirjoitinta") . "</option>";
 

--- a/tulosta_tuotetarrat.php
+++ b/tulosta_tuotetarrat.php
@@ -211,9 +211,11 @@ if (($tee == 'Z' or $tee == 'H') and $ulos == '') {
 
     if ($malli == "Hintalappu PDF") {
       $tuotteet = array($trow);
-      $params   = array(
-        "kpl"  => $tulostakappale,
-        "koko" => $koko,
+
+      $params = array(
+        "kpl"           => $tulostakappale,
+        "koko"          => $koko,
+        "barcode_field" => $barcode_field,
       );
 
       require "tilauskasittely/tulosta_hintalaput.inc";
@@ -246,7 +248,7 @@ if (!isset($nayta_pdf)) {
 
   $tarrat = $toim == "HINTA" ? "hintalaput" : "tuotetarrat";
 
-  $colspan = $toim == 'HINTA' ? "3" : "5";
+  $colspan = $toim == 'HINTA' ? "4" : "5";
 
   echo
   "<tr><th colspan='{$colspan}'><center>" .
@@ -258,6 +260,7 @@ if (!isset($nayta_pdf)) {
 
   if ($toim == 'HINTA') {
     echo "<th><label for='koko'>" . t('Koko') . "</label></th>";
+    echo "<th><label for='barcode_field'>" . t('Viivakoodikenttä') . "</label></th>";
   }
   else {
     echo "<th>" . t("Kirjoitin") . "</th>";
@@ -278,6 +281,13 @@ if (!isset($nayta_pdf)) {
     echo "<select id='koko' name='koko'>";
     echo "<option value='4.9x3cm'>49 x 30 mm</option>";
     echo "<option value='6.2x2.9cm'>62 x 29 mm</option>";
+    echo "</select>";
+    echo "</td>";
+
+    echo "<td>";
+    echo "<select id='barcode_field' name='barcode_field'>";
+    echo "<option value='tuoteno'>Tuoteno</option>";
+    echo "<option value='eankoodi'>Eankoodi</option>";
     echo "</select>";
     echo "</td>";
   }

--- a/tulosta_tuotetarrat.php
+++ b/tulosta_tuotetarrat.php
@@ -1,5 +1,7 @@
 <?php
 
+$_REQUEST['malli'] = isset($_REQUEST['malli']) ? $_REQUEST['malli'] : null;
+
 if ($_REQUEST['malli'] == 'PDF24' or
   $_REQUEST['malli'] == 'PDF40' or
   $_REQUEST['malli'] == 'PDF' or


### PR DESCRIPTION
* Voidaan valita koko hintalapulle. Tällä hetkellä tuettuja koko ovat 49 x 30 mm & 62 x 29 mm.
* Tuetaan EAN-koodia viivakoodissa