### PR TITLE
Saldovahvistusviestin sisältö

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -29108,6 +29108,10 @@ if (!function_exists('generoi_saldovahvistus_sahkopostit')) {
       }
       else {
         $saldovahvistus = $request['valitut_laskut'][$valittu_saldovahvistus];
+
+        //Valittu saldovahvistusviesti
+        $saldovahvistus['saldovahvistus_viesti'] = search_array_key_for_value_recursive($request['saldovahvistus_viestit'], 'selite', $request["valitut_laskut"][$valittu_saldovahvistus]["saldovahvistus_viesti"]);
+        $saldovahvistus['saldovahvistus_viesti'] = $saldovahvistus['saldovahvistus_viesti'][0];
       }
 
       if ($saldovahvistus['asiakas']['talhal_email'] != '') {

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -29049,10 +29049,14 @@ if (!function_exists('sum_array')) {
 }
 
 if (!function_exists('hae_saldovahvistus_viestit')) {
-  function hae_saldovahvistus_viestit() {
+  function hae_saldovahvistus_viestit($kieli = "") {
     global $kukarow, $yhtiorow;
 
-    $result = t_avainsana('SALDOVAHVISTUS');
+    if ($kieli == "") {
+      $kieli = $yhtiorow["kieli"];
+    }
+
+    $result = t_avainsana('SALDOVAHVISTUS', $kieli);
     $saldovahvistus_viestit = array();
     while ($saldovahvistus_viesti = mysql_fetch_assoc($result)) {
       $saldovahvistus_viestit[] = $saldovahvistus_viesti;

--- a/tilauskasittely/lahetetyt_saldovahvistukset.php
+++ b/tilauskasittely/lahetetyt_saldovahvistukset.php
@@ -87,7 +87,20 @@ $request['haku_tyypit'] = array(
   'nimi'     => t('Nimi'),
 );
 
-$request['saldovahvistus_viestit'] = hae_saldovahvistus_viestit();
+$kieli = "";
+
+$query = "SELECT asiakas.kieli
+          FROM saldovahvistukset
+          JOIN asiakas ON (asiakas.yhtio = saldovahvistukset.yhtio AND asiakas.tunnus = saldovahvistukset.liitostunnus)
+          WHERE saldovahvistukset.yhtio = '{$kukarow['yhtio']}'
+          AND saldovahvistukset.tunnus = '{$request['saldovahvistus']['saldovahvistus_tunnus']}'";
+$kielirow = mysql_fetch_assoc(pupe_query($query));
+
+if (!empty($kielirow)) {
+  $kieli = $kielirow["kieli"];
+}
+
+$request['saldovahvistus_viestit'] = hae_saldovahvistus_viestit($kieli);
 
 echo_lahetetyt_saldovahvistukset_kayttoliittyma($request);
 

--- a/tilauskasittely/lahetetyt_saldovahvistukset.php
+++ b/tilauskasittely/lahetetyt_saldovahvistukset.php
@@ -87,22 +87,12 @@ $request['haku_tyypit'] = array(
   'nimi'     => t('Nimi'),
 );
 
-if ($tee == "NAYTATILAUS") {
-  $haku_kentta = "asiakas.{$request['ryhmittely_tyyppi']}";
-
-  $query = "SELECT asiakas.kieli
-            FROM saldovahvistukset
-            JOIN asiakas ON (asiakas.yhtio = saldovahvistukset.yhtio AND asiakas.tunnus = saldovahvistukset.liitostunnus)
-            WHERE saldovahvistukset.yhtio = '{$kukarow['yhtio']}'
-            AND {$haku_kentta} = '{$request['ryhmittely_arvo']}'";
-  $kielirow = mysql_fetch_assoc(pupe_query($query));
-}
-else {
+if (isset($saldovahvistus_tunnus)) {
   $query = "SELECT asiakas.kieli
           FROM saldovahvistukset
           JOIN asiakas ON (asiakas.yhtio = saldovahvistukset.yhtio AND asiakas.tunnus = saldovahvistukset.liitostunnus)
           WHERE saldovahvistukset.yhtio = '{$kukarow['yhtio']}'
-          AND saldovahvistukset.tunnus = '{$request['saldovahvistus']['saldovahvistus_tunnus']}'";
+          AND saldovahvistukset.tunnus = '{$saldovahvistus_tunnus}'";
   $kielirow = mysql_fetch_assoc(pupe_query($query));
 }
 

--- a/tilauskasittely/lahetetyt_saldovahvistukset.php
+++ b/tilauskasittely/lahetetyt_saldovahvistukset.php
@@ -87,15 +87,26 @@ $request['haku_tyypit'] = array(
   'nimi'     => t('Nimi'),
 );
 
-$kieli = "";
+if ($tee == "NAYTATILAUS") {
+  $haku_kentta = "asiakas.{$request['ryhmittely_tyyppi']}";
 
-$query = "SELECT asiakas.kieli
+  $query = "SELECT asiakas.kieli
+            FROM saldovahvistukset
+            JOIN asiakas ON (asiakas.yhtio = saldovahvistukset.yhtio AND asiakas.tunnus = saldovahvistukset.liitostunnus)
+            WHERE saldovahvistukset.yhtio = '{$kukarow['yhtio']}'
+            AND {$haku_kentta} = '{$request['ryhmittely_arvo']}'";
+  $kielirow = mysql_fetch_assoc(pupe_query($query));
+}
+else {
+  $query = "SELECT asiakas.kieli
           FROM saldovahvistukset
           JOIN asiakas ON (asiakas.yhtio = saldovahvistukset.yhtio AND asiakas.tunnus = saldovahvistukset.liitostunnus)
           WHERE saldovahvistukset.yhtio = '{$kukarow['yhtio']}'
           AND saldovahvistukset.tunnus = '{$request['saldovahvistus']['saldovahvistus_tunnus']}'";
-$kielirow = mysql_fetch_assoc(pupe_query($query));
+  $kielirow = mysql_fetch_assoc(pupe_query($query));
+}
 
+$kieli = "";
 if (!empty($kielirow)) {
   $kieli = $kielirow["kieli"];
 }

--- a/tilauskasittely/saldovahvistus.php
+++ b/tilauskasittely/saldovahvistus.php
@@ -119,7 +119,9 @@ $request['ryhmittely_tyypit'] = array(
   'asiakasnro' => t('Asiakasnumero'),
 );
 
-$request['saldovahvistus_viestit'] = hae_saldovahvistus_viestit();
+$_key = key($_SESSION['valitut_laskut']);
+
+$request['saldovahvistus_viestit'] = hae_saldovahvistus_viestit($_SESSION['valitut_laskut'][$_key]['asiakas']['kieli']);
 
 if ($request['tee'] == 'poista_valinnat') {
   unset($_SESSION['valitut_laskut']);


### PR DESCRIPTION
Saldovahvistus-ohjelmasta lähetettyihin sähköposteihin ei tullut saldovahvistusviestiä mukaan. Nyt tämä on korjattu niin, että saldovahvistusviesti saadaan sähköpostiin mukaan.

Muokattu myös samalla niin, että saadaan viestin sisältö asiakkaan kielelle.