### PR TITLE
Tyhjä rahtikirja: korjaus rahtikirjannumeron tekoon

### DIFF
--- a/tilauskasittely/rahtikirja_postitarra_ulkomaa_pdf.inc
+++ b/tilauskasittely/rahtikirja_postitarra_ulkomaa_pdf.inc
@@ -102,7 +102,7 @@ for ($tulostuskpl=1; $tulostuskpl<=$tulostakolli; $tulostuskpl++) {
     $query = "SELECT rahtikirjanro
               FROM rahtikirjat
               WHERE yhtio       = '$kukarow[yhtio]'
-              AND rahtikirjanro LIKE 'CE%FI%'
+              AND rahtikirjanro LIKE '%CE%FI%'
               ORDER BY tunnus desc
               LIMIT 1";
     $ranres = pupe_query($query);
@@ -110,7 +110,14 @@ for ($tulostuskpl=1; $tulostuskpl<=$tulostakolli; $tulostuskpl++) {
 
     $edmax = array_pop(explode(" ", trim($ranrow["rahtikirjanro"])));
 
-    $juokseva = sprintf("%04d", $tulostuskpl + (int) substr($edmax, 6, 4));
+    if (strpos($edmax, "CE") == 0) {
+      $juokseva = sprintf("%04d", $tulostuskpl + (int) substr($edmax, 6, 4));
+    }
+    else {
+      $_koodipos = strpos($edmax, "CE") + 6;
+      $juokseva = sprintf("%04d", $tulostuskpl + (int) substr($edmax, $_koodipos, 4));
+    }
+
   }
 
   if (substr($juokseva, 0, 2) != "CE" or substr($juokseva, -2, 2) != "FI") {

--- a/tilauskasittely/rahtikirja_postitarra_ulkomaa_pdf.inc
+++ b/tilauskasittely/rahtikirja_postitarra_ulkomaa_pdf.inc
@@ -110,14 +110,8 @@ for ($tulostuskpl=1; $tulostuskpl<=$tulostakolli; $tulostuskpl++) {
 
     $edmax = array_pop(explode(" ", trim($ranrow["rahtikirjanro"])));
 
-    if (strpos($edmax, "CE") == 0) {
-      $juokseva = sprintf("%04d", $tulostuskpl + (int) substr($edmax, 6, 4));
-    }
-    else {
-      $_koodipos = strpos($edmax, "CE") + 6;
-      $juokseva = sprintf("%04d", $tulostuskpl + (int) substr($edmax, $_koodipos, 4));
-    }
-
+    $_koodipos = strpos($edmax, "CE") + 6;
+    $juokseva = sprintf("%04d", $tulostuskpl + (int) substr($edmax, $_koodipos, 4));
   }
 
   if (substr($juokseva, 0, 2) != "CE" or substr($juokseva, -2, 2) != "FI") {


### PR DESCRIPTION
Tyhjä rahtikirja ohjelmassa tehtyjen rahtikirjojen rahtikirjannumeron eteen tulee --merkki ja 4 numeroa. Tätä tunnistetta ei osattu ottaa huomioon tyhjien rahtikirjojen syötössä, joten jos syötti monta tyhjää rahtikirjaa peräjälkeen saivat nämä kaikki saman rahtikirjannumeron. Korjattu nyt niin, että tyhjä rahtikirja osaa ottaa huomioon tyhjässä rahtikirjassa tehdyt rahtikirjat.