### PR TITLE
* Ostolaskujen hyväksyntä valinnaiseksi

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -33991,7 +33991,8 @@ if (!function_exists("laskun_hyvaksyjia")) {
     $query = " SELECT count(*) kpl
                FROM kuka
                WHERE yhtio = '$kukarow[yhtio]'
-               AND hyvaksyja != ''";
+               AND hyvaksyja != ''
+               AND extranet = ''";
     $hyv_res = pupe_query($query);
     $hyv_row = mysql_fetch_assoc($hyv_res);
     

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -33984,6 +33984,26 @@ if (!function_exists('tilausrivin_esisyotto')) {
   }
 }
 
+if (!function_exists("laskun_hyvaksyjia")) {
+  function laskun_hyvaksyjia() {
+    global $kukarow, $yhtiorow;
+
+    $query = " SELECT count(*) kpl
+               FROM kuka
+               WHERE yhtio = '$kukarow[yhtio]'
+               AND hyvaksyja != ''";
+    $hyv_res = pupe_query($query);
+    $hyv_row = mysql_fetch_assoc($hyv_res);
+    
+    if ($hyv_row['kpl'] > 0) {
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+}
+
 if (!function_exists("laske_korko")) {
   function laske_korko(Array $params) {
     global $kukarow, $yhtiorow;

--- a/inc/toimitarkista.inc
+++ b/inc/toimitarkista.inc
@@ -29,7 +29,7 @@ if (!function_exists("toimitarkista")) {
         $t[$i] = $tmp_nimi;
       }
 
-      if (trim($t[$i]) == '' and ($yhtiorow['jalkilaskenta_kuluperuste'] != 'VS' or $alias_set == "KAYTTAJA")) {
+      if (trim($t[$i]) == '' and ($yhtiorow['jalkilaskenta_kuluperuste'] != 'VS' or $alias_set == "KAYTTAJA") and laskun_hyvaksyjia()) {
         $virhe[$i] = t("Tieto puuttuu");
       }
     }

--- a/ulask.php
+++ b/ulask.php
@@ -1681,46 +1681,54 @@ if ($tee == 'P' or $tee == 'E') {
 
   echo "</tr>";
 
-  echo "<tr><td colspan='2'><hr></td></tr>";
+  if (laskun_hyvaksyjia()) {
+    
+    echo "<tr><td colspan='2'><hr></td></tr>";
+    echo "<tr><td valign='top'>".t("Hyv‰ksyj‰t")."</td><td>";
 
-  echo "<tr><td valign='top'>".t("Hyv‰ksyj‰t")."</td><td>";
+    $query = "SELECT DISTINCT kuka.kuka, kuka.nimi
+              FROM kuka
+              JOIN oikeu ON oikeu.yhtio = kuka.yhtio and oikeu.kuka = kuka.kuka and oikeu.nimi like '%hyvak.php'
+              WHERE kuka.yhtio    = '$kukarow[yhtio]'
+              AND kuka.aktiivinen = 1
+              AND kuka.extranet   = ''
+              and kuka.hyvaksyja  = 'o'
+              ORDER BY kuka.nimi";
+    $vresult = pupe_query($query);
 
-  $query = "SELECT DISTINCT kuka.kuka, kuka.nimi
-            FROM kuka
-            JOIN oikeu ON oikeu.yhtio = kuka.yhtio and oikeu.kuka = kuka.kuka and oikeu.nimi like '%hyvak.php'
-            WHERE kuka.yhtio    = '$kukarow[yhtio]'
-            AND kuka.aktiivinen = 1
-            AND kuka.extranet   = ''
-            and kuka.hyvaksyja  = 'o'
-            ORDER BY kuka.nimi";
-  $vresult = pupe_query($query);
+    $ulos = '';
+    // T‰ytet‰‰n 5 hyv‰ksynt‰kentt‰‰
+    for ($i=1; $i<6; $i++) {
 
-  $ulos = '';
-  // T‰ytet‰‰n 5 hyv‰ksynt‰kentt‰‰
-  for ($i=1; $i<6; $i++) {
-
-    while ($vrow = mysql_fetch_assoc($vresult)) {
-      $sel = "";
-      if ($hyvak[$i] == $vrow['kuka']) {
-        $sel = "selected";
+      while ($vrow = mysql_fetch_assoc($vresult)) {
+        $sel = "";
+        if ($hyvak[$i] == $vrow['kuka']) {
+          $sel = "selected";
+        }
+        $ulos .= "<option value ='$vrow[kuka]' $sel>$vrow[nimi]";
       }
-      $ulos .= "<option value ='$vrow[kuka]' $sel>$vrow[nimi]";
+
+      // K‰yd‰‰n sama data l‰pi uudestaan
+      if (!mysql_data_seek($vresult, 0)) {
+        echo "mysql_data_seek failed!";
+        exit;
+      }
+
+      echo "<select name='hyvak[$i]' tabindex='24'>
+          <option value = ' '>".t("Ei kukaan")."
+          $ulos
+          </select>";
+      $ulos="";
+
+      // Tehd‰‰n checkbox, jolla annetaan lupa muuttaa hyv‰ksynt‰listaa myˆhemmin
+      if ($i == 1) {
+        echo " ".t("Listaa saa muuttaa")." <input type='checkbox' name='ohyvaksynnanmuutos' $ohyvaksynnanmuutos tabindex='-1'>";
+      }
+      echo "<br>";
     }
 
-    echo "<select name='hyvak[$i]' tabindex='24'>
-        <option value = ' '>".t("Ei kukaan")."
-        $ulos
-        </select>";
-    $ulos="";
-
-    // Tehd‰‰n checkbox, jolla annetaan lupa muuttaa hyv‰ksynt‰listaa myˆhemmin
-    if ($i == 1) {
-      echo " ".t("Listaa saa muuttaa")." <input type='checkbox' name='ohyvaksynnanmuutos' $ohyvaksynnanmuutos tabindex='-1'>";
-    }
-    echo "<br>";
+    echo "</td></tr>";
   }
-
-  echo "</td></tr>";
 
   echo "<tr><td colspan='2'>";
 

--- a/ulask.php
+++ b/ulask.php
@@ -619,7 +619,7 @@ if ($tee == 'I') {
     $tee = 'E';
   }
 
-  if (trim($hyvak[1]) == "") {
+  if (trim($hyvak[1]) == "" and laskun_hyvaksyjia()) {
     $errormsg .= "<font class='error'>".t("Laskulla on pakko olla ensimm‰inen hyv‰ksyj‰")."!</font><br>";
     $tee = 'E';
   }
@@ -1707,11 +1707,6 @@ if ($tee == 'P' or $tee == 'E') {
       $ulos .= "<option value ='$vrow[kuka]' $sel>$vrow[nimi]";
     }
 
-    // K‰yd‰‰n sama data l‰pi uudestaan
-    if (!mysql_data_seek($vresult, 0)) {
-      echo "mysql_data_seek failed!";
-      exit;
-    }
     echo "<select name='hyvak[$i]' tabindex='24'>
         <option value = ' '>".t("Ei kukaan")."
         $ulos


### PR DESCRIPTION
Jatkossa yrityksen käyttäjien ei ole pakko hyväksyä ostolaskuja. 

Toiminnallisuus vaatii että yksikään yrityksen käyttäjä ei ole merkitty hyväksyjäksi (tätä säädetään käyttäjäylläpidossa). Ominaisuuden myötä toimittajalle ei tarvitse kertoa oletushyväksyjää eikä uuden laskun syötössä tarvitse kertoa hyväksyjiä. Ostolasku menee luonnin jälkeen suoraan maksatukseen.

Jos yrityksessä on yksikin käyttäjä merkitty hyväksyjäksi, niin toiminnallisuuteen ei tule muutoksia.