### PR TITLE
Tuotekysely: ostohinnan valuutta

### DIFF
--- a/tuote.php
+++ b/tuote.php
@@ -2474,7 +2474,7 @@ if ($tee == 'Z') {
       $query = "SELECT *
                 FROM valuu
                 WHERE yhtio = '{$kukarow['yhtio']}'
-                AND nimi    = '{$tt_rivi['oletus_valkoodi']}'
+                AND nimi    = '{$tt_rivi['valuutta']}'
                 ORDER BY tunnus DESC
                 LIMIT 1";
       $kurssi_chk_res = pupe_query($query);
@@ -2482,12 +2482,13 @@ if ($tee == 'Z') {
 
       $_laskurow = array(
         'liitostunnus'   => $tt_rivi['liitostunnus'],
-        'valkoodi'     => $tt_rivi['oletus_valkoodi'],
+        'valkoodi'     => $tt_rivi['valuutta'],
         'ytunnus'     => $tt_rivi['ytunnus'],
         'vienti_kurssi' => $kurssi_chk_row['kurssi']
       );
 
       list($_hinta, $_netto, $_ale, $_valuutta) = alehinta_osto($_laskurow, $tuoterow, 1, '', '', array());
+
       echo "<span style='font-weight:bold;'>", hintapyoristys(hinta_kuluineen($tuoterow['tuoteno'], $_hinta)), " {$_valuutta}</span> / ";
 
       foreach ($_ale as $key => $val) {

--- a/tuote.php
+++ b/tuote.php
@@ -2488,7 +2488,6 @@ if ($tee == 'Z') {
       );
 
       list($_hinta, $_netto, $_ale, $_valuutta) = alehinta_osto($_laskurow, $tuoterow, 1, '', '', array());
-
       echo "<span style='font-weight:bold;'>", hintapyoristys(hinta_kuluineen($tuoterow['tuoteno'], $_hinta)), " {$_valuutta}</span> / ";
 
       foreach ($_ale as $key => $val) {


### PR DESCRIPTION
Tuotekyselyssä tuotteen ostohinta laskettiin tuotteen toimittajan taakse määriteltyyn valuuttaan, mutta valuuttakoodiksi laitettiin tuotteen toimittajatiedoissa oleva valuuttakoodi. Tämä aiheutti ristiriidan hinnan ja valuutan välillä mikäli toimittajan valuutta ja tuotteen toimittajatiedoissa oleva valuutta olivat eri.