### PR TITLE
Valmista tuotteita: reseptien tarkistus

### DIFF
--- a/tilauskasittely/tarkistarivi.inc
+++ b/tilauskasittely/tarkistarivi.inc
@@ -305,7 +305,7 @@ if (!in_array($row["var"], array('', 'P', 'J', 'H', 'S', 'T', 'U', 'V', 'A', 'B'
   $tilausok++;
 }
 
-if ($row["tyyppi"] == 'V' and $row["perheid"] == 0 and $toim == "VALMISTAVARASTOON") {
+if (in_array($row["tyyppi"], array('V', 'W')) and $row["perheid"] == 0 and $toim == "VALMISTAVARASTOON") {
   $varaosavirhe .= t("VIRHE: Tuote ei kuulu mihink‰‰n reseptiin!")."<br>";
   $riviok++;
   $tilausok++;

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -10889,7 +10889,11 @@ if ($tee == '') {
           </form> ";
     }
 
-    if (($muokkauslukko == "" or $myyntikielto != '') and ($toim != "PROJEKTI" or ($toim == "PROJEKTI" and $projektilask == 0)) and $kukarow["mitatoi_tilauksia"] == "" and ($row["laskutettuaika"] == "0000-00-00" or !isset($row["laskutettuaika"]))) {
+    $ei_laskutettu = ($row["laskutettuaika"] == "0000-00-00" or !isset($row["laskutettuaika"]));
+    $ei_valmistettu = TRUE;
+    if ($laskurow["tila"] == "V" and $row["toimitettuaika"] != "0000-00-00" and isset($row["toimitettuaika"])) $ei_valmistettu = FALSE;
+
+    if (($muokkauslukko == "" or $myyntikielto != '') and ($toim != "PROJEKTI" or ($toim == "PROJEKTI" and $projektilask == 0)) and $kukarow["mitatoi_tilauksia"] == "" and $ei_laskutettu and $ei_valmistettu) {
       echo "<SCRIPT LANGUAGE=JAVASCRIPT>
             function verify(){
               msg = '".t("Haluatko todella poistaa tämän tietueen?")."';


### PR DESCRIPTION
Yksinäisiä valmisterivejä pystyi lisäämään valmistukselle ilman raaka-aineita. Valmistuksen sai kyllä eteenpäin ja valmistuksen toisen valmistuksen valmistettua, mutta valmistus ei mennyt yksinäisen valmisteen takia valmistettu tilaan, mikä aiheutti ongelmia. Nyt on tarkistuksia korjattu niin, että yksinäisistä valmisteriveistä infotaan käyttäjää samaan tapaan kuin yksinäisistä raaka-aineriveistä.

Lisäksi otetaan mitätöinti-nappi pois muokkaa tilausta näkymästä mikäli valmistuksella on valmistettuja rivejä.