### PR TITLE
Presta asiakkaat yhteyshenkilöittäin

### DIFF
--- a/rajapinnat/presta/presta_addresses.php
+++ b/rajapinnat/presta/presta_addresses.php
@@ -73,7 +73,7 @@ class PrestaAddresses extends PrestaClient {
     // loop all given addresses
     foreach ($addresses as $address) {
       $current++;
-      $this->logger->log("[{$current}/{$count}] Käsitellään osoite");
+      $this->logger->log("Käsitellään osoite ({$current}/{$count})");
 
       // we need to add customer id to address -array since we don't know it in pupesoft
       $address['id_customer'] = $presta_customer_id;
@@ -150,7 +150,7 @@ class PrestaAddresses extends PrestaClient {
     // delete addresses from presta
     foreach ($remove_ids as $presta_id) {
       $current++;
-      $this->logger->log("[{$current}/{$total}] Poistetaan osoite {$presta_id}");
+      $this->logger->log("Poistetaan osoite {$presta_id} ({$current}/{$total})");
 
       try {
         $this->delete($presta_id);

--- a/rajapinnat/presta/presta_addresses.php
+++ b/rajapinnat/presta/presta_addresses.php
@@ -67,9 +67,14 @@ class PrestaAddresses extends PrestaClient {
 
   public function add_addresses_for_customer($presta_customer_id, Array $addresses, $id_shop = null) {
     $added_addresses = array();
+    $count = count($addresses);
+    $current = 0;
 
     // loop all given addresses
     foreach ($addresses as $address) {
+      $current++;
+      $this->logger->log("[{$current}/{$count}] K‰sitell‰‰n osoite");
+
       // we need to add customer id to address -array since we don't know it in pupesoft
       $address['id_customer'] = $presta_customer_id;
 
@@ -109,7 +114,7 @@ class PrestaAddresses extends PrestaClient {
         'postcode'     => $this->clean_field($address['postino']),
       );
 
-      $this->logger->log("Etsit‰‰n osoitteet osoitetietojen mukaan");
+      $this->logger->log("Etsit‰‰n osoitteet osoitetietojen mukaan ({$filter['address1']})");
     }
     else {
       // otherwise we search only with customer id

--- a/rajapinnat/presta/presta_client.php
+++ b/rajapinnat/presta/presta_client.php
@@ -530,8 +530,13 @@ abstract class PrestaClient {
     foreach ($parameters as $parameter) {
       $key       = $parameter['arvo'];
       $attribute = $parameter['nimi'];
-      $value     = $this->xml_value($value_array[$key]);
 
+      if (empty($value_array[$key])) {
+        $this->logger->log("VIRHE! Kenttää {$key} ei ole asetettu. Ei voida asettaa arvoa {$attribute} -kenttään.");
+        continue;
+      }
+
+      $value = $this->xml_value($value_array[$key]);
       $xml_node->$attribute = $value;
 
       $this->logger->log("Poikkeava arvo {$attribute} -kenttään. Asetetaan {$key} kentän arvo {$value}");

--- a/rajapinnat/presta/presta_client.php
+++ b/rajapinnat/presta/presta_client.php
@@ -538,6 +538,19 @@ abstract class PrestaClient {
     }
   }
 
+  protected function clean_field($value) {
+    $field = empty($value) ? "-" : trim($value);
+
+    return $this->xml_value($field);
+  }
+
+  protected function clean_name($value) {
+    // max 32, numbers and special characters not allowed
+    $name = preg_replace("/[^a-zA-ZäöåÄÖÅ ]+/", "", substr($value, 0, 32));
+
+    return $this->clean_field($name);
+  }
+
   public function set_dynamic_fields($fields) {
     $this->dynamic_fields = $fields;
   }

--- a/rajapinnat/presta/presta_customers.php
+++ b/rajapinnat/presta/presta_customers.php
@@ -12,7 +12,6 @@ class PrestaCustomers extends PrestaClient {
     parent::__construct($url, $api_key, $log_file);
 
     $this->presta_addresses = new PrestaAddresses($url, $api_key, $log_file);
-    $this->presta_addresses->set_customer_handling($this->customer_handling);
   }
 
   protected function resource_name() {
@@ -121,7 +120,11 @@ class PrestaCustomers extends PrestaClient {
             $id = (string) $response['customer']['id'];
           }
 
+          // set customer handling here, and add addresses
+          $this->presta_addresses->set_customer_handling($this->customer_handling);
           $this->presta_addresses->add_addresses_for_customer($id, $customer['osoitteet'], $id_shop);
+
+          // update presta customer id to pupesoft
           $this->update_to_pupesoft($id, $customer['tunnus'], $customer['yhtio']);
         }
         catch (Exception $e) {

--- a/rajapinnat/presta/presta_customers.php
+++ b/rajapinnat/presta/presta_customers.php
@@ -12,6 +12,7 @@ class PrestaCustomers extends PrestaClient {
     parent::__construct($url, $api_key, $log_file);
 
     $this->presta_addresses = new PrestaAddresses($url, $api_key, $log_file);
+    $this->presta_addresses->set_customer_handling($this->customer_handling);
   }
 
   protected function resource_name() {

--- a/rajapinnat/presta/presta_customers.php
+++ b/rajapinnat/presta/presta_customers.php
@@ -4,6 +4,7 @@ require_once 'rajapinnat/presta/presta_client.php';
 require_once 'rajapinnat/presta/presta_addresses.php';
 
 class PrestaCustomers extends PrestaClient {
+  private $customer_handling = null;
   private $default_groups = array();
   private $presta_addresses = null;
 
@@ -196,5 +197,9 @@ class PrestaCustomers extends PrestaClient {
     if (is_array($value)) {
       $this->default_groups = $value;
     }
+  }
+
+  public function set_customer_handling($value) {
+    $this->customer_handling = $value;
   }
 }

--- a/rajapinnat/presta/presta_customers.php
+++ b/rajapinnat/presta/presta_customers.php
@@ -36,12 +36,8 @@ class PrestaCustomers extends PrestaClient {
 
     $_email = empty($customer['email']) ? 'test@example.com' : $customer['email'];
 
-    // max 32, numbers and special characters not allowed
-    $_nimi = preg_replace("/[^a-zA-ZäöåÄÖÅ ]+/", "", substr($customer['nimi'], 0, 32));
-    $_nimi = empty($_nimi) ? '-' : $_nimi;
-
     $xml->customer->firstname = "-";
-    $xml->customer->lastname = $this->xml_value($_nimi);
+    $xml->customer->lastname = $this->clean_name($customer['nimi']);
     $xml->customer->email = $this->xml_value($_email);
 
     if (!empty($customer['verkkokauppa_salasana'])) {
@@ -118,18 +114,13 @@ class PrestaCustomers extends PrestaClient {
 
           if (in_array($id, $existing_customers)) {
             $this->update($id, $customer, $id_shop);
-
-            $customer['presta_customer_id'] = $id;
-            $this->presta_addresses->update_with_customer_id($customer, $id_shop);
           }
           else {
             $response = $this->create($customer, $id_shop);
             $id = (string) $response['customer']['id'];
-
-            $customer['presta_customer_id'] = $id;
-            $this->presta_addresses->create($customer, $id_shop);
           }
 
+          $this->presta_addresses->add_addresses_for_customer($id, $customer['osoitteet'], $id_shop);
           $this->update_to_pupesoft($id, $customer['tunnus'], $customer['yhtio']);
         }
         catch (Exception $e) {

--- a/rajapinnat/presta/presta_functions.php
+++ b/rajapinnat/presta/presta_functions.php
@@ -196,6 +196,27 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
   return $asiakkaat;
 }
 
+function presta_hae_asiakas_tunnuksella($tunnus) {
+  global $kukarow, $yhtiorow;
+
+  if (empty($tunnus)) {
+    return null;
+  }
+
+  $query = "SELECT asiakas.*
+            FROM asiakas
+            WHERE yhtio = '{$kukarow['yhtio']}'
+            AND tunnus = {$asiakasnumero}
+            LIMIT 1";
+  $result = pupe_query($query);
+
+  if (mysql_num_rows($result) != 1) {
+    return null;
+  }
+
+  return mysql_fetch_assoc($result);
+}
+
 function presta_hae_yhteyshenkilon_asiakas_ulkoisella_asiakasnumerolla($asiakasnumero) {
   global $kukarow, $yhtiorow;
 
@@ -207,8 +228,8 @@ function presta_hae_yhteyshenkilon_asiakas_ulkoisella_asiakasnumerolla($asiakasn
             FROM yhteyshenkilo
             INNER JOIN asiakas
             ON (asiakas.yhtio = yhteyshenkilo.yhtio
-              AND asiakas.tunnus                     = yhteyshenkilo.liitostunnus)
-            WHERE yhteyshenkilo.yhtio                = '{$kukarow['yhtio']}'
+              AND asiakas.tunnus = yhteyshenkilo.liitostunnus)
+            WHERE yhteyshenkilo.yhtio = '{$kukarow['yhtio']}'
             AND yhteyshenkilo.ulkoinen_asiakasnumero = {$asiakasnumero}
             LIMIT 1";
   $result = pupe_query($query);

--- a/rajapinnat/presta/presta_functions.php
+++ b/rajapinnat/presta/presta_functions.php
@@ -210,7 +210,7 @@ function presta_hae_asiakas_tunnuksella($tunnus) {
   $query = "SELECT asiakas.*
             FROM asiakas
             WHERE yhtio = '{$kukarow['yhtio']}'
-            AND tunnus = {$asiakasnumero}
+            AND tunnus = {$tunnus}
             LIMIT 1";
   $result = pupe_query($query);
 

--- a/rajapinnat/presta/presta_functions.php
+++ b/rajapinnat/presta/presta_functions.php
@@ -68,18 +68,19 @@ function presta_hae_asiakkaat_asiakkaittain() {
     $osoitteet = array();
     $osoitteet[] = array(
       "asiakas_id" => $asiakas['asiakas_tunnus'],
+      "gsm"        => $asiakas['gsm'],
+      "maa"        => $asiakas['maa'],
+      "nimi"       => $asiakas['nimi'],
       "osoite"     => $asiakas['osoite'],
       "postino"    => $asiakas['postino'],
       "postitp"    => $asiakas['postitp'],
-      "maa"        => $asiakas['maa'],
+      "puh"        => $asiakas['puh'],
     );
 
     $asiakkaat[] = array(
       "email"                   => $asiakas['email'],
-      "gsm"                     => $asiakas['gsm'],
       "nimi"                    => $asiakas['nimi'],
       "presta_customergroup_id" => $asiakas['selitetark_5'],
-      "puh"                     => $asiakas['puh'],
       "tunnus"                  => $asiakas['yhteyshenkilo_tunnus'],
       "ulkoinen_asiakasnumero"  => $asiakas['ulkoinen_asiakasnumero'],
       "verkkokauppa_nakyvyys"   => $asiakas['verkkokauppa_nakyvyys'],
@@ -118,6 +119,7 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
             WHERE yhteyshenkilo.yhtio = '{$kukarow['yhtio']}'
             AND yhteyshenkilo.rooli = 'Presta'
             AND yhteyshenkilo.email != ''
+            AND yhteyshenkilo.nimi != ''
             GROUP BY yhteyshenkilo.email";
   $result = pupe_query($query);
 
@@ -141,10 +143,13 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
     while ($osoite = mysql_fetch_assoc($osoite_result)) {
       $osoitteet[] = array(
         "asiakas_id" => $osoite['tunnus'],
+        "gsm"        => $yhteyshenkilo['gsm'],
+        "maa"        => $osoite['maa'],
+        "nimi"       => $yhteyshenkilo['nimi'],
         "osoite"     => $osoite['osoite'],
         "postino"    => $osoite['postino'],
         "postitp"    => $osoite['postitp'],
-        "maa"        => $osoite['maa'],
+        "puh"        => $yhteyshenkilo['puh'],
       );
     }
 
@@ -164,20 +169,21 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
     while ($osoite = mysql_fetch_assoc($osoite_result)) {
       $osoitteet[] = array(
         "asiakas_id" => $osoite['tunnus'],
+        "gsm"        => $yhteyshenkilo['gsm'],
+        "maa"        => $osoite['toim_maa'],
+        "nimi"       => $yhteyshenkilo['nimi'],
         "osoite"     => $osoite['toim_osoite'],
         "postino"    => $osoite['toim_postino'],
         "postitp"    => $osoite['toim_postitp'],
-        "maa"        => $osoite['toim_maa'],
+        "puh"        => $yhteyshenkilo['puh'],
       );
     }
 
     // lisätään asiakas array
     $asiakkaat[] = array(
       "email"                   => $yhteyshenkilo['email'],
-      "gsm"                     => $yhteyshenkilo['gsm'],
       "nimi"                    => $yhteyshenkilo['nimi'],
       "presta_customergroup_id" => $yhteyshenkilo['selitetark_5'],
-      "puh"                     => $yhteyshenkilo['puh'],
       "tunnus"                  => $yhteyshenkilo['tunnus'],
       "ulkoinen_asiakasnumero"  => $yhteyshenkilo['ulkoinen_asiakasnumero'],
       "verkkokauppa_nakyvyys"   => $yhteyshenkilo['verkkokauppa_nakyvyys'],

--- a/rajapinnat/presta/presta_functions.php
+++ b/rajapinnat/presta/presta_functions.php
@@ -20,6 +20,7 @@ function presta_hae_asiakkaat_asiakkaittain() {
   global $kukarow, $yhtiorow, $ajetaanko_kaikki;
 
   $asiakkaat = array();
+
   $datetime_checkpoint = presta_export_checkpoint('PSTS_ASIAKAS');
 
   if ($ajetaanko_kaikki == "NO") {
@@ -35,6 +36,7 @@ function presta_hae_asiakkaat_asiakkaittain() {
   }
 
   $query = "SELECT
+            asiakas.tunnus as asiakas_tunnus,
             avainsana.selitetark_5,
             yhteyshenkilo.email,
             yhteyshenkilo.gsm,
@@ -44,7 +46,7 @@ function presta_hae_asiakkaat_asiakkaittain() {
             yhteyshenkilo.postino,
             yhteyshenkilo.postitp,
             yhteyshenkilo.puh,
-            yhteyshenkilo.tunnus,
+            yhteyshenkilo.tunnus as yhteyshenkilo_tunnus,
             yhteyshenkilo.ulkoinen_asiakasnumero,
             yhteyshenkilo.verkkokauppa_nakyvyys,
             yhteyshenkilo.verkkokauppa_salasana,
@@ -63,21 +65,27 @@ function presta_hae_asiakkaat_asiakkaittain() {
   $result = pupe_query($query);
 
   while ($asiakas = mysql_fetch_assoc($result)) {
+    $osoitteet = array();
+    $osoitteet[] = array(
+      "asiakas_id" => $asiakas['asiakas_tunnus'],
+      "osoite"     => $asiakas['osoite'],
+      "postino"    => $asiakas['postino'],
+      "postitp"    => $asiakas['postitp'],
+      "maa"        => $asiakas['maa'],
+    );
+
     $asiakkaat[] = array(
       "email"                   => $asiakas['email'],
       "gsm"                     => $asiakas['gsm'],
-      "maa"                     => $asiakas['maa'],
       "nimi"                    => $asiakas['nimi'],
-      "osoite"                  => $asiakas['osoite'],
-      "postino"                 => $asiakas['postino'],
-      "postitp"                 => $asiakas['postitp'],
       "presta_customergroup_id" => $asiakas['selitetark_5'],
       "puh"                     => $asiakas['puh'],
-      "tunnus"                  => $asiakas['tunnus'],
+      "tunnus"                  => $asiakas['yhteyshenkilo_tunnus'],
       "ulkoinen_asiakasnumero"  => $asiakas['ulkoinen_asiakasnumero'],
       "verkkokauppa_nakyvyys"   => $asiakas['verkkokauppa_nakyvyys'],
       "verkkokauppa_salasana"   => $asiakas['verkkokauppa_salasana'],
       "yhtio"                   => $asiakas['yhtio'],
+      "osoitteet"               => $osoitteet,
     );
   }
 
@@ -119,7 +127,7 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
 
     // haetaan kaikki osoitteet asiakkailta
     $query = "SELECT distinct
-              asiakas.tunnus as asiakas_id,
+              asiakas.tunnus,
               asiakas.osoite,
               asiakas.postino,
               asiakas.postitp,
@@ -131,16 +139,22 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
     $osoite_result = pupe_query($query);
 
     while ($osoite = mysql_fetch_assoc($osoite_result)) {
-      $osoitteet[] = $osoite;
+      $osoitteet[] = array(
+        "asiakas_id" => $osoite['tunnus'],
+        "osoite"     => $osoite['osoite'],
+        "postino"    => $osoite['postino'],
+        "postitp"    => $osoite['postitp'],
+        "maa"        => $osoite['maa'],
+      );
     }
 
     // haetaan kaikki toimitusosoitteet asiakkailta
     $query = "SELECT distinct
-              asiakas.tunnus as asiakas_id,
-              asiakas.toim_osoite as osoite,
-              asiakas.toim_postino as postino,
-              asiakas.toim_postitp as postitp,
-              asiakas.toim_maa as maa
+              asiakas.tunnus,
+              asiakas.toim_osoite,
+              asiakas.toim_postino,
+              asiakas.toim_postitp,
+              asiakas.toim_maa
               FROM asiakas
               WHERE asiakas.yhtio = '{$kukarow['yhtio']}'
               AND asiakas.tunnus in ($asiakas_tunnukset)
@@ -148,7 +162,13 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
     $osoite_result = pupe_query($query);
 
     while ($osoite = mysql_fetch_assoc($osoite_result)) {
-      $osoitteet[] = $osoite;
+      $osoitteet[] = array(
+        "asiakas_id" => $osoite['tunnus'],
+        "osoite"     => $osoite['toim_osoite'],
+        "postino"    => $osoite['toim_postino'],
+        "postitp"    => $osoite['toim_postitp'],
+        "maa"        => $osoite['toim_maa'],
+      );
     }
 
     // lis‰t‰‰n asiakas array

--- a/rajapinnat/presta/presta_functions.php
+++ b/rajapinnat/presta/presta_functions.php
@@ -91,14 +91,15 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
 
   // Haetaan kaikki yhteyshenkilöt ja niiden asiakkaat
   $query = "SELECT yhteyshenkilo.email,
-            max(yhteyshenkilo.nimi) as nimi,
+            max(avainsana.selitetark_5) as selitetark_5,
             max(yhteyshenkilo.gsm) as gsm,
+            max(yhteyshenkilo.nimi) as nimi,
             max(yhteyshenkilo.puh) as puh,
+            max(yhteyshenkilo.tunnus) as tunnus,
             max(yhteyshenkilo.ulkoinen_asiakasnumero) as ulkoinen_asiakasnumero,
             max(yhteyshenkilo.verkkokauppa_nakyvyys) as verkkokauppa_nakyvyys,
-            max(yhteyshenkilo.yhtio) as yhtio,
             max(yhteyshenkilo.verkkokauppa_salasana) as verkkokauppa_salasana,
-            max(avainsana.selitetark_5) as selitetark_5,
+            max(yhteyshenkilo.yhtio) as yhtio,
             group_concat(yhteyshenkilo.liitostunnus) as asiakkaat
             FROM yhteyshenkilo
             INNER JOIN asiakas ON (asiakas.yhtio = yhteyshenkilo.yhtio
@@ -118,11 +119,11 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
 
     // haetaan kaikki osoitteet asiakkailta
     $query = "SELECT distinct
-              tunnus,
-              osoite,
-              postino,
-              postitp,
-              maa
+              asiakas.tunnus as asiakas_id,
+              asiakas.osoite,
+              asiakas.postino,
+              asiakas.postitp,
+              asiakas.maa
               FROM asiakas
               WHERE asiakas.yhtio = '{$kukarow['yhtio']}'
               AND asiakas.tunnus in ($asiakas_tunnukset)
@@ -135,11 +136,11 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
 
     // haetaan kaikki toimitusosoitteet asiakkailta
     $query = "SELECT distinct
-              tunnus,
-              toim_osoite as osoite,
-              toim_postino as postino,
-              toim_postitp as postitp,
-              toim_maa as maa
+              asiakas.tunnus as asiakas_id,
+              asiakas.toim_osoite as osoite,
+              asiakas.toim_postino as postino,
+              asiakas.toim_postitp as postitp,
+              asiakas.toim_maa as maa
               FROM asiakas
               WHERE asiakas.yhtio = '{$kukarow['yhtio']}'
               AND asiakas.tunnus in ($asiakas_tunnukset)
@@ -155,9 +156,10 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
       "email"                   => $yhteyshenkilo['email'],
       "gsm"                     => $yhteyshenkilo['gsm'],
       "nimi"                    => $yhteyshenkilo['nimi'],
-      "presta_customer_id"      => $yhteyshenkilo['ulkoinen_asiakasnumero'],
       "presta_customergroup_id" => $yhteyshenkilo['selitetark_5'],
       "puh"                     => $yhteyshenkilo['puh'],
+      "tunnus"                  => $yhteyshenkilo['tunnus'],
+      "ulkoinen_asiakasnumero"  => $yhteyshenkilo['ulkoinen_asiakasnumero'],
       "verkkokauppa_nakyvyys"   => $yhteyshenkilo['verkkokauppa_nakyvyys'],
       "verkkokauppa_salasana"   => $yhteyshenkilo['verkkokauppa_salasana'],
       "yhtio"                   => $yhteyshenkilo['yhtio'],

--- a/rajapinnat/presta/presta_functions.php
+++ b/rajapinnat/presta/presta_functions.php
@@ -19,6 +19,7 @@ function presta_hae_asiakkaat($asiakaskasittely) {
 function presta_hae_asiakkaat_asiakkaittain() {
   global $kukarow, $yhtiorow, $ajetaanko_kaikki;
 
+  $asiakkaat = array();
   $datetime_checkpoint = presta_export_checkpoint('PSTS_ASIAKAS');
 
   if ($ajetaanko_kaikki == "NO") {
@@ -33,9 +34,21 @@ function presta_hae_asiakkaat_asiakkaittain() {
     $muutoslisa = "";
   }
 
-  $query = "SELECT asiakas.*,
-            yhteyshenkilo.*,
-            avainsana.selitetark_5 AS presta_customergroup_id
+  $query = "SELECT
+            avainsana.selitetark_5,
+            yhteyshenkilo.email,
+            yhteyshenkilo.gsm,
+            yhteyshenkilo.maa,
+            yhteyshenkilo.nimi,
+            yhteyshenkilo.osoite,
+            yhteyshenkilo.postino,
+            yhteyshenkilo.postitp,
+            yhteyshenkilo.puh,
+            yhteyshenkilo.tunnus,
+            yhteyshenkilo.ulkoinen_asiakasnumero,
+            yhteyshenkilo.verkkokauppa_nakyvyys,
+            yhteyshenkilo.verkkokauppa_salasana,
+            yhteyshenkilo.yhtio
             FROM yhteyshenkilo
             INNER JOIN asiakas
             ON (asiakas.yhtio = yhteyshenkilo.yhtio
@@ -49,9 +62,23 @@ function presta_hae_asiakkaat_asiakkaittain() {
             {$muutoslisa}";
   $result = pupe_query($query);
 
-  $asiakkaat = array();
   while ($asiakas = mysql_fetch_assoc($result)) {
-    $asiakkaat[] = $asiakas;
+    $asiakkaat[] = array(
+      "email"                   => $asiakas['email'],
+      "gsm"                     => $asiakas['gsm'],
+      "maa"                     => $asiakas['maa'],
+      "nimi"                    => $asiakas['nimi'],
+      "osoite"                  => $asiakas['osoite'],
+      "postino"                 => $asiakas['postino'],
+      "postitp"                 => $asiakas['postitp'],
+      "presta_customergroup_id" => $asiakas['selitetark_5'],
+      "puh"                     => $asiakas['puh'],
+      "tunnus"                  => $asiakas['tunnus'],
+      "ulkoinen_asiakasnumero"  => $asiakas['ulkoinen_asiakasnumero'],
+      "verkkokauppa_nakyvyys"   => $asiakas['verkkokauppa_nakyvyys'],
+      "verkkokauppa_salasana"   => $asiakas['verkkokauppa_salasana'],
+      "yhtio"                   => $asiakas['yhtio'],
+    );
   }
 
   return $asiakkaat;

--- a/rajapinnat/presta/presta_functions.php
+++ b/rajapinnat/presta/presta_functions.php
@@ -37,6 +37,7 @@ function presta_hae_asiakkaat_asiakkaittain() {
 
   $query = "SELECT
             asiakas.tunnus as asiakas_tunnus,
+            asiakas.kuljetusohje,
             avainsana.selitetark_5,
             yhteyshenkilo.email,
             yhteyshenkilo.gsm,
@@ -79,14 +80,15 @@ function presta_hae_asiakkaat_asiakkaittain() {
 
     $asiakkaat[] = array(
       "email"                   => $asiakas['email'],
+      "kuljetusohje"            => $asiakas['kuljetusohje'],
       "nimi"                    => $asiakas['nimi'],
+      "osoitteet"               => $osoitteet,
       "presta_customergroup_id" => $asiakas['selitetark_5'],
       "tunnus"                  => $asiakas['yhteyshenkilo_tunnus'],
       "ulkoinen_asiakasnumero"  => $asiakas['ulkoinen_asiakasnumero'],
       "verkkokauppa_nakyvyys"   => $asiakas['verkkokauppa_nakyvyys'],
       "verkkokauppa_salasana"   => $asiakas['verkkokauppa_salasana'],
       "yhtio"                   => $asiakas['yhtio'],
-      "osoitteet"               => $osoitteet,
     );
   }
 
@@ -109,6 +111,7 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
             max(yhteyshenkilo.verkkokauppa_nakyvyys) as verkkokauppa_nakyvyys,
             max(yhteyshenkilo.verkkokauppa_salasana) as verkkokauppa_salasana,
             max(yhteyshenkilo.yhtio) as yhtio,
+            max(asiakas.kuljetusohje) as kuljetusohje,
             group_concat(yhteyshenkilo.liitostunnus) as asiakkaat
             FROM yhteyshenkilo
             INNER JOIN asiakas ON (asiakas.yhtio = yhteyshenkilo.yhtio
@@ -182,14 +185,15 @@ function presta_hae_asiakkaat_yhteyshenkiloittain() {
     // lisätään asiakas array
     $asiakkaat[] = array(
       "email"                   => $yhteyshenkilo['email'],
+      "kuljetusohje"            => $yhteyshenkilo['kuljetusohje'],
       "nimi"                    => $yhteyshenkilo['nimi'],
+      "osoitteet"               => $osoitteet,
       "presta_customergroup_id" => $yhteyshenkilo['selitetark_5'],
       "tunnus"                  => $yhteyshenkilo['tunnus'],
       "ulkoinen_asiakasnumero"  => $yhteyshenkilo['ulkoinen_asiakasnumero'],
       "verkkokauppa_nakyvyys"   => $yhteyshenkilo['verkkokauppa_nakyvyys'],
       "verkkokauppa_salasana"   => $yhteyshenkilo['verkkokauppa_salasana'],
       "yhtio"                   => $yhteyshenkilo['yhtio'],
-      "osoitteet"               => $osoitteet,
     );
   }
 

--- a/rajapinnat/presta/presta_products.php
+++ b/rajapinnat/presta/presta_products.php
@@ -611,7 +611,11 @@ class PrestaProducts extends PrestaClient {
   }
 
   public function product_id_by_sku($sku) {
-    $product_id = array_search($sku, $this->all_skus());
+    // lowercase all Presta SKU:s and the search term
+    $all_products = array_map('strtolower', $this->all_skus());
+    $search = strtolower($sku);
+
+    $product_id = array_search($search, $all_products);
 
     return $product_id;
   }

--- a/rajapinnat/presta/presta_sales_orders.php
+++ b/rajapinnat/presta/presta_sales_orders.php
@@ -207,7 +207,18 @@ class PrestaSalesOrders extends PrestaClient {
     $invoice_country  = $params["invoice_country"];
     $order            = $params["order"];
 
-    $pupesoft_customer = presta_hae_yhteyshenkilon_asiakas_ulkoisella_asiakasnumerolla($order['id_customer']);
+    // if we have pupesoft customer id in delivery address DNI
+    $pupesoft_customer = presta_hae_asiakas_tunnuksella($delivery_address['dni']);
+
+    // if we have pupesoft customer id in invoice address DNI
+    if (empty($pupesoft_customer)) {
+      $pupesoft_customer = presta_hae_asiakas_tunnuksella($invoice_address['dni']);
+    }
+
+    // find customer with ulkoinen asiakasnumero
+    if (empty($pupesoft_customer)) {
+      $pupesoft_customer = presta_hae_yhteyshenkilon_asiakas_ulkoisella_asiakasnumerolla($order['id_customer']);
+    }
 
     if (empty($pupesoft_customer)) {
       $msg = "Asiakasta {$order['id_customer']} ei löytynyt Pupesoftista! ";

--- a/rajapinnat/presta/presta_sales_orders.php
+++ b/rajapinnat/presta/presta_sales_orders.php
@@ -270,8 +270,8 @@ class PrestaSalesOrders extends PrestaClient {
       }
     }
 
-    $invoice_name = $this->clean_name($invoice_address['firstname'], $invoice_address['lastname']);
-    $delivery_name = $this->clean_name($delivery_address['firstname'], $delivery_address['lastname']);
+    $invoice_name = $this->cleanup_name($invoice_address['firstname'], $invoice_address['lastname']);
+    $delivery_name = $this->cleanup_name($delivery_address['firstname'], $delivery_address['lastname']);
 
     // fetch order messages, implode into one string, and remove newlines.
     $order_messages = $this->presta_customer_messages->messages_by_order($order['id']);
@@ -462,7 +462,7 @@ class PrestaSalesOrders extends PrestaClient {
     return "{$this->edi_filepath_base}/liitetiedostot";
   }
 
-  private function clean_name($firstname, $lastname) {
+  private function cleanup_name($firstname, $lastname) {
     $firstname = trim($firstname);
     $lastname = trim($lastname);
 

--- a/rajapinnat/presta/presta_specific_prices.php
+++ b/rajapinnat/presta/presta_specific_prices.php
@@ -197,7 +197,11 @@ class PrestaSpecificPrices extends PrestaClient {
    * @throws Exception
    */
   private function find_presta_product_id($tuoteno) {
-    $presta_product_id = array_search($tuoteno, $this->product_ids);
+    // lowercase all Presta SKU:s and the search term
+    $all_products = array_map('strtolower', $this->product_ids);
+    $search = strtolower($tuoteno);
+
+    $presta_product_id = array_search($search, $all_products);
 
     if ($presta_product_id === false) {
       $msg = "Tuotetta {$tuoteno} ei löytynyt";

--- a/rajapinnat/presta/presta_tuote_export.php
+++ b/rajapinnat/presta/presta_tuote_export.php
@@ -96,11 +96,11 @@ if (!isset($presta_laskutusosoitteen_muutos)) {
   $presta_laskutusosoitteen_muutos = true;
 }
 if (!isset($presta_asiakaskasittely)) {
-  // Prestan asiakkaan määrittely, joko "asiakkaittain" tai "yhteyshenkiloittain".
-  // asiakkaittain = Pupesoftin yhteyshenkilöstä tehdään Prestan asiakas. Prestan asiakkaalla on yksi
-  // osoite, joka tulee Pupesoftin yhteyshenkiloltä.
-  // yhteyshenkiloittain = Pupesoftin asiakkaat groupataan yhteyshenkilon mukaan ja Prestan asiakkaalle
-  // tulee useampi osoitetieto Pupesoftin eri asiakkailta. Yksi osoite per Pupesoftin asiakas.
+  // PrestaShopin asiakkaan määrittely joko "asiakkaittain" tai "yhteyshenkiloittain".
+  // "asiakkaittain" = Pupesoftin yhteyshenkilöstä tehdään PrestaShopin asiakas. PrestaShopin
+  // asiakkaalla on yksi osoite, joka tulee Pupesoftin yhteyshenkiloltä.
+  // "yhteyshenkiloittain" = Pupesoftin asiakkaat yhdistetään yhteyshenkilön mukaan. PrestaShopin
+  // asiakkaalle tulee useampi osoitetieto, jotka tulevat Pupesoftin eri asiakkailta.
   $presta_asiakaskasittely = 'asiakkaittain';
 }
 if (!isset($presta_haettavat_tilaus_statukset)) {

--- a/rajapinnat/presta/presta_tuote_export.php
+++ b/rajapinnat/presta/presta_tuote_export.php
@@ -308,7 +308,7 @@ if (presta_ajetaanko_sykronointi('asiakasryhmat', $synkronoi)) {
 }
 
 if (presta_ajetaanko_sykronointi('asiakkaat', $synkronoi)) {
-  $asiakkaat = presta_hae_asiakkaat();
+  $asiakkaat = presta_hae_asiakkaat($presta_asiakaskasittely);
 
   presta_echo("Siirret‰‰n asiakkaat.");
   $presta_customer = new PrestaCustomers($presta_url, $presta_api_key, 'presta_asiakkaat');

--- a/rajapinnat/presta/presta_tuote_export.php
+++ b/rajapinnat/presta/presta_tuote_export.php
@@ -95,6 +95,14 @@ if (!isset($presta_laskutusosoitteen_muutos)) {
   // jos false, otetaan aina pupesoftin asiakkaan laskutusosoite
   $presta_laskutusosoitteen_muutos = true;
 }
+if (!isset($presta_asiakaskasittely)) {
+  // Prestan asiakkaan määrittely, joko "asiakkaittain" tai "yhteyshenkiloittain".
+  // asiakkaittain = Pupesoftin yhteyshenkilöstä tehdään Prestan asiakas. Prestan asiakkaalla on yksi
+  // osoite, joka tulee Pupesoftin yhteyshenkiloltä.
+  // yhteyshenkiloittain = Pupesoftin asiakkaat groupataan yhteyshenkilon mukaan ja Prestan asiakkaalle
+  // tulee useampi osoitetieto Pupesoftin eri asiakkailta. Yksi osoite per Pupesoftin asiakas.
+  $presta_asiakaskasittely = 'asiakkaittain';
+}
 if (!isset($presta_haettavat_tilaus_statukset)) {
   // Missä tilassa olevia tilauksia haetaan Prestasta
   /* Tämä on Prestan default status list;
@@ -305,6 +313,7 @@ if (presta_ajetaanko_sykronointi('asiakkaat', $synkronoi)) {
   presta_echo("Siirretään asiakkaat.");
   $presta_customer = new PrestaCustomers($presta_url, $presta_api_key, 'presta_asiakkaat');
 
+  $presta_customer->set_customer_handling($presta_asiakaskasittely);
   $presta_customer->set_default_groups($presta_vakioasiakasryhmat);
   $presta_customer->set_dynamic_fields($presta_dynaamiset_asiakasparametrit);
   $presta_customer->sync_customers($asiakkaat);


### PR DESCRIPTION
PrestaShopin asiakkaan määrittely joko "asiakkaittain" tai "yhteyshenkilöittäin".

* **Asiakkaittain.** Pupesoftin yhteyshenkilöstä tehdään PrestaShopin asiakas. PrestaShopin asiakkaalla on yksi osoite, joka tulee Pupesoftin yhteyshenkiloltä.

* **Yhteyshenkilöittäin.** Pupesoftin asiakkaat yhdistetään yhteyshenkilön mukaan. PrestaShopin asiakkaalle tulee useampi osoitetieto, jotka tulevat Pupesoftin eri asiakkailta.