### PR TITLE
Myyntitilaus: hinnan syöttäminen

### DIFF
--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -368,11 +368,11 @@ $hinta  = str_replace(',', '.', $hinta);
 
 // lis‰t‰‰n alvit (jos hintamuunnos p‰‰ll‰)
 if ($trow['alv'] < 500 and isset($tilausrivi_alvillisuus) and $tilausrivi_alvillisuus == "E" and $yhtiorow["alv_kasittely"] == '' and $yhtiorow["alv_kasittely_hintamuunnos"] == 'o' and !is_array($hyvityssaanto_hinta_array)) {
-  $hinta = round($hinta * (1+$trow['alv']/100), $yhtiorow['hintapyoristys']);
+  $hinta = round($hinta * (1+$trow['alv']/100), 6);
 }
 // poistetaan alvit (jos hintamuunnos p‰‰ll‰)
 if ($trow['alv'] < 500 and isset($tilausrivi_alvillisuus) and $tilausrivi_alvillisuus == "K" and $yhtiorow["alv_kasittely"] == 'o' and $yhtiorow["alv_kasittely_hintamuunnos"] == 'o' and !is_array($hyvityssaanto_hinta_array)) {
-  $hinta = round($hinta / (1+$trow['alv']/100), $yhtiorow['hintapyoristys']);
+  $hinta = round($hinta / (1+$trow['alv']/100), 6);
 }
 
 if ($laskurow['tila'] == 'O' or $laskurow['tila'] == 'K') {


### PR DESCRIPTION
Mikäli yhtiön parametreissä Alv_kasittely_hintamuunnos-parametrillä oli mahdollistettu hintojen syöttäminen verollisena/verottomana sen sijaan, että hinnat syötettäisiin saman kaavan mukaan kuin millä hinnat on tallennettuna Pupeen saattoi tilausrivin hinnassa olla pyöristysero syötettyyn hintaan nähden. Tämä on nyt korjattu ja syötetyt hinnat tallennetaan tarkemmin mahdollisimman tarkan lopputuloksen aikaansaamiseksi.