### PR TITLE
Ostoehotukselta tehdyn oston riveille otsikon toimitusaika

### DIFF
--- a/inc/tilaa_ajax.inc
+++ b/inc/tilaa_ajax.inc
@@ -86,13 +86,15 @@ if ($maara > 0) {
 
   $jatka = "jatka";
 
-  $query = "SELECT max(tunnus) tunnus
+  $query = "SELECT tunnus, toimaika
             FROM lasku
             WHERE yhtio      = '$kukarow[yhtio]'
             AND tila         = 'O'
             AND alatila      = ''
             AND liitostunnus = '$toimittaja'
-            AND myyja        = '$kukarow[tunnus]'";
+            AND myyja        = '$kukarow[tunnus]'
+            ORDER BY tunnus DESC
+            LIMIT 1";
   $lasres = pupe_query($query);
   $lasrow = mysql_fetch_array($lasres);
 
@@ -102,6 +104,7 @@ if ($maara > 0) {
   }
   else {
     $tilausnumero = $lasrow['tunnus'];
+    $otstoimaika  = $lasrow['toimaika'];
 
     $query = "SELECT max(tilaajanrivinro) tilaajanrivinro
               FROM tilausrivi

--- a/inc/tilaa_ajax.inc
+++ b/inc/tilaa_ajax.inc
@@ -190,7 +190,7 @@ if ($maara > 0) {
   }
 
   if ($toimaika == "" or $toimaika == "0000-00-00") {
-    $toimaika = $laskurow["toimaika"];
+    $toimaika = $otstoimaika;
   }
 
   // lis‰t‰‰n ostotilausrivi

--- a/tilauskasittely/otsik_ostotilaus.inc
+++ b/tilauskasittely/otsik_ostotilaus.inc
@@ -11,6 +11,7 @@ if ($tee == '') {
 
     $kukarow['kesken']   = 0;
     $tilausnumero     = 0;
+    $otstoimaika      = '';
   }
 }
 

--- a/tilauskasittely/otsik_ostotilaus.inc
+++ b/tilauskasittely/otsik_ostotilaus.inc
@@ -721,6 +721,7 @@ if (isset($jatka)) {
 
     $kukarow["kesken"] = $id;
     $tilausnumero = $id;
+    $otstoimaika = $toimvv."-".$toimkk."-".$toimpp;
   }
 
   //menn‰‰n tilaukselle


### PR DESCRIPTION
Kun ostoehdotuksesta tehtiin uusi ostotilaus, otsikolle päivittyi toimitusaika, mutta ei riveille. Tämän jälkeen riveille ei voinut päivittää otsikolta uutta toimitusaikaa, koska rivien toimitusaika oli nolla.