### PR TITLE
Tuotteen toimittajat oletuksia

### DIFF
--- a/inc/tuotteen_toimittajattarkista.inc
+++ b/inc/tuotteen_toimittajattarkista.inc
@@ -60,6 +60,8 @@ if (!function_exists("tuotteen_toimittajattarkista")) {
           if (mysql_num_rows($sresult) == 1) {
             $srow = mysql_fetch_assoc($sresult);
             $liitostunnus_static = $srow["tunnus"];
+            $maa_static = $srow['maa'];
+            $valuutta_static = $srow['oletus_valkoodi'];
           }
         }
 


### PR DESCRIPTION
Lisätty tuki toimittajan valuutan ja toimittajan lähetysmaan hakuun toimittajalta sillon kun tuotteen toimittajat on jo perustettuna. Aikaisemmin perustuksen jälkeen ei voinut esim valuuttaa hakea uudestaan toimittajalta. Jatkossa voi, kunhan alasvetolaatikkoon valitsee "toimittajan valuutta".