### PR TITLE
Tarjous: tarjouksen mitätöinnistä syykommentti

### DIFF
--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -277,6 +277,7 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "CRM_ROOLI") $ulos .= "<option value='CRM_ROOLI' $avain_sel[CRM_ROOLI]>".t("Yhteyshenkilön rooli")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "CRM_SUORAMARKKI") $ulos .= "<option value='CRM_SUORAMARKKI' $avain_sel[CRM_SUORAMARKKI]>".t("Yhteyshenkilön suoramarkkinointitiedot")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "CRM_HAAS") $ulos .= "<option value='CRM_HAAS' {$avain_sel['CRM_HAAS']}>".t("Haas USR-kentät")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "CRMVIESTI_TARJOUSPOISTO") $ulos .= "<option value='CRMVIESTI_TARJOUSPOISTO' {$avain_sel['CRMVIESTI_TARJOUSPOISTO']}>".t("CRM viesti tarjouksen poistosta")."</option>";
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
   if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Muut avainsanat")."'>";

--- a/inventoi.php
+++ b/inventoi.php
@@ -2359,7 +2359,7 @@ if ($tee == 'INVENTOI') {
     echo "<td><select id='inven_laji' name='inven_laji'>";
 
     while ($itrow = mysql_fetch_assoc($tresult)) {
-
+echo "2362 itrow $itrow <br><br>";
       if (!isset($inven_laji) and !isset($sel)) {
         $sel = 'selected';
         $lisaselite = $itrow["selitetark_4"];
@@ -2377,7 +2377,7 @@ if ($tee == 'INVENTOI') {
     }
     echo "</select></td></tr>";
   }
-
+echo "2380 {$itrow["selite"]} <br><br>";
   if (substr($toim, 0, 4) != "OSTO") {
     echo "<tr><th>".t("Syötä inventointiselite:")."</th>";
     echo "<td><input type='text' size='50' id='lisaselite' name='lisaselite' value='$lisaselite'></td></tr>";

--- a/inventoi.php
+++ b/inventoi.php
@@ -2359,7 +2359,7 @@ if ($tee == 'INVENTOI') {
     echo "<td><select id='inven_laji' name='inven_laji'>";
 
     while ($itrow = mysql_fetch_assoc($tresult)) {
-echo "2362 itrow $itrow <br><br>";
+
       if (!isset($inven_laji) and !isset($sel)) {
         $sel = 'selected';
         $lisaselite = $itrow["selitetark_4"];
@@ -2377,7 +2377,7 @@ echo "2362 itrow $itrow <br><br>";
     }
     echo "</select></td></tr>";
   }
-echo "2380 {$itrow["selite"]} <br><br>";
+
   if (substr($toim, 0, 4) != "OSTO") {
     echo "<tr><th>".t("Syötä inventointiselite:")."</th>";
     echo "<td><input type='text' size='50' id='lisaselite' name='lisaselite' value='$lisaselite'></td></tr>";


### PR DESCRIPTION
Uusi yhtiön avainsana, jolla voidaan määritellä ennalta kommentteja tarjouksen poiston syiksi. Tarjouksen mitätöintivaiheessa, avoimet tarjoukset näkymässä, muokkaa tarjouksia näkymässä sekä tarjousnäkymässä, pystyy valitsemaan alasvetovalikosta syyn tarjouksen mitätöinnille. Mitätöinnin jälkeen tarjouksen asiakkaan memoon lisätään muistiinpano tarjouksen mitätöinnistä, sekä kommenttiin lisätään tämä syyteksti.