### PR TITLE
Tuotepäivitys Magentoon

### DIFF
--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1646,12 +1646,12 @@ class MagentoClient {
     $current = 0;
     $total = count($asiakkaat_per_yhteyshenkilo);
     $asiakashinnat = array();
-    $offset = 0;
-    $poistettu = 0;
 
     if ($kaikki_kerralla) {
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
 
+      $offset = 0;
+      $poistettu = 0;
       foreach ($asiakkaat_per_yhteyshenkilo as $asiakas) {
         $asiakashinnat[] = array(
           'customerEmail' => $asiakas['asiakas_email'],

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -325,7 +325,7 @@ class MagentoClient {
           $key = $parametri['option_name'];
           $option_id = $this->get_option_id($key, $parametri['arvo'], $attribute_set_id);
 
-          if ($option_id == 0) {
+          if ($option_id === false) {
             continue;
           }
 
@@ -361,7 +361,7 @@ class MagentoClient {
         if (isset($tuote[$erikoisparametri['arvo']])) {
           $option_id = $this->get_option_id($key, $tuote[$erikoisparametri['arvo']], $attribute_set_id);
 
-          if ($option_id == 0) {
+          if ($option_id === false) {
             $this->log('magento_tuotteet', "Erikoisparametri {$key}: {$tuote[$erikoisparametri['arvo']]} #option_id == 0, jätetään päivittämättä");
             continue;
           }
@@ -546,7 +546,7 @@ class MagentoClient {
                 $key = $parametri['option_name'];
                 $option_id = $this->get_option_id($key, $parametri['arvo'], $attribute_set_id);
 
-                if ($option_id == 0) {
+                if ($option_id === false) {
                   continue;
                 }
 
@@ -728,7 +728,7 @@ class MagentoClient {
           $key = $parametri['option_name'];
           $option_id = $this->get_option_id($key, $parametri['arvo'], $attribute_set_id);
 
-          if ($option_id == 0) {
+          if ($option_id === false) {
             continue;
           }
 
@@ -758,7 +758,7 @@ class MagentoClient {
         if (isset($lapsituotteen_tiedot[$erikoisparametri['arvo']])) {
           $option_id = $this->get_option_id($key, $lapsituotteen_tiedot[$erikoisparametri['arvo']], $attribute_set_id);
 
-          if ($option_id == 0) {
+          if ($option_id === false) {
             continue;
           }
 
@@ -822,7 +822,7 @@ class MagentoClient {
               $key = $parametri['option_name'];
               $option_id = $this->get_option_id($key, $parametri['arvo'], $attribute_set_id);
 
-              if ($option_id == 0) {
+              if ($option_id === false) {
                 continue;
               }
 
@@ -2244,7 +2244,7 @@ class MagentoClient {
     if (empty($attribute_id)) {
       $this->log('magento_tuotteet', "Atribuuttia '{$name}' ei löydetty setistä {$attribute_set_id}");
 
-      return 0;
+      return false;
     }
 
     // Jos dynaaminen parametri on matkalla teksti- tai hintakenttään niin idtä ei tarvita, palautetaan vaan arvo
@@ -2313,7 +2313,7 @@ class MagentoClient {
     $this->log('magento_tuotteet', "Attribuutin '{$name}' arvon '{$value}' haku setistä {$attribute_set_id} ei onnistunut.");
 
     // Mitään ei löytyny
-    return 0;
+    return false;
   }
 
   // Hakee $status -tilassa olevat tilaukset Magentosta ja merkkaa ne noudetuksi.

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1554,7 +1554,7 @@ class MagentoClient {
     $onnistuiko_lisays = true;
     $offset = 0;
 
-    while ($hintadata = array_slice($asiakaskohtainenhintadata, $offset, 500)) {
+    while ($hintadata = array_slice($asiakaskohtainenhintadata, $offset, 300)) {
       try {
         $reply = $this->_proxy->call(
           $this->_session,
@@ -1562,9 +1562,9 @@ class MagentoClient {
           array($magento_tuotenumero, $hintadata)
         );
 
-        $this->log('magento_tuotteet', "({$offset}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat lisätty. Block size 500");
+        $this->log('magento_tuotteet', "({$offset}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat lisätty. Block size 300");
         $this->debug('magento_tuotteet', $hintadata);
-        $offset += 500;
+        $offset += 300;
       }
       catch (Exception $e) {
         $this->_error_count++;
@@ -1575,11 +1575,11 @@ class MagentoClient {
       $onnistuiko_lisays = true;
     }
     
-    if ($onnistuiko_lisays === false) { 
+    if ($onnistuiko_lisays === false) {
+      $offset = $offset - 300;
       $current = $offset;
       for ($i = $offset; $i <= $total; $i++) {
         $hintadata = $asiakaskohtainenhintadata[$i];
-        var_dump($hintadata);
         $current++;
         try {
           $reply = $this->_proxy->call(
@@ -1669,21 +1669,19 @@ class MagentoClient {
         }
         catch(Exception $e) {
           $this->_error_count++;
-          $this->log('magento_tuotteet', "Virhe asiakaskohtaisten hintojen poistossa! Magento-tuoteno {$magento_tuotenumero}, website-code: {$this->_asiakaskohtaiset_tuotehinnat}", $e);
+          $this->log('magento_tuotteet', "Virhe asiakaskohtaisten hintojen poistossa! Magento-tuoteno {$magento_tuotenumero}, {$offset}, {$total}, website-code: {$this->_asiakaskohtaiset_tuotehinnat}", $e);
           $onnistuiko_paivitys = false;
           break;
         }
       }
-
       $onnistuiko_paivitys = true;
     }
     if ($onnistuiko_paivitys === false) {
+      $offset = $offset - 500;
       $current = $offset;
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
       for ($i = $offset; $i <= $total; $i++) {
         $asiakashinta = $asiakashinnat[$i];
-        
-        var_dump($asiakashinta);
         $current++;
 
         try {

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -2265,7 +2265,7 @@ class MagentoClient {
     // Etitään optionsin value
     foreach ($options as $option) {
       if (strcasecmp($option['label'], $value) == 0) {
-        $this->log('magento_tuotteet', "Palautetaan option-value(2246): {$option[value]}");
+        $this->log('magento_tuotteet', "Palautetaan option-value(2246): {$option['value']}");
         return $option['value'];
       }
     }

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1554,7 +1554,7 @@ class MagentoClient {
     $onnistuiko_lisays = true;
     $offset = 0;
 
-    while ($hintadata = array_slice($asiakaskohtainenhintadata, $offset, 500)) {
+    while ($hintadata = array_slice($asiakaskohtainenhintadata, $offset, 200)) {
       try {
         $reply = $this->_proxy->call(
           $this->_session,
@@ -1562,9 +1562,9 @@ class MagentoClient {
           array($magento_tuotenumero, $hintadata)
         );
 
-        $this->log('magento_tuotteet', "({$current}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat lisätty. Block size 500");
+        $this->log('magento_tuotteet', "({$current}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat lisätty. Block size 200");
         $this->debug('magento_tuotteet', $hintadata);
-        $offset += 500;
+        $offset += 200;
       }
       catch (Exception $e) {
         $this->_error_count++;
@@ -1572,6 +1572,7 @@ class MagentoClient {
         $onnistuiko_lisays = false;
         continue;
       }
+      $onnistuiko_lisays = true;
     }
     
     if ($onnistuiko_lisays === false) { 

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1647,10 +1647,11 @@ class MagentoClient {
     $total = count($asiakkaat_per_yhteyshenkilo);
     $asiakashinnat = array();
     $offset = 0;
+    $poistettu = 0;
 
     if ($kaikki_kerralla) {
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
-      $offset = 0;
+
       foreach ($asiakkaat_per_yhteyshenkilo as $asiakas) {
         $asiakashinnat[] = array(
           'customerEmail' => $asiakas['asiakas_email'],
@@ -1674,7 +1675,7 @@ class MagentoClient {
         catch(Exception $e) {
           $this->_error_count++;
           $this->log('magento_tuotteet', "Virhe asiakaskohtaisten hintojen poistossa! Magento-tuoteno {$magento_tuotenumero}, website-code: {$this->_asiakaskohtaiset_tuotehinnat}", $e);
-
+          $poistettu = $offset;
           return false;
         }
       }
@@ -1684,7 +1685,7 @@ class MagentoClient {
     else {
       $current = $offset;
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
-      for ($i = $offset; $i <= $total; $i++) {
+      for ($i = $poistettu; $i <= $total; $i++) {
         $asiakas = $asiakkaat_per_yhteyshenkilo[$i];
         $current++;
         $asiakashinnat = array(

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1576,7 +1576,6 @@ class MagentoClient {
     }
     
     if ($onnistuiko_lisays === false) {
-      $offset = $offset - 300;
       $current = $offset;
       for ($i = $offset; $i <= $total; $i++) {
         $hintadata = $asiakaskohtainenhintadata[$i];
@@ -1669,7 +1668,7 @@ class MagentoClient {
         }
         catch(Exception $e) {
           $this->_error_count++;
-          $this->log('magento_tuotteet', "Virhe asiakaskohtaisten hintojen poistossa! Magento-tuoteno {$magento_tuotenumero}, {$offset}, {$total}, website-code: {$this->_asiakaskohtaiset_tuotehinnat}", $e);
+          $this->log('magento_tuotteet', "Virhe asiakaskohtaisten hintojen poistossa! Magento-tuoteno {$magento_tuotenumero}, website-code: {$this->_asiakaskohtaiset_tuotehinnat}", $e);
           $onnistuiko_paivitys = false;
           break;
         }
@@ -1677,7 +1676,6 @@ class MagentoClient {
       $onnistuiko_paivitys = true;
     }
     if ($onnistuiko_paivitys === false) {
-      $offset = $offset - 500;
       $current = $offset;
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
       for ($i = $offset; $i <= $total; $i++) {

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1538,6 +1538,7 @@ class MagentoClient {
       return false;
     }
 
+    $poistettu = 0;
     // Ensin poistetaan tuotteen asiakashinnat Magentosta kaikki kerralla
     $onnistuiko_paivitys = $this->poista_tuotteen_asiakaskohtaiset_hinnat($asiakkaat_per_yhteyshenkilo, $magento_tuotenumero, true);
 
@@ -1651,7 +1652,6 @@ class MagentoClient {
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
 
       $offset = 0;
-      $poistettu = 0;
       foreach ($asiakkaat_per_yhteyshenkilo as $asiakas) {
         $asiakashinnat[] = array(
           'customerEmail' => $asiakas['asiakas_email'],
@@ -1687,6 +1687,7 @@ class MagentoClient {
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
       for ($i = $poistettu; $i <= $total; $i++) {
         $asiakashinta = $asiakashinnat[$i];
+        var_dump($asiakashinta);
         $current++;
 
         try {
@@ -1696,11 +1697,11 @@ class MagentoClient {
             array($magento_tuotenumero, array($asiakashinta))
           );
 
-          $this->log('magento_tuotteet', "({$current}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat poistettu ({$asiakas['asiakas_email']})");
+          $this->log('magento_tuotteet', "({$current}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat poistettu ({$asiakashinta['asiakas_email']})");
         }
         catch(Exception $e) {
           $this->_error_count++;
-          $this->log('magento_tuotteet', "Virhe asiakaskohtaisten hintojen poistossa! Magento-tuoteno {$magento_tuotenumero}, asiakas_email: {$asiakas['asiakas_email']}, website-code: {$this->_asiakaskohtaiset_tuotehinnat}", $e);
+          $this->log('magento_tuotteet', "Virhe asiakaskohtaisten hintojen poistossa! Magento-tuoteno {$magento_tuotenumero}, asiakas_email: {$asiakashinta['asiakas_email']}, website-code: {$this->$asiakashinta}", $e);
         }
       }
 

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1570,7 +1570,7 @@ class MagentoClient {
         $this->_error_count++;
         $this->log('magento_tuotteet', "Virhe! Tuotteen {$magento_tuotenumero} asiakaskohtaisen ({$hintadata['customerEmail']}) hinnan lisäys epäonnistui blockina", $e);
         $onnistuiko_lisays = false;
-        continue;
+        break;
       }
       $onnistuiko_lisays = true;
     }
@@ -1671,7 +1671,7 @@ class MagentoClient {
           $this->_error_count++;
           $this->log('magento_tuotteet', "Virhe asiakaskohtaisten hintojen poistossa! Magento-tuoteno {$magento_tuotenumero}, website-code: {$this->_asiakaskohtaiset_tuotehinnat}", $e);
           $onnistuiko_paivitys = false;
-          continue;
+          break;
         }
       }
 

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1671,11 +1671,11 @@ class MagentoClient {
 
           $this->log('magento_tuotteet', "({$offset}/{$total}) Tuotteen {$magento_tuotenumero} kaikki asiakaskohtaiset hinnat poistettu. Block size 500");
           $offset += 500;
+          $poistettu += 500;
         }
         catch(Exception $e) {
           $this->_error_count++;
           $this->log('magento_tuotteet', "Virhe asiakaskohtaisten hintojen poistossa! Magento-tuoteno {$magento_tuotenumero}, website-code: {$this->_asiakaskohtaiset_tuotehinnat}", $e);
-          $poistettu = $offset;
           return false;
         }
       }
@@ -1683,7 +1683,7 @@ class MagentoClient {
       return true;
     }
     else {
-      $current = $offset;
+      $current = $poistettu;
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
       for ($i = $poistettu; $i <= $total; $i++) {
         $asiakas = $asiakkaat_per_yhteyshenkilo[$i];

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1573,15 +1573,16 @@ class MagentoClient {
       }
       catch (Exception $e) {
         $this->_error_count++;
-        $this->log('magento_tuotteet', "Virhe! Tuotteen {$magento_tuotenumero} asiakaskohtaisen ({$hintadata['customerEmail']}) hinnan lisäys epäonnistui", $e);
+        $this->log('magento_tuotteet', "Virhe! Tuotteen {$magento_tuotenumero} asiakaskohtaisen ({$hintadata['customerEmail']}) hinnan lisäys epäonnistui blockina", $e);
         $onnistuiko_lisays = false;
+        continue;
       }
     }
     
     if ($onnistuiko_lisays === false) { 
       for ($i = $offset; $i <= $total; $i++) {
         $hintadata = $asiakaskohtainenhintadata[$i];
-
+        $current++;
         try {
           $reply = $this->_proxy->call(
             $this->_session,
@@ -1647,6 +1648,7 @@ class MagentoClient {
 
     if ($kaikki_kerralla) {
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
+      $offset = 0;
       foreach ($asiakkaat_per_yhteyshenkilo as $asiakas) {
         $asiakashinnat[] = array(
           'customerEmail' => $asiakas['asiakas_email'],
@@ -1678,10 +1680,11 @@ class MagentoClient {
       return true;
     }
     else {
+      $current = $offset;
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
       for ($i = $offset; $i <= $total; $i++) {
         $asiakas = $asiakkaat_per_yhteyshenkilo[$i];
-
+        $current++;
         $asiakashinnat = array(
           'customerEmail' => $asiakas['asiakas_email'],
           'websiteCode' => $this->_asiakaskohtaiset_tuotehinnat,
@@ -2265,7 +2268,7 @@ class MagentoClient {
     // Etitään optionsin value
     foreach ($options as $option) {
       if (strcasecmp($option['label'], $value) == 0) {
-        $this->log('magento_tuotteet', "Palautetaan option-value(2246): {$option['value']}");
+        $this->log('magento_tuotteet', "Palautetaan option-value: {$option['value']}");
         return $option['value'];
       }
     }

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1642,6 +1642,7 @@ class MagentoClient {
     $current = 0;
     $total = count($asiakkaat_per_yhteyshenkilo);
     $asiakashinnat = array();
+    $onnistuiko_paivitys = true;
 
     if ($kaikki_kerralla) {
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
@@ -1673,7 +1674,6 @@ class MagentoClient {
           break;
         }
       }
-      $onnistuiko_paivitys = true;
     }
     if ($onnistuiko_paivitys === false) {
       $current = $offset;

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1580,8 +1580,10 @@ class MagentoClient {
     }
     
     if ($onnistuiko_lisays === false) { 
+      $current = $offset;
       for ($i = $offset; $i <= $total; $i++) {
         $hintadata = $asiakaskohtainenhintadata[$i];
+        var_dump($hintadata);
         $current++;
         try {
           $reply = $this->_proxy->call(
@@ -1590,12 +1592,12 @@ class MagentoClient {
             array($magento_tuotenumero, array($hintadata))
           );
       
-          $this->log('magento_tuotteet', "({$current}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset ({$hintadata['customerEmail']}) hinnat lisätty");
+          $this->log('magento_tuotteet', "({$current}/{$i}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset ({$hintadata['customerEmail']}) hinnat lisätty");
           $this->debug('magento_tuotteet', $hintadata);
         }
         catch (Exception $e) {
           $this->_error_count++;
-          $this->log('magento_tuotteet', "Virhe! Tuotteen {$magento_tuotenumero} asiakaskohtaisen ({$hintadata['customerEmail']}) hinnan lisäys epäonnistui", $e);
+          $this->log('magento_tuotteet', "Virhe! Tuotteen {$magento_tuotenumero} asiakaskohtaisen ({$hintadata['customerEmail']}) hinnan lisäys epäonnistui", $e, $i);
         }
       }
     }
@@ -1698,7 +1700,7 @@ class MagentoClient {
             array($magento_tuotenumero, array($asiakashinnat))
           );
 
-          $this->log('magento_tuotteet', "({$current}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat poistettu ({$asiakas['asiakas_email']})");
+          $this->log('magento_tuotteet', "({$current}/{$i}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat poistettu ({$asiakas['asiakas_email']})");
         }
         catch(Exception $e) {
           $this->_error_count++;

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1554,7 +1554,7 @@ class MagentoClient {
     $onnistuiko_lisays = true;
     $offset = 0;
 
-    while ($hintadata = array_slice($asiakaskohtainenhintadata, $offset, 200)) {
+    while ($hintadata = array_slice($asiakaskohtainenhintadata, $offset, 500)) {
       try {
         $reply = $this->_proxy->call(
           $this->_session,
@@ -1562,9 +1562,9 @@ class MagentoClient {
           array($magento_tuotenumero, $hintadata)
         );
 
-        $this->log('magento_tuotteet', "({$current}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat lisätty. Block size 200");
+        $this->log('magento_tuotteet', "({$offset}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat lisätty. Block size 500");
         $this->debug('magento_tuotteet', $hintadata);
-        $offset += 200;
+        $offset += 500;
       }
       catch (Exception $e) {
         $this->_error_count++;
@@ -1671,6 +1671,7 @@ class MagentoClient {
           $this->_error_count++;
           $this->log('magento_tuotteet', "Virhe asiakaskohtaisten hintojen poistossa! Magento-tuoteno {$magento_tuotenumero}, website-code: {$this->_asiakaskohtaiset_tuotehinnat}", $e);
           $onnistuiko_paivitys = false;
+          continue;
         }
       }
 

--- a/rajapinnat/magento_client.php
+++ b/rajapinnat/magento_client.php
@@ -1686,22 +1686,17 @@ class MagentoClient {
       $current = $poistettu;
       // Poistetaan kaikkien asiakkaiden hinta tältä tuotteelta
       for ($i = $poistettu; $i <= $total; $i++) {
-        $asiakas = $asiakkaat_per_yhteyshenkilo[$i];
+        $asiakashinta = $asiakashinnat[$i];
         $current++;
-        $asiakashinnat = array(
-          'customerEmail' => $asiakas['asiakas_email'],
-          'websiteCode' => $this->_asiakaskohtaiset_tuotehinnat,
-          'delete' => 1
-        );
 
         try {
           $this->_proxy->call(
             $this->_session,
             'price_per_customer.setPriceForCustomersPerProduct',
-            array($magento_tuotenumero, array($asiakashinnat))
+            array($magento_tuotenumero, array($asiakashinta))
           );
 
-          $this->log('magento_tuotteet', "({$current}/{$i}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat poistettu ({$asiakas['asiakas_email']})");
+          $this->log('magento_tuotteet', "({$current}/{$total}): Tuotteen {$magento_tuotenumero} asiakaskohtaiset hinnat poistettu ({$asiakas['asiakas_email']})");
         }
         catch(Exception $e) {
           $this->_error_count++;

--- a/rajapinnat/tuote_export.php
+++ b/rajapinnat/tuote_export.php
@@ -403,8 +403,8 @@ if (in_array('tuotteet', $magento_ajolista)) {
   tuote_export_echo("Päivitetään simple tuotteet");
   $magento_client->lisaa_simple_tuotteet($dnstuote, $individual_tuotteet);
 
-  tuote_export_echo("Poistetaan ylimääräiset tuotteet");
-  $magento_client->poista_poistetut($kaikki_tuotteet, true);
+  #tuote_export_echo("Poistetaan ylimääräiset tuotteet");
+  #$magento_client->poista_poistetut($kaikki_tuotteet, true);
 }
 
 if (in_array('saldot', $magento_ajolista)) {

--- a/rajapinnat/tuote_export.php
+++ b/rajapinnat/tuote_export.php
@@ -403,8 +403,8 @@ if (in_array('tuotteet', $magento_ajolista)) {
   tuote_export_echo("Päivitetään simple tuotteet");
   $magento_client->lisaa_simple_tuotteet($dnstuote, $individual_tuotteet);
 
-  #tuote_export_echo("Poistetaan ylimääräiset tuotteet");
-  #$magento_client->poista_poistetut($kaikki_tuotteet, true);
+  tuote_export_echo("Poistetaan ylimääräiset tuotteet");
+  $magento_client->poista_poistetut($kaikki_tuotteet, true);
 }
 
 if (in_array('saldot', $magento_ajolista)) {

--- a/rajapinnat/tuote_export.php
+++ b/rajapinnat/tuote_export.php
@@ -375,8 +375,10 @@ $magento_client->setTuetutKieliversiot($tuetut_kieliversiot);
 $kieliversiot = array("fi"); //oletuskieli
 
 // tuotteiden hakuun tehdään valmis taulukko kielistä
-foreach ($tuetut_kieliversiot as $kieli => $bar) {
-  $kieliversiot[] = $kieli;
+if (isset($tuetut_kieliversiot)) {
+  foreach ($tuetut_kieliversiot as $kieli => $bar) {
+    $kieliversiot[] = $kieli;
+  }
 }
 
 if (in_array('tuotteet', $magento_ajolista)) {

--- a/rajapinnat/tuote_export_functions.php
+++ b/rajapinnat/tuote_export_functions.php
@@ -154,7 +154,7 @@ function tuote_export_hae_tuotetiedot($params) {
             AND tuote.status != 'P'
             AND tuote.tuotetyyppi NOT in ('A','B')
             AND tuote.tuoteno != ''
-            AND tuote.tuoteno = '110000'
+            AND tuote.tuoteno = '107303'
             AND tuote.nakyvyys != ''
             $muutoslisa
             ORDER BY tuote.tuoteno";
@@ -697,7 +697,7 @@ function tuote_export_hae_lajitelmatuotteet($params) {
               AND tuote.status != 'P'
               AND tuote.tuotetyyppi NOT in ('A','B')
               AND tuote.tuoteno != ''
-              AND tuote.tutoeno = '110000'
+              AND tuote.tutoeno = '107303'
               AND tuote.nakyvyys != '')
             LEFT JOIN avainsana as try_fi ON (try_fi.yhtio = tuote.yhtio
               and try_fi.selite = tuote.try

--- a/rajapinnat/tuote_export_functions.php
+++ b/rajapinnat/tuote_export_functions.php
@@ -697,7 +697,7 @@ function tuote_export_hae_lajitelmatuotteet($params) {
               AND tuote.status != 'P'
               AND tuote.tuotetyyppi NOT in ('A','B')
               AND tuote.tuoteno != ''
-              AND tuote.tutoeno = '107303'
+              AND tuote.tuoteno = '107303'
               AND tuote.nakyvyys != '')
             LEFT JOIN avainsana as try_fi ON (try_fi.yhtio = tuote.yhtio
               and try_fi.selite = tuote.try

--- a/rajapinnat/tuote_export_functions.php
+++ b/rajapinnat/tuote_export_functions.php
@@ -154,6 +154,7 @@ function tuote_export_hae_tuotetiedot($params) {
             AND tuote.status != 'P'
             AND tuote.tuotetyyppi NOT in ('A','B')
             AND tuote.tuoteno != ''
+            AND tuote.tuoteno = '110000'
             AND tuote.nakyvyys != ''
             $muutoslisa
             ORDER BY tuote.tuoteno";
@@ -696,6 +697,7 @@ function tuote_export_hae_lajitelmatuotteet($params) {
               AND tuote.status != 'P'
               AND tuote.tuotetyyppi NOT in ('A','B')
               AND tuote.tuoteno != ''
+              AND tuote.tutoeno = '110000'
               AND tuote.nakyvyys != '')
             LEFT JOIN avainsana as try_fi ON (try_fi.yhtio = tuote.yhtio
               and try_fi.selite = tuote.try

--- a/rajapinnat/tuote_export_functions.php
+++ b/rajapinnat/tuote_export_functions.php
@@ -154,7 +154,6 @@ function tuote_export_hae_tuotetiedot($params) {
             AND tuote.status != 'P'
             AND tuote.tuotetyyppi NOT in ('A','B')
             AND tuote.tuoteno != ''
-            AND tuote.tuoteno = '107303'
             AND tuote.nakyvyys != ''
             $muutoslisa
             ORDER BY tuote.tuoteno";
@@ -697,7 +696,6 @@ function tuote_export_hae_lajitelmatuotteet($params) {
               AND tuote.status != 'P'
               AND tuote.tuotetyyppi NOT in ('A','B')
               AND tuote.tuoteno != ''
-              AND tuote.tuoteno = '107303'
               AND tuote.nakyvyys != '')
             LEFT JOIN avainsana as try_fi ON (try_fi.yhtio = tuote.yhtio
               and try_fi.selite = tuote.try

--- a/yllapito.php
+++ b/yllapito.php
@@ -254,7 +254,13 @@ if ($del == 1) {
       $result = pupe_query($query);
     }
   }
-
+  if ($toim == "hinnasto") {
+        $query = "UPDATE tuote
+                  SET muuttaja = '$kukarow[kuka]', muutospvm=now()
+                  WHERE yhtio = '$kukarow[yhtio]'
+                  and tuoteno = '$trow[tuoteno]'";
+        $result = pupe_query($query);
+  }
   synkronoi($kukarow["yhtio"], $toim, $tunnus, $trow, "");
 
   //  Jos poistetaan perheen osa palataan perheelle

--- a/yllapito.php
+++ b/yllapito.php
@@ -277,6 +277,13 @@ if ($del == 2) {
                 WHERE tunnus='$poista_tunnus'";
       $result = pupe_query($query);
 
+      if ($toim == "hinnasto") {
+        $query = "UPDATE tuote
+                  SET muuttaja = '$kukarow[kuka]', muutospvm=now()
+                  WHERE yhtio = '$kukarow[yhtio]'
+                  and tuoteno = '$trow[tuoteno]'";
+        $result = pupe_query($query);
+      }
       synkronoi($kukarow["yhtio"], $toim, $tunnus, $trow, "");
     }
   }


### PR DESCRIPTION
Asiakashintojen päivitystä muutettu niin, että poistot ja lisäykset tehdään massana
   --jos virheitä, poistot/lisäykset yksitellen vasta virheellisestä blockista lähtien.

Myös arvot nolla ja tyhjä huomioidaan päivityksinä.

Erikoishinnan poisto päivittää automaattisesti tuotteen muutospäivää, jolloin muutos päivittyy seuraavan päivitysajon yhteydessä verkkokauppaan.