### PR TITLE
Ostotilaus PDF: asiakkaiden nimet

### DIFF
--- a/inc/valitse_tulostin.inc
+++ b/inc/valitse_tulostin.inc
@@ -102,6 +102,9 @@ if ($toim == "OSTO" or $tulostimet[0] == "Ostotilaus") {
 
   echo "<tr><th>", t("Tulosta nimitykset ostotilaukselle"), "</th><td><input type='checkbox' name='nimitykset' {$chk}></td></tr>";
 
+  $chk = empty($asiakkaiden_nimet) ? '' : 'checked';
+  echo "<tr><th>", t("Tulosta myös asiakkaiden nimet"), "</th><td><input type='checkbox' name='asiakkaiden_nimet' {$chk}></td></tr>";
+
   $mista = 'toimi';
 
   $editsql = "SELECT *

--- a/tilauskasittely/tulosta_ostotilaus.inc
+++ b/tilauskasittely/tulosta_ostotilaus.inc
@@ -498,8 +498,10 @@ else {
                     t.tyyppi != 'D'
                   )
                   WHERE l.yhtio = '{$kukarow['yhtio']}'
-                  AND (l.tila = 'N' OR l.tila = 'L')
-                  AND l.alatila = 'A'
+                  AND (
+                    (l.tila = 'N' AND l.alatila IN ('A','T')) OR
+                    (l.tila = 'L' AND l.alatila = 'A')
+                  )
                   AND t.tuoteno = '{$row['tuoteno']}'
                   GROUP BY l.tunnus";
         $nimetres = pupe_query($query);

--- a/tilauskasittely/tulosta_ostotilaus.inc
+++ b/tilauskasittely/tulosta_ostotilaus.inc
@@ -490,7 +490,7 @@ else {
       }
 
       if (!empty($asiakkaiden_nimet)) {
-        $query = "SELECT TRIM(CONCAT_WS(' ', l.nimi, l.nimitark)) nimi
+        $query = "SELECT DISTINCT TRIM(CONCAT_WS(' ', l.nimi, l.nimitark)) nimi
                   FROM lasku AS l
                   JOIN tilausrivi AS t ON (
                     t.yhtio = l.yhtio AND
@@ -502,8 +502,7 @@ else {
                     (l.tila = 'N' AND l.alatila IN ('A','T')) OR
                     (l.tila = 'L' AND l.alatila = 'A')
                   )
-                  AND t.tuoteno = '{$row['tuoteno']}'
-                  GROUP BY l.tunnus";
+                  AND t.tuoteno = '{$row['tuoteno']}'";
         $nimetres = pupe_query($query);
 
         while ($nimetrow = mysql_fetch_assoc($nimetres)) {

--- a/tilauskasittely/tulosta_ostotilaus.inc
+++ b/tilauskasittely/tulosta_ostotilaus.inc
@@ -489,6 +489,26 @@ else {
         $lask++;
       }
 
+      if (!empty($asiakkaiden_nimet)) {
+        $query = "SELECT TRIM(CONCAT_WS(' ', l.nimi, l.nimitark)) nimi
+                  FROM lasku AS l
+                  JOIN tilausrivi AS t ON (
+                    t.yhtio = l.yhtio AND
+                    t.otunnus = l.tunnus AND
+                    t.tyyppi != 'D'
+                  )
+                  WHERE l.yhtio = '{$kukarow['yhtio']}'
+                  AND (l.tila = 'N' OR l.tila = 'L')
+                  AND l.alatila = 'A'
+                  AND t.tuoteno = '{$row['tuoteno']}'
+                  GROUP BY l.tunnus";
+        $nimetres = pupe_query($query);
+
+        while ($nimetrow = mysql_fetch_assoc($nimetres)) {
+          $row['kommentti'] .= "\n{$nimetrow['nimi']}";
+        }
+      }
+
       if (trim($row["kommentti"]) != '') {
         foreach (explode("\n", wordwrap(trim($row["kommentti"]), 90, "\n")) as $kommentti) {
           $kala = $kala - 15;
@@ -752,6 +772,7 @@ else {
     'sivu'                      => 1,
     'tee'                       => $tee,
     'nimitykset'                => $nimitykset,
+    'asiakkaiden_nimet'         => $asiakkaiden_nimet,
     'thispage'                  => NULL,
     'toim'                      => $toim,
     'rivinumerot'               => $rivinumerot,


### PR DESCRIPTION
Voidaan tulostaa ostotilauksen PDF:lle asiakkaiden nimet tuotekohtaisesti, joilla on avoimia myyntitilauksia.

Asiakkaiden nimet haettaisiin kaikilta avoimilta myyntitilauksilta, joilla ko. tuotetta. Avoimilla myyntitilauksilla tarkoitetaan tulostusjonossa olevia ja niitä, joiden keräyslista tulostettu, mutta ei kerätty. Kesken olevia myyntitilauksia ei huomioida.

Tämä on tehty niin että ostotilauksen tulostukseen on lisätty valintaruksi "Tulosta myös asiakkaiden nimet". Tämä ominaisuus tulee tuoteriville rivikommenttiin lisättynä mahdollisten muiden rivikommenttien lisäksi.