### PR TITLE
Myyntitilaus: tuoteperheen jälkitoimitus-nappi

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -4952,7 +4952,7 @@ if ($tee == '') {
           $toimitettuaika = 0;
         }
 
-        if ($tila == "VARMUUTOS" and in_array($tapa, array("POISJTSTA","PUUTE","PUUTE"))) {
+        if ($tila == "VARMUUTOS" and in_array($tapa, array("POISJTSTA","PUUTE","JT"))) {
           //otetaan varattukpl ja jtkpl muuttuja käyttöön
           $varattukpl = 0;
           $jtkpl = 0;


### PR DESCRIPTION
Myyntitilauksilla tuoteperheiden kohdalla oleva jälkitoimitus-nappi ei toiminut oikein. Jälkitoimitus-nappi sai kyseisen rivin muokattavaksi, mutta jätti perheen kuitenkin koskemattomana tilausrivilistaan. Tämä on nyt korjattu ja tuoteperheiden jälkitoimitus-nappi toimii taas normaaliin tapaan.