### PR TITLE
Cron-sähköpostit: Javascriptit pois viesteistä

### DIFF
--- a/muuvarastopaikka.php
+++ b/muuvarastopaikka.php
@@ -4,8 +4,10 @@ if (strpos($_SERVER['SCRIPT_NAME'], "muuvarastopaikka.php")  !== FALSE) {
   require "inc/parametrit.inc";
 }
 
-// Enaboidaan ajax kikkare
-enable_ajax();
+if (php_sapi_name() != 'cli') {
+  // Enaboidaan ajax kikkare
+  enable_ajax();
+}
 
 if ($tee != '') {
   $query  = "LOCK TABLE tuotepaikat WRITE,


### PR DESCRIPTION
Ei kutsuta javascripti-funktioita jos ajetaan komentoriviltä. Näin ei tule cron-maileihin ylimääräistä sisältöä.
