### PR TITLE
Varastosiirtojen vastaanotto: tuplavastaanottojen esto

### DIFF
--- a/tilauskasittely/vastaanota.php
+++ b/tilauskasittely/vastaanota.php
@@ -481,6 +481,15 @@ if ($tee == 'valmis') {
 
   $virheita = 0;
 
+  $lock_params = array(
+    "return"   => true,
+  );
+
+  if (!pupesoft_flock($lock_params)) {
+    echo "Ruuhkaa varastosiirtojen vastaanotossa, yritä myöhemmin uudelleen!";
+    exit();
+  }
+
   //käydään kaikki riviti läpi ja siirretään saldoja
   foreach ($tunnus as $tun) {
 

--- a/tilauskasittely/vastaanota.php
+++ b/tilauskasittely/vastaanota.php
@@ -481,13 +481,15 @@ if ($tee == 'valmis') {
 
   $virheita = 0;
 
-  $lock_params = array(
-    "return"   => true,
-  );
+  if (php_sapi_name() != 'cli') {
+    $lock_params = array(
+      "return"   => true,
+    );
 
-  if (!pupesoft_flock($lock_params)) {
-    echo "Ruuhkaa varastosiirtojen vastaanotossa, yritä myöhemmin uudelleen!";
-    exit();
+    if (!pupesoft_flock($lock_params)) {
+      echo "Ruuhkaa varastosiirtojen vastaanotossa, yritä myöhemmin uudelleen!";
+      exit();
+    }
   }
 
   //käydään kaikki riviti läpi ja siirretään saldoja

--- a/tilauskasittely/vastaanota.php
+++ b/tilauskasittely/vastaanota.php
@@ -481,6 +481,8 @@ if ($tee == 'valmis') {
 
   $virheita = 0;
 
+  // Tehdään lukko, jotta vain yksi ajo kerrallaan,
+  // mutta lukko vain selaimesta mennessä
   if (php_sapi_name() != 'cli') {
     $lock_params = array(
       "return"   => true,

--- a/tilauskasittely/vastaanota.php
+++ b/tilauskasittely/vastaanota.php
@@ -481,17 +481,14 @@ if ($tee == 'valmis') {
 
   $virheita = 0;
 
-  // Tehdään lukko, jotta vain yksi ajo kerrallaan,
-  // mutta lukko vain selaimesta mennessä
-  if (php_sapi_name() != 'cli') {
-    $lock_params = array(
-      "return"   => true,
-    );
+  // Tehdään lukko, jotta vain yksi ajo kerrallaan
+  $lock_params = array(
+    "return"   => true,
+  );
 
-    if (!pupesoft_flock($lock_params)) {
-      echo "Ruuhkaa varastosiirtojen vastaanotossa, yritä myöhemmin uudelleen!";
-      exit();
-    }
+  if (!pupesoft_flock($lock_params)) {
+    echo "Ruuhkaa varastosiirtojen vastaanotossa, yritä myöhemmin uudelleen!";
+    exit();
   }
 
   //käydään kaikki riviti läpi ja siirretään saldoja


### PR DESCRIPTION
Sallitaan vain yksi varastosiirtojen vastaanotto ajettavaksi kerrallaan, jotta pystyttäisiin varmistamaan ettei samaa varastosiirtoa päästäisi vastaanottamaan kahdesti.