### PR TITLE
Korjaus verkkokauppatilauksen muokkaamiseen

### DIFF
--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -4330,15 +4330,23 @@ if (isset($jatka)) {
 
   // Käsinsyötetyt verkkokauppatilaukset-toiminnallisuus
   // Tilaus laskutetaan heti ja laitetaan sitten sen jälkeen takaisin keräsyjonoon
-  // Siäsinen täppä tulee laittaa vain jos tilaus on vielä kesken,
-  // muuten se saa tilauksen menemään toimitettu tilaan
-  if ($tilaustyyppi == "W" and mysql_num_rows($vk_kassalipas_res) and $alatila == "") {
+  if ($tilaustyyppi == "W" and mysql_num_rows($vk_kassalipas_res)) {
     $kassalipas_row = mysql_fetch_assoc($vk_kassalipas_res);
 
     $kassalipas = $kassalipas_row['kassalipas'];
     $maksuehto  = $kassalipas_row['maksuehto'];
-    $sisainen   = "o";
+
+    // Siäsinen täppä tulee laittaa vain jos tilaus on vielä kesken,
+    // muuten se saa tilauksen menemään toimitettu tilaan
+    if ($alatila == "") {
+      $sisainen = "o";
+    }
+    else {
+      $sisainen = "";
+    }
+
   }
+
 
   if (!isset($campaign_id)) {
     $campaign_id = 'NULL';

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -4330,7 +4330,9 @@ if (isset($jatka)) {
 
   // Käsinsyötetyt verkkokauppatilaukset-toiminnallisuus
   // Tilaus laskutetaan heti ja laitetaan sitten sen jälkeen takaisin keräsyjonoon
-  if ($tilaustyyppi == "W" and mysql_num_rows($vk_kassalipas_res)) {
+  // Siäsinen täppä tulee laittaa vain jos tilaus on vielä kesken,
+  // muuten se saa tilauksen menemään toimitettu tilaan
+  if ($tilaustyyppi == "W" and mysql_num_rows($vk_kassalipas_res) and $alatila == "") {
     $kassalipas_row = mysql_fetch_assoc($vk_kassalipas_res);
 
     $kassalipas = $kassalipas_row['kassalipas'];

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -4344,9 +4344,7 @@ if (isset($jatka)) {
     else {
       $sisainen = "";
     }
-
   }
-
 
   if (!isset($campaign_id)) {
     $campaign_id = 'NULL';


### PR DESCRIPTION
Kertaalleen valmiiksi laitetun (ei enää kesken tilassa olevan) etukäteen maksetun verkkokauppatilauksen otsikolla käyminen sai sisäisen laskutuksen täppäytymään uudelleen päälle, mikä sai tilauksen toimittumaan heti ja johti tilauksen jumittumiseen hankalaan tilaan. Korjattu nyt niin, että laskuta heti sisäinen täppää ei automaattisesti uudestaan päälle täpätä.