### PR TITLE
Ylläpitosopimukset: sopimusten laskutus

### DIFF
--- a/tilauskasittely/yllapitosopimukset.php
+++ b/tilauskasittely/yllapitosopimukset.php
@@ -205,7 +205,8 @@ if ($tee == "laskuta" and count($laskutapvm) > 0) {
                  eilahetetta  = 'o',
                  clearing     = 'sopimus',
                  swift        = '$tilausnumero',
-                 tilaustyyppi = ''
+                 tilaustyyppi = '',
+                 luontiaika  = '$tapahtumapvm'
                  {$laskutuskausilisa}
                  WHERE yhtio  = '$kukarow[yhtio]'
                  and tunnus   = '$ok'
@@ -275,8 +276,7 @@ if ($tee == "laskuta" and count($laskutapvm) > 0) {
       // p‰ivitet‰‰n tila myyntitilaus valmis, suoraan laskutukseen (clearing on sopimus ja swift kent‰ss‰ on mik‰ soppari on kopsattu)
       $query  = "UPDATE lasku
                  SET tila   = 'L',
-                 alatila     = 'D',
-                 luontiaika  = '$tapahtumapvm'
+                 alatila     = 'D'
                  WHERE yhtio = '$kukarow[yhtio]'
                  and tunnus  = '$ok'
                  and tila    = 'L'";


### PR DESCRIPTION
Yritettäessä laskuttaa ylläpitosopimusta, jonka asiakas on myyntikiellossa teki Pupe oikein uuden myyntitilauksen ja jätti sen Myyntitilaus kesken-tilaan. Erheellisesti uuden myyntitilauksen luontipäivämääräksi jäi ylläpitosopimuksen luontipäivämäärä eikä tullut ylläpitosopimuksen kauden päivämäärää. Tämän takia, kun poisti myyntikiellon ja laskutti myyntitilauksen niin se meni väärälle päivälle ja näytti siltä että kyseistä kautta ei olisi vielä laskutettu ja sen pääsi laskuttamaan uudestaan. Korjattu nyt niin, että päivämäärä menee oikein.