### PR TITLE
Erätulostus Unifaun-toimitustavalla: tulostettavien tilausten tila korjaus

### DIFF
--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -405,7 +405,6 @@ if ($tee == 'close_with_printer') {
   $mergeid_arr = array();
 
   while ($row = mysql_fetch_assoc($rakir_res)) {
-
     $mergeid = md5(date("Ymd").$row["ytunnus"].$row["toim_osoite"].$row["toim_postino"].$row["toim_postitp"]);
     $mergeid_arr[$mergeid] = $mergeid;
 

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -388,7 +388,7 @@ if ($tee == 'close_with_printer') {
 
   $query = "SELECT lasku.tunnus, lasku.toimitustavan_lahto, lasku.toimitustapa, lasku.ytunnus, lasku.toim_osoite, lasku.toim_postino, lasku.toim_postitp, asiakas.toimitusvahvistus, group_concat(DISTINCT rahtikirjat.tunnus) ratunnarit, sum(rahtikirjat.kilot) kilot
             FROM rahtikirjat
-            JOIN lasku USE INDEX (PRIMARY) on (lasku.tunnus=rahtikirjat.otsikkonro and lasku.yhtio=rahtikirjat.yhtio and lasku.tila in ('L','G') AND lasku.alatila = 'B' $ltun_querylisa)
+            JOIN lasku USE INDEX (PRIMARY) on (lasku.tunnus=rahtikirjat.otsikkonro and lasku.yhtio=rahtikirjat.yhtio and lasku.tila in ('L','G') AND lasku.alatila IN ('B', 'E') $ltun_querylisa)
             $vainvakilliset
             LEFT JOIN asiakas ON (asiakas.yhtio = lasku.yhtio AND asiakas.tunnus = lasku.liitostunnus)
             LEFT JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio and lasku.maksuehto = maksuehto.tunnus)
@@ -1439,7 +1439,7 @@ if ($tee == '') {
   // haetaan kaikki distinct toimitustavat joille meillä on rahtikirjoja tulostettavana..
   $query = "SELECT lasku.yhtio yhtio, lasku.toimitustapa, varastopaikat.tunnus, varastopaikat.nimitys, varastopaikat.printteri7, group_concat(distinct lasku.tunnus ORDER BY lasku.tunnus ASC) ltunnus
             FROM rahtikirjat
-            JOIN lasku USE INDEX (PRIMARY) on (lasku.tunnus=rahtikirjat.otsikkonro and lasku.yhtio=rahtikirjat.yhtio and lasku.tila in ('L','G') and lasku.alatila = 'B')
+            JOIN lasku USE INDEX (PRIMARY) on (lasku.tunnus=rahtikirjat.otsikkonro and lasku.yhtio=rahtikirjat.yhtio and lasku.tila in ('L','G') and lasku.alatila IN ('B', 'E'))
             JOIN toimitustapa on lasku.yhtio = toimitustapa.yhtio
             AND lasku.toimitustapa        = toimitustapa.selite
             AND toimitustapa.tulostustapa in ('E','L')

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -388,7 +388,7 @@ if ($tee == 'close_with_printer') {
 
   $query = "SELECT lasku.tunnus, lasku.toimitustavan_lahto, lasku.toimitustapa, lasku.ytunnus, lasku.toim_osoite, lasku.toim_postino, lasku.toim_postitp, asiakas.toimitusvahvistus, group_concat(DISTINCT rahtikirjat.tunnus) ratunnarit, sum(rahtikirjat.kilot) kilot
             FROM rahtikirjat
-            JOIN lasku USE INDEX (PRIMARY) on (lasku.tunnus=rahtikirjat.otsikkonro and lasku.yhtio=rahtikirjat.yhtio and lasku.tila in ('L','G') AND lasku.alatila NOT IN ('X', 'V') $ltun_querylisa)
+            JOIN lasku USE INDEX (PRIMARY) on (lasku.tunnus=rahtikirjat.otsikkonro and lasku.yhtio=rahtikirjat.yhtio and lasku.tila in ('L','G') AND lasku.alatila = 'B' $ltun_querylisa)
             $vainvakilliset
             LEFT JOIN asiakas ON (asiakas.yhtio = lasku.yhtio AND asiakas.tunnus = lasku.liitostunnus)
             LEFT JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio and lasku.maksuehto = maksuehto.tunnus)

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -388,7 +388,7 @@ if ($tee == 'close_with_printer') {
 
   $query = "SELECT lasku.tunnus, lasku.toimitustavan_lahto, lasku.toimitustapa, lasku.ytunnus, lasku.toim_osoite, lasku.toim_postino, lasku.toim_postitp, asiakas.toimitusvahvistus, group_concat(DISTINCT rahtikirjat.tunnus) ratunnarit, sum(rahtikirjat.kilot) kilot
             FROM rahtikirjat
-            JOIN lasku USE INDEX (PRIMARY) on (lasku.tunnus=rahtikirjat.otsikkonro and lasku.yhtio=rahtikirjat.yhtio and lasku.tila in ('L','G') $ltun_querylisa)
+            JOIN lasku USE INDEX (PRIMARY) on (lasku.tunnus=rahtikirjat.otsikkonro and lasku.yhtio=rahtikirjat.yhtio and lasku.tila in ('L','G') AND lasku.alatila NOT IN ('X', 'V') $ltun_querylisa)
             $vainvakilliset
             LEFT JOIN asiakas ON (asiakas.yhtio = lasku.yhtio AND asiakas.tunnus = lasku.liitostunnus)
             LEFT JOIN maksuehto ON (lasku.yhtio = maksuehto.yhtio and lasku.maksuehto = maksuehto.tunnus)
@@ -405,6 +405,7 @@ if ($tee == 'close_with_printer') {
   $mergeid_arr = array();
 
   while ($row = mysql_fetch_assoc($rakir_res)) {
+
     $mergeid = md5(date("Ymd").$row["ytunnus"].$row["toim_osoite"].$row["toim_postino"].$row["toim_postitp"]);
     $mergeid_arr[$mergeid] = $mergeid;
 


### PR DESCRIPTION
Unifaun erätulostuksessa saattoi käytä niin, että aiemmin Toimita ja laskuta-ohjelman laskutetut tilaukset palautettiin virheellisesti ohjelmassa takaisin toimitettu-tilaan, minkä seurauksena laskutettuja tilauksia oli jumissta Myyntitilaus toimitettu-tilassa. Korjattu nyt niin, että laskutettuja tilauksia ei erätulostuksessa huomioida.
