### PR TITLE
Tarjous: tarjouksen hylkäyksestä syykommentti

### DIFF
--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -277,6 +277,7 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "CRM_ROOLI") $ulos .= "<option value='CRM_ROOLI' $avain_sel[CRM_ROOLI]>".t("Yhteyshenkilön rooli")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "CRM_SUORAMARKKI") $ulos .= "<option value='CRM_SUORAMARKKI' $avain_sel[CRM_SUORAMARKKI]>".t("Yhteyshenkilön suoramarkkinointitiedot")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "CRM_HAAS") $ulos .= "<option value='CRM_HAAS' {$avain_sel['CRM_HAAS']}>".t("Haas USR-kentät")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "CRM_TARJOUSPOIS") $ulos .= "<option value='CRM_TARJOUSPOIS' {$avain_sel['CRM_TARJOUSPOIS']}>".t("CRM viesti tarjouksen poistosta")."</option>";
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
   if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Muut avainsanat")."'>";

--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -277,7 +277,7 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "CRM_ROOLI") $ulos .= "<option value='CRM_ROOLI' $avain_sel[CRM_ROOLI]>".t("Yhteyshenkilön rooli")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "CRM_SUORAMARKKI") $ulos .= "<option value='CRM_SUORAMARKKI' $avain_sel[CRM_SUORAMARKKI]>".t("Yhteyshenkilön suoramarkkinointitiedot")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "CRM_HAAS") $ulos .= "<option value='CRM_HAAS' {$avain_sel['CRM_HAAS']}>".t("Haas USR-kentät")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "CRM_TARJOUSPOIS") $ulos .= "<option value='CRM_TARJOUSPOIS' {$avain_sel['CRM_TARJOUSPOIS']}>".t("CRM viesti tarjouksen poistosta")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "CRM_TARJOUSPOIS") $ulos .= "<option value='CRM_TARJOUSPOIS' {$avain_sel['CRM_TARJOUSPOIS']}>".t("CRM viesti tarjouksen hylkäyksestä")."</option>";
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
   if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Muut avainsanat")."'>";

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -1105,6 +1105,16 @@ if ($kukarow["extranet"] == "" and $tee == "HYLKAATARJOUS" and $muokkauslukko ==
     exit;
   }
 
+  if (isset($crm_tarjouspois)) {
+    $hylkays_kommentti = " Tarjouksen hylk‰yksen syy: $crm_tarjouspois";
+
+    $query = "UPDATE lasku SET comments = '{$hylkays_kommentti}' where yhtio='$kukarow[yhtio]' and tunnus='$kukarow[kesken]'";
+    $result = pupe_query($query);
+
+    // Tehd‰‰n tarjouksen poistosta kommentti asiakasmemoon
+    kalenteritapahtuma("Memo", "Tarjous asiakkaalle", "Tarjouksen hylk‰yksen syy: {$crm_tarjouspois}", $laskurow["liitostunnus"], "", "", $laskurow["tunnus"]);
+  }
+
   $query = "UPDATE lasku SET alatila='X' where yhtio='$kukarow[yhtio]' and tunnus='$kukarow[kesken]'";
   $result = pupe_query($query);
 
@@ -10336,8 +10346,22 @@ if ($tee == '') {
       if ($toim != 'EXTTARJOUS') {
         echo "  <br>
             <br>
-            <form name='hylkaa' method='post' action='{$palvelin2}{$tilauskaslisa}tilaus_myynti.php' onsubmit=\"return confirm('Oletko varma ett‰ haluat hyl‰t‰ tarjouksen $kukarow[kesken]?')\">
-            <input type='hidden' name='toim' value='$toim'>
+            <form name='hylkaa' method='post' action='{$palvelin2}{$tilauskaslisa}tilaus_myynti.php' onsubmit=\"return confirm('Oletko varma ett‰ haluat hyl‰t‰ tarjouksen $kukarow[kesken]?')\">";
+
+        $tresult = t_avainsana("CRM_TARJOUSPOIS");
+
+        if (mysql_num_rows($tresult) > 0) {
+          echo t("Hylk‰yksen syy").":";
+
+          echo "<select name='crm_tarjouspois'>";
+
+          while ($itrow = mysql_fetch_assoc($tresult)) {
+            echo "<option value='$itrow[selitetark]' $sel>$itrow[selite]</option>";
+          }
+          echo "</select>";
+        }
+
+        echo "<input type='hidden' name='toim' value='$toim'>
             <input type='hidden' name='lopetus' value='$lopetus'>
             <input type='hidden' name='ruutulimit' value = '$ruutulimit'>
             <input type='hidden' name='projektilla' value='$projektilla'>

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -1108,7 +1108,7 @@ if ($kukarow["extranet"] == "" and $tee == "HYLKAATARJOUS" and $muokkauslukko ==
   if (isset($crm_tarjouspois)) {
     $hylkays_kommentti = " Tarjouksen hylk‰yksen syy: $crm_tarjouspois";
 
-    $query = "UPDATE lasku SET comments = '{$hylkays_kommentti}' where yhtio='$kukarow[yhtio]' and tunnus='$kukarow[kesken]'";
+    $query = "UPDATE lasku SET comments = CONCAT(comments, ' {$hylkays_kommentti}') where yhtio='$kukarow[yhtio]' and tunnus='$kukarow[kesken]'";
     $result = pupe_query($query);
 
     // Tehd‰‰n tarjouksen poistosta kommentti asiakasmemoon


### PR DESCRIPTION
Uusi yhtiön avainsana, jolla voidaan määritellä ennalta kommentteja tarjouksen hylkäyksen syiksi. Tarjouksen hylkäämisvaiheessa pystyy valitsemaan alasvetovalikosta syyn tarjouksen hylkäykselle. Hylkäyksen jälkeen tarjouksen asiakkaan memoon lisätään muistiinpano tarjouksen hylkäyksestä, sekä tarjouksen kommenttiin lisätään tämä syyteksti.