### PR TITLE
Valmistuksien valmistus: vain raaka-aineita

### DIFF
--- a/tilauskasittely/valmista_tilaus.php
+++ b/tilauskasittely/valmista_tilaus.php
@@ -210,7 +210,7 @@ if (!function_exists("onkokaikkivalmistettu")) {
 
     // Laitetaan valmistus valmis tilaan vain,
     // jos kaikki on jo valmsitettu
-    if ($valmistettu) {
+    if ($valmistettu and isset($tilrivirow["otunnus"])) {
       //Jos kyseessä on varastovalmistus
       $query = "UPDATE lasku
                 SET alatila  = 'V'
@@ -236,6 +236,10 @@ if (!function_exists("onkokaikkivalmistettu")) {
       $valmistettavat = "";
     }
     else {
+      if (!$tilrivirow["otunnus"]) {
+        echo "<font class='error'>".t("VIRHE: Tarkista tilauksen rivit")."! </font><br>";
+      }
+
       $tee = "VALMISTA";
     }
   }

--- a/tilauskasittely/valmista_tilaus.php
+++ b/tilauskasittely/valmista_tilaus.php
@@ -209,7 +209,7 @@ if (!function_exists("onkokaikkivalmistettu")) {
     }
 
     // Laitetaan valmistus valmis tilaan vain,
-    // jos kaikki on jo valmsitettu
+    // jos kaikki on jo valmistettu
     if ($valmistettu and isset($tilrivirow["otunnus"])) {
       //Jos kyseessä on varastovalmistus
       $query = "UPDATE lasku
@@ -237,7 +237,7 @@ if (!function_exists("onkokaikkivalmistettu")) {
     }
     else {
       if (!$tilrivirow["otunnus"]) {
-        echo "<font class='error'>".t("VIRHE: Tarkista tilauksen rivit")."! </font><br>";
+        echo "<font class='error'>".t("VIRHE: Tarkista valmistuksen rivit")."! </font><br>";
       }
 
       $tee = "VALMISTA";

--- a/tilauskasittely/valmista_tilaus.php
+++ b/tilauskasittely/valmista_tilaus.php
@@ -237,7 +237,7 @@ if (!function_exists("onkokaikkivalmistettu")) {
     }
     else {
       if (!$tilrivirow["otunnus"]) {
-        echo "<font class='error'>".t("VIRHE: Tarkista valmistuksen rivit")."! </font><br>";
+        echo "<font class='error'>".t("VIRHE: Valmistukselta puuttuu valmisterivi. Tarkista valmistuksen rivit")."! </font><br>";
       }
 
       $tee = "VALMISTA";


### PR DESCRIPTION
Mikäli valmistukselle oli epähuomiossa laittanut pelkästään raaka-aineita ja yritti tälläisen valmistuksen valmistaa niin tuli ruudulle pelkästään epäselvä virheilmoitus. Tätä on nyt viilattu niin, että saataisiin ruudulle hieman selkeämpi virheilmoitus, jolloin käyttäjän olisi helpompi tietää mitä tapahtuu.