### PR TITLE
WooCommerce rajapinta

### DIFF
--- a/inc/parametrit.inc
+++ b/inc/parametrit.inc
@@ -272,6 +272,7 @@ unset($magento_api_ht_pas);
 unset($magento_api_ht_edi);
 
 unset($logmaster);
+unset($woo_config);
 
 unset($pupesoft_commandlinelog);
 

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -4,6 +4,8 @@ if (strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-tulostus.php") !== FALSE) {
   require "inc/parametrit.inc";
 }
 
+require_once 'rajapinnat/woo/woo-functions.php';
+
 $logistiikka_yhtio = '';
 $logistiikka_yhtiolisa = '';
 if (!isset($unifaun_era_vainkollitarra)) $unifaun_era_vainkollitarra = FALSE;
@@ -1135,6 +1137,14 @@ if ($tee == 'tulosta') {
       if (strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-kopio.php") === FALSE and $rakir_row['jv'] == '' and !$unifaun_era_vainkollitarra) {
         paivita_rahtikirjat_tulostetuksi_ja_toimitetuksi(array('otunnukset' => $otunnukset, 'kilotyht' => $kilotyht));
       }
+
+      // Merkaatan woo-commerce tilaukset toimitetuiksi kauppaan
+      $woo_params = array(
+        "pupesoft_tunnukset" => explode(",", $otunnukset),
+        "tracking_code" => $rahtikirjanro,
+      );
+
+      woo_commerce_toimita_tilaus($woo_params);
 
       // Katsotaan onko Magento käytössä, silloin merkataan tilaus toimitetuksi Magentoon kun rahtikirja tulostetaan
       $_magento_kaytossa = (!empty($magento_api_tt_url) and !empty($magento_api_tt_usr) and !empty($magento_api_tt_pas));

--- a/rajapinnat/logmaster/tracking_code.php
+++ b/rajapinnat/logmaster/tracking_code.php
@@ -25,6 +25,7 @@ error_reporting(E_ALL);
 require "inc/connect.inc";
 require "inc/functions.inc";
 require "rajapinnat/logmaster/logmaster-functions.php";
+require 'rajapinnat/woo/woo-functions.php';
 
 // Logitetaan ajo
 cron_log();
@@ -134,6 +135,14 @@ while (false !== ($file = readdir($handle))) {
     paivita_rahtikirjat_tulostetuksi_ja_toimitetuksi($params);
 
     pupesoft_log('logmaster_tracking_code', "Tilauksen {$tilausnumero} seurantakoodisanoma käsitelty");
+
+    // Merkaatan woo-commerce tilaukset toimitetuiksi kauppaan
+    $woo_params = array(
+      "pupesoft_tunnukset" => array($tilausnumero),
+      "tracking_code" => $seurantakoodi,
+    );
+
+    woo_commerce_toimita_tilaus($woo_params);
 
     // Jos Magento on käytössä, merkataan tilaus toimitetuksi Magentoon kun rahtikirja tulostetaan
     if ($_magento_kaytossa) {

--- a/rajapinnat/woo/woo-functions.php
+++ b/rajapinnat/woo/woo-functions.php
@@ -44,11 +44,11 @@ function woo_commerce_toimita_tilaus($params) {
 function woo_commerce_hae_woo_tilausnumerot($pupesoft_tunnukset) {
   global $kukarow, $yhtiorow;
 
-  $result = array();
+  $response = array();
 
   // jos meill‰ ei ole yht‰‰n tilausnumeroita
   if (empty($pupesoft_tunnukset) or !is_array($pupesoft_tunnukset)) {
-    return $result;
+    return $response;
   }
 
   // tehd‰‰n tunnuksista stringi
@@ -65,8 +65,8 @@ function woo_commerce_hae_woo_tilausnumerot($pupesoft_tunnukset) {
   $result = pupe_query($query);
 
   while ($row = mysql_fetch_assoc($result)) {
-    $result[] = $row['asiakkaan_tilausnumero'];
+    $response[] = $row['asiakkaan_tilausnumero'];
   }
 
-  return $result;
+  return $response;
 }

--- a/rajapinnat/woo/woo-functions.php
+++ b/rajapinnat/woo/woo-functions.php
@@ -35,9 +35,7 @@ function woo_commerce_toimita_tilaus($params) {
     );
 
     // tehd‰‰n request
-    $response = pupenext_rest($woo_parameters, "woo/complete_order");
-
-    pupesoft_log("woocommerce_order", $response);
+    pupenext_rest($woo_parameters, "woo_complete_order");
   }
 }
 
@@ -53,6 +51,8 @@ function woo_commerce_hae_woo_tilausnumerot($pupesoft_tunnukset) {
 
   // tehd‰‰n tunnuksista stringi
   $tunnukset = implode(",", $pupesoft_tunnukset);
+
+  pupesoft_log("woocommerce_orders", "P‰ivitet‰‰n tilaukset $tunnukset toimitetuiksi.");
 
   // tehd‰‰n request tilaus kerrallaan
   // ainoastaan jos moduli on magento ja asiakkaan tilausnumero lˆytyy

--- a/rajapinnat/woo/woo-functions.php
+++ b/rajapinnat/woo/woo-functions.php
@@ -1,0 +1,72 @@
+<?php
+
+require 'inc/pupenext_functions.inc';
+
+function woo_commerce_toimita_tilaus($params) {
+  global $woo_config;
+
+  // jos Woo Commerce API ei k‰ytˆss‰
+  if (empty($woo_config)
+      or empty($woo_config["access_token"])
+      or empty($woo_config["consumer_key"])
+      or empty($woo_config["consumer_secret"])
+      or empty($woo_config["store_url"])) {
+    return false;
+  }
+
+  // parametrein‰ pupesoft tunnukset array sek‰ seurantakoodit string
+  $pupesoft_tunnukset = $params["pupesoft_tunnukset"];
+  $tracking_code = $params["tracking_code"];
+
+  // haetaan tilausten woo tilausnumerot
+  $woo_tilausnumerot = woo_commerce_hae_woo_tilausnumerot($pupesoft_tunnukset);
+
+  foreach ($woo_tilausnumerot as $order_number) {
+    // rakennetaan woo request
+    $woo_parameters = array(
+      "access_token"    => $woo_config["access_token"],
+      "store_url"       => $woo_config["store_url"],
+      "consumer_key"    => $woo_config["consumer_key"],
+      "consumer_secret" => $woo_config["consumer_secret"],
+      "order"           => array(
+        "order_number"  => $order_number,
+        "tracking_code" => $tracking_code,
+      ),
+    );
+
+    // tehd‰‰n request
+    $response = pupenext_rest($woo_parameters, "woo/complete_order");
+
+    pupesoft_log("woocommerce_order", $response);
+  }
+}
+
+function woo_commerce_hae_woo_tilausnumerot($pupesoft_tunnukset) {
+  global $kukarow, $yhtiorow;
+
+  $result = array();
+
+  // jos meill‰ ei ole yht‰‰n tilausnumeroita
+  if (empty($pupesoft_tunnukset) or !is_array($pupesoft_tunnukset)) {
+    return $result;
+  }
+
+  // tehd‰‰n tunnuksista stringi
+  $tunnukset = implode(",", $pupesoft_tunnukset);
+
+  // tehd‰‰n request tilaus kerrallaan
+  // ainoastaan jos moduli on magento ja asiakkaan tilausnumero lˆytyy
+  $query = "SELECT asiakkaan_tilausnumero
+            FROM lasku
+            WHERE yhtio = '{$kukarow['yhtio']}'
+            AND tunnus in ({$tunnukset})
+            AND ohjelma_moduli = 'MAGENTO'
+            AND asiakkaan_tilausnumero  != ''";
+  $result = pupe_query($query);
+
+  while ($row = mysql_fetch_assoc($result)) {
+    $result[] = $row['asiakkaan_tilausnumero'];
+  }
+
+  return $result;
+}

--- a/tilauskasittely/editilaus_in.inc
+++ b/tilauskasittely/editilaus_in.inc
@@ -42,6 +42,11 @@ if ($php_cli) {
     $edi_tyyppi = 'presta';
   }
 
+  // tunnistetaan woo commerce -tyyppinen k‰sittely tiedostonimest‰
+  if ($edi_tyyppi == 'futursoft' and preg_match("/^woo\-order/", $verkkokauppa_filename) === 1) {
+    $edi_tyyppi = 'woo';
+  }
+
   // Pupeasennuksen root
   $pupe_root_polku = dirname(dirname(__FILE__));
 }
@@ -315,6 +320,11 @@ elseif ($edi_tyyppi == "presta") {
   $edi_subj = "Sis‰‰ntuleva Verkkokauppa-tilaus";
   $edi_laatija = "Presta";
   $edi_tyyppi = "magento"; // presta toimii t‰‰ll‰ samaan tapaan kuin magento
+}
+elseif ($edi_tyyppi == "woo") {
+  $edi_subj = "Sis‰‰ntuleva Verkkokauppa-tilaus";
+  $edi_laatija = "WooCommerce";
+  $edi_tyyppi = "magento"; // woocommerce toimii t‰‰ll‰ samaan tapaan kuin magento
 }
 elseif ($edi_tyyppi == "edifact911") {
 
@@ -2557,7 +2567,7 @@ while ($tietue = fgets($fd)) {
 
         // magentotilaus on laskutettu, jos meill‰ on kassalipas
         $laskutettu_magento_tilaus = ($edi_tyyppi == "magento" and $editilaus_kassalipas != "");
-        
+
         // jos etuk‰teen maksettu mutta ei haluta laskuttaa, p‰ivitet‰‰n tilaukselle tunnistustiedot
         if (!$ei_esteta_laskutusta and $laskutettu_magento_tilaus) {
           $query = "UPDATE lasku SET

--- a/tilauskasittely/tilaus_in.php
+++ b/tilauskasittely/tilaus_in.php
@@ -70,7 +70,7 @@ if (move_uploaded_file($_FILES['userfile']['tmp_name'], $filename)) {
     echo "</pre>";
   }
 
-  if ($tyyppi == 'magento' or $tyyppi == 'presta' or $tyyppi == 'ahkio') {
+  if ($tyyppi == 'magento' or $tyyppi == 'presta' or $tyyppi == 'ahkio' or $tyyppi = 'woo') {
     // tarvitaan $filename
     echo "<pre>";
     $edi_tyyppi = $tyyppi;
@@ -121,6 +121,7 @@ else {
          <option value='futursoft'>Futursoft</option>
          <option value='magento'>Magento</option>
          <option value='presta'>PrestaShop</option>
+         <option value='woo'>WooCommerce</option>
          <option value='pos'>".t("Kassap‰‰te")."</option>
          <option value='yct'>Yamaha Center</option>
          <option value='edifact911'>Orders 91.1</option>

--- a/unifaun_fetch.php
+++ b/unifaun_fetch.php
@@ -38,6 +38,8 @@ if ($php_cli and count(debug_backtrace()) <= 1) {
   $yhtiorow = hae_yhtion_parametrit($kukarow['yhtio']);
 }
 
+require 'rajapinnat/woo/woo-functions.php';
+
 // Sallitaan vain yksi instanssi tästä skriptistä kerrallaan
 pupesoft_flock();
 
@@ -390,6 +392,14 @@ if ($handle = opendir($ftpget_dest[$operaattori])) {
             }
           }
         }
+
+        // Merkaatan woo-commerce tilaukset toimitetuiksi kauppaan
+        $woo_params = array(
+          "pupesoft_tunnukset" => explode(",", $otunnukset),
+          "tracking_code" => $sscc_ulkoinen,
+        );
+
+        woo_commerce_toimita_tilaus($woo_params);
 
         // Katsotaan onko Magento käytössä, merkataan tilaus toimitetuksi
         $_magento_kaytossa = (!empty($magento_api_tt_url) and !empty($magento_api_tt_usr) and !empty($magento_api_tt_pas));


### PR DESCRIPTION
Merkataan tilaukset toimitetuiksi kauppaan. Toimii rahtikirjan syötössä sekä Logmaster ja Unifaun rajapinnan yhteydessä.

Suoratoimitus eikä JT-prosessi ei ole tuettuna.