### PR TITLE
Merkitään myös rahtimaksu- ja kuljetusvakuutusrivit toimitetuiksi

### DIFF
--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -1344,8 +1344,8 @@ else {
               }
             }
 
-            $query  = "INSERT INTO tilausrivi (laatija, laadittu, hinta, {$ale_lisa_insert_query_1} netto, varattu, tilkpl, otunnus, tuoteno, nimitys, yhtio, tyyppi, alv, kommentti, kerattyaika, toimitettuaika)
-                       values ('automaatti', now(), '$rah_hinta', {$ale_lisa_insert_query_2} '$rah_netto', '1', '1', '$otunnus', '$trow[tuoteno]', '$nimitys', '$kukarow[yhtio]', 'L', '$rah_alv', '$kommentti', now(), now())";
+            $query  = "INSERT INTO tilausrivi (laatija, laadittu, hinta, {$ale_lisa_insert_query_1} netto, varattu, tilkpl, otunnus, tuoteno, nimitys, yhtio, tyyppi, alv, kommentti, keratty, kerattyaika, toimitettu, toimitettuaika)
+                       values ('automaatti', now(), '$rah_hinta', {$ale_lisa_insert_query_2} '$rah_netto', '1', '1', '$otunnus', '$trow[tuoteno]', '$nimitys', '$kukarow[yhtio]', 'L', '$rah_alv', '$kommentti', 'saldoton', now(), 'saldoton', now())";
             $addtil = pupe_query($query);
 
             if ($silent == "") {
@@ -1559,7 +1559,9 @@ else {
                           perheid2        = '',
                           nimitys         = '$trow[nimitys]',
                           jaksotettu      = '',
+                          keratty         = 'saldoton',
                           kerattyaika     = now(),
+                          toimitettu      = 'saldoton',
                           toimitettuaika  = now()";
                 $addtil = pupe_query($query);
                 $lisatty_tun = mysql_insert_id($GLOBALS["masterlink"]);
@@ -1799,7 +1801,9 @@ else {
                         perheid2        = '',
                         nimitys         = '$trow[nimitys]',
                         jaksotettu      = '',
+                        keratty         = 'saldoton',
                         kerattyaika     = now(),
+                        toimitettu      = 'saldoton',
                         toimitettuaika  = now()";
               $addtil = pupe_query($query);
               $lisatty_tun = mysql_insert_id($GLOBALS["masterlink"]);

--- a/tilauskasittely/verkkolasku.php
+++ b/tilauskasittely/verkkolasku.php
@@ -1344,8 +1344,8 @@ else {
               }
             }
 
-            $query  = "INSERT INTO tilausrivi (laatija, laadittu, hinta, {$ale_lisa_insert_query_1} netto, varattu, tilkpl, otunnus, tuoteno, nimitys, yhtio, tyyppi, alv, kommentti)
-                       values ('automaatti', now(), '$rah_hinta', {$ale_lisa_insert_query_2} '$rah_netto', '1', '1', '$otunnus', '$trow[tuoteno]', '$nimitys', '$kukarow[yhtio]', 'L', '$rah_alv', '$kommentti')";
+            $query  = "INSERT INTO tilausrivi (laatija, laadittu, hinta, {$ale_lisa_insert_query_1} netto, varattu, tilkpl, otunnus, tuoteno, nimitys, yhtio, tyyppi, alv, kommentti, kerattyaika, toimitettuaika)
+                       values ('automaatti', now(), '$rah_hinta', {$ale_lisa_insert_query_2} '$rah_netto', '1', '1', '$otunnus', '$trow[tuoteno]', '$nimitys', '$kukarow[yhtio]', 'L', '$rah_alv', '$kommentti', now(), now())";
             $addtil = pupe_query($query);
 
             if ($silent == "") {
@@ -1559,7 +1559,8 @@ else {
                           perheid2        = '',
                           nimitys         = '$trow[nimitys]',
                           jaksotettu      = '',
-                          kerattyaika     = now()";
+                          kerattyaika     = now(),
+                          toimitettuaika  = now()";
                 $addtil = pupe_query($query);
                 $lisatty_tun = mysql_insert_id($GLOBALS["masterlink"]);
 
@@ -1798,7 +1799,8 @@ else {
                         perheid2        = '',
                         nimitys         = '$trow[nimitys]',
                         jaksotettu      = '',
-                        kerattyaika     = now()";
+                        kerattyaika     = now(),
+                        toimitettuaika  = now()";
               $addtil = pupe_query($query);
               $lisatty_tun = mysql_insert_id($GLOBALS["masterlink"]);
 


### PR DESCRIPTION
Laskutusvaiheessa, kun lisätään mahdolliset kuljetusvakuutus ja rahtikulurivit, niitä ei merkitty toimitetuiksi, jolloin saattoi näyttää tilauksen otsikolla, että tilausta ei ole toimitettu lainkaan, vaikka todelliset tuoterivit oli toimitettu