### PR TITLE
Sarjanumeroseuranta: massakohdistus

### DIFF
--- a/tilauskasittely/sarjanumeroseuranta.php
+++ b/tilauskasittely/sarjanumeroseuranta.php
@@ -509,12 +509,33 @@ if ($toiminto == 'MUOKKAA') {
   }
 }
 
-// Ollaan syötetty uusi
-if ($toiminto == 'LISAA' and trim($sarjanumero) != '') {
+echo "<pre>",var_dump($_FILES['userfile']),"</pre>";
 
-  $sarjanumero = trim($sarjanumero);
+// Ollaan syötetty uusi
+if ($toiminto == 'LISAA' and (trim($sarjanumero) != '' or is_uploaded_file($_FILES['userfile']['tmp_name']) === true)) {
+  $sarjanumero_array = array();
+
+  if (is_uploaded_file($_FILES['userfile']['tmp_name']) === true) {
+
+    $kasiteltava_tiedoto_path = $_FILES['userfile']['tmp_name'];
+    $path_parts = pathinfo($_FILES['userfile']['name']);
+    $ext = strtoupper($path_parts['extension']);
+
+    $sarjanumero_array = pupeFileReader($kasiteltava_tiedoto_path, $ext);
+  }
+  else {
+    $sarjanumero = trim($sarjanumero);
+    $sarjanumero_array[] = $sarjanumero;
+  }
+
   $era_kpl    = (float) str_replace(",", ".", $era_kpl);
   $insok      = "OK";
+
+  foreach ($sarjanumero_array as $sarjanumero) {
+    echo "sarjanumero: $sarjanumero<br>";
+  }
+
+  exit;
 
   if ($rivirow["sarjanumeroseuranta"] == "S" or $rivirow["sarjanumeroseuranta"] == "T" or $rivirow["sarjanumeroseuranta"] == "V") {
     $query = "SELECT *
@@ -1685,6 +1706,25 @@ if ($rivirow["tyyppi"] != 'V') {
     echo "<td class='back'><input type='submit' value='".t("Lisää")."'></td>";
     echo "</form>";
     echo "</tr></table>";
+
+    echo "<br>";
+    echo "<form method='post' action='sarjanumeroseuranta.php' enctype='multipart/form-data' autocomplete='off'>";
+    echo "<input type='hidden' name='$tunnuskentta' value='$rivitunnus'>";
+    echo "<input type='hidden' name='from' value='$from'>";
+    echo "<input type='hidden' name='lopetus' value='$lopetus'>";
+    echo "<input type='hidden' name='aputoim' value='$aputoim'>";
+    echo "<input type='hidden' name='otunnus' value='$otunnus'>";
+    echo "<input type='hidden' name='muut_siirrettavat' value='$muut_siirrettavat'>";
+    echo "<input type='hidden' name='toiminto' value='LISAA'>";
+    echo "<input type='hidden' name='valitut_sarjat' value='".implode(",", $valitut_sarjat)."'>";
+    echo "<table>";
+    echo "<tr>";
+    echo "<th>".t("Lisää excelistä")."</th>";
+    echo "<td><input type='file' name='userfile'></td>";
+    echo "<td class='back' colspan='2'><input type='submit' value='".t("Lisää")."'></td>";
+    echo "</tr>";
+    echo "</table>";
+    echo "</form>";
   }
 }
 

--- a/tilauskasittely/sarjanumeroseuranta.php
+++ b/tilauskasittely/sarjanumeroseuranta.php
@@ -521,7 +521,11 @@ if ($toiminto == 'LISAA' and (trim($sarjanumero) != '' or is_uploaded_file($_FIL
     $path_parts = pathinfo($_FILES['userfile']['name']);
     $ext = strtoupper($path_parts['extension']);
 
-    $sarjanumero_array = pupeFileReader($kasiteltava_tiedoto_path, $ext);
+    $excelrivit = pupeFileReader($kasiteltava_tiedoto_path, $ext);
+
+    foreach($excelrivit as $rivi) {
+      $sarjanumero_array[] = $rivi[0];
+    }
   }
   else {
     $sarjanumero = trim($sarjanumero);

--- a/tilauskasittely/sarjanumeroseuranta.php
+++ b/tilauskasittely/sarjanumeroseuranta.php
@@ -94,6 +94,7 @@ echo "<font class='head'>".t("Sarjanumeroseuranta")."</font><hr>";
 $tunnuskentta = "";
 $rivitunnus = "";
 $hyvitysrivi = "";
+$is_uploaded_file = is_uploaded_file($_FILES['userfile']['tmp_name']);
 
 if ($myyntirivitunnus != "") {
   $tunnuskentta = "myyntirivitunnus";
@@ -510,10 +511,10 @@ if ($toiminto == 'MUOKKAA') {
 }
 
 // Ollaan syötetty uusi
-if ($toiminto == 'LISAA' and (trim($sarjanumero) != '' or is_uploaded_file($_FILES['userfile']['tmp_name']) === true)) {
+if ($toiminto == 'LISAA' and (trim($sarjanumero) != '' or $is_uploaded_file === true)) {
   $sarjanumero_array = array();
 
-  if (is_uploaded_file($_FILES['userfile']['tmp_name']) === true) {
+  if ($is_uploaded_file === true) {
 
     $kasiteltava_tiedoto_path = $_FILES['userfile']['tmp_name'];
     $path_parts = pathinfo($_FILES['userfile']['name']);

--- a/tilauskasittely/sarjanumeroseuranta.php
+++ b/tilauskasittely/sarjanumeroseuranta.php
@@ -531,6 +531,8 @@ if ($toiminto == 'LISAA' and (trim($sarjanumero) != '' or is_uploaded_file($_FIL
   $era_kpl    = (float) str_replace(",", ".", $era_kpl);
   $insok      = "OK";
 
+  echo "<pre>",var_dump($sarjanumero_array),"</pre>";
+
   foreach ($sarjanumero_array as $sarjanumero) {
     echo "sarjanumero: $sarjanumero<br>";
   }

--- a/tilauskasittely/sarjanumeroseuranta.php
+++ b/tilauskasittely/sarjanumeroseuranta.php
@@ -509,8 +509,6 @@ if ($toiminto == 'MUOKKAA') {
   }
 }
 
-echo "<pre>",var_dump($_FILES['userfile']),"</pre>";
-
 // Ollaan syötetty uusi
 if ($toiminto == 'LISAA' and (trim($sarjanumero) != '' or is_uploaded_file($_FILES['userfile']['tmp_name']) === true)) {
   $sarjanumero_array = array();


### PR DESCRIPTION
Nyt voi massakohdistaa sarjanumeroita suoraan Excelistä. Käyttöliittymään on lisätty kohta "Lisää Excelistä". Excelistä ajetut sarjanumerot käyvät läpi saman logiikan kuin yksittäisen sarjanumeron lisäys.

Excelin rakenne on yksinkertainen: A-sarakkeeseen listataan haluttuja sarjanumeroita.