### PR TITLE
Etukäteen maksetun verkkokauppatilauksen muokkaaminen

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -10925,7 +10925,7 @@ if ($tee == '') {
           </form> ";
     }
 
-    if (($muokkauslukko == "" or $myyntikielto != '') and ($toim != "PROJEKTI" or ($toim == "PROJEKTI" and $projektilask == 0)) and $kukarow["mitatoi_tilauksia"] == "") {
+    if (($muokkauslukko == "" or $myyntikielto != '') and ($toim != "PROJEKTI" or ($toim == "PROJEKTI" and $projektilask == 0)) and $kukarow["mitatoi_tilauksia"] == "" and $row["laskutettuaika"] == "0000-00-00") {
       echo "<SCRIPT LANGUAGE=JAVASCRIPT>
             function verify(){
               msg = '".t("Haluatko todella poistaa tämän tietueen?")."';


### PR DESCRIPTION
Ennakkoon maksettuja verkkokappatilauksia pystyi edelleen Pupessa mitätöimään, mitä ei saisi missään tapauksessa tehdä. Nyt etukäteen maksettujen verkkokauppatilausten eli tilausten, joille on jo lasku olemassa, mitätöiminen on estetty.