### PR TITLE
Myyntitilaus: ei ulkoista varastoa

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -1120,7 +1120,7 @@ else {
 $muokkauslukko = $state = "";
 
 # Laitetaan tilaus lukkoon, jos tilaus on lähetetty ulkoiseen varastoon
-if (!empty($laskurow['lahetetty_ulkoiseen_varastoon'])) {
+if (!empty($laskurow['lahetetty_ulkoiseen_varastoon']) and $laskurow['lahetetty_ulkoiseen_varastoon'] != "0000-00-00 00:00:00") {
   $muokkauslukko = 'LUKOSSA';
 }
 


### PR DESCRIPTION
Vaikka ulkoista varastoa ei ollut käytössä saattoivat tilaukset silti mennä ulkoisen varaston muokkauslukkoon. Korjattu nyt niin, että tilaukset eivät tästä syystä muokkauslukkoon mene.