### PR TITLE
Unifaun toimitustavat: toimitusvahvistus sähköpostiin

### DIFF
--- a/unifaun_fetch.php
+++ b/unifaun_fetch.php
@@ -19,7 +19,6 @@ if ($php_cli and count(debug_backtrace()) <= 1) {
   }
 
   // otetaan includepath aina rootista
-  ini_set("include_path", ini_get("include_path").PATH_SEPARATOR.dirname(__FILE__).PATH_SEPARATOR."/usr/share/pear");
   error_reporting(E_ALL ^E_WARNING ^E_NOTICE);
   ini_set("display_errors", 0);
 
@@ -27,8 +26,10 @@ if ($php_cli and count(debug_backtrace()) <= 1) {
   require "inc/connect.inc";
   require "inc/functions.inc";
 
+  ini_set("include_path", ini_get("include_path").PATH_SEPARATOR.dirname(__FILE__).PATH_SEPARATOR."/usr/share/pear");
+
   // Pupeasennuksen root polku, toimitusvahvistuksia varten
-  $pupe_root_polku = dirname(dirname(__FILE__));
+  $pupe_root_polku = dirname(__FILE__);
 
   $kukarow['yhtio'] = (string) $argv[1];
   $kukarow['kuka']  = 'admin';
@@ -372,7 +373,7 @@ if ($handle = opendir($ftpget_dest[$operaattori])) {
             $desadv_version = "";
           }
 
-          if (file_exists("tilauskasittely/{$laskurow['toimitusvahvistus']}")) {
+          if (file_exists("{$pupe_root_polku}/tilauskasittely/{$laskurow['toimitusvahvistus']}")) {
 
             $rakir_row = $laskurow;
 

--- a/unifaun_fetch.php
+++ b/unifaun_fetch.php
@@ -19,14 +19,13 @@ if ($php_cli and count(debug_backtrace()) <= 1) {
   }
 
   // otetaan includepath aina rootista
+  ini_set("include_path", ini_get("include_path").PATH_SEPARATOR.dirname(__FILE__).PATH_SEPARATOR."/usr/share/pear");
   error_reporting(E_ALL ^E_WARNING ^E_NOTICE);
   ini_set("display_errors", 0);
 
   // otetaan tietokanta connect
   require "inc/connect.inc";
   require "inc/functions.inc";
-
-  ini_set("include_path", ini_get("include_path").PATH_SEPARATOR.dirname(__FILE__).PATH_SEPARATOR."/usr/share/pear");
 
   // Pupeasennuksen root polku, toimitusvahvistuksia varten
   $pupe_root_polku = dirname(__FILE__);


### PR DESCRIPTION
Unifaun toimitustapojen kohdalla oli ongelmia toimitusvahvistuksen lähetyksessä ja toimitusvahvistuksia ei saatu sähköpostiin. Tätä on nyt korjattu ja jatkossa toimitusvahvistusten lähetys toimii taas.