### PR TITLE
Myyntitilaus: muuta asiakasta-painike otsikolla

### DIFF
--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -1264,7 +1264,7 @@ if ($tila == "" and !isset($jatka)) {
     }
 
     if (tarkista_oikeus("yllapito.php", $ealisa, "X")) {
-      echo "<tr><td></td><td><a href='".$palvelin2."yllapito.php?toim=$ealisa&tunnus=$srow[liitostunnus]&lopetus=tilauskasittely/tilaus_myynti.php////toim=$toim//tee=$tee//tilausnumero=$tilausnumero//mista=$mista//tila=$tila//from=ASIAKASYLLAPITO//asiakasid=$asiakasid'>".t("Muuta asiakkaan tietoja")."</a></td></tr>";
+      echo "<tr><td></td><td><a href='".$palvelin2."yllapito.php?toim=$ealisa&tunnus=$srow[liitostunnus]&lopetus=tilauskasittely/tilaus_myynti.php////toim=$toim//tee=$tee//tilausnumero=$tilausnumero//mista=$mista//tila=$tila//ylatila=$ylatila//alatila=$alatila//from=ASIAKASYLLAPITO//asiakasid=$asiakasid'>".t("Muuta asiakkaan tietoja")."</a></td></tr>";
     }
   }
 


### PR DESCRIPTION
Myyntitilauksen otsikolta, jos meni Muuta asiakasta-linkin kautta katselemaan ja muokkaamaan asiakkaan tietoja, niin kun palasi takaisin myyntitilaukselle saattoi myyntitilaus tietyissä tapauksissa mennä takaisin tulostusjonoon ja päivittyä väärään tilaan. Korjattu nyt niin, että myyntitilauksen alkuperäinen tila säilyy.