### PR TITLE
Extranet: saldotarkistus tuoteperheelle

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -534,9 +534,13 @@ if ($tee == 'TARKISTA') {
   $xresult = pupe_query($xquery);
 
   while ($xrow = mysql_fetch_assoc($xresult)) {
-    $tuoteno_array[]                   = $xrow['tuoteno'];
-    $kpl_array[$xrow['tuoteno']]       = $xrow['tilkpl'];
-    $kommentti_array[$xrow['tuoteno']] = $xrow['kommentti'];
+    // Lis‰t‰‰n tuoteno_array muttujaan vain is‰tuotteet,
+    // koska muuten lapset lis‰t‰‰ perheen mukana JA itsen‰isin‰ tuotteina
+    if ($xrow["perheid"] == 0 or $xrow["perheid"] == $xrow["tunnus"]) {
+      $tuoteno_array[]                   = $xrow['tuoteno'];
+      $kpl_array[$xrow['tuoteno']]       = $xrow['tilkpl'];
+      $kommentti_array[$xrow['tuoteno']] = $xrow['kommentti'];
+    }
 
     $query = "UPDATE tilausrivi SET
               tyyppi      = 'D'


### PR DESCRIPTION
Extranetin saldotarkistus ei osannut käsitellä tuoteperheellisiä tuotteita. Saldotarkistuksen jälkeen, kun tilausrivit lisättiin takaisin tilaukselle, niin tässä kohdin tuoteperheen lapset lisättiin sekä itsenäisinä tuotteina, että osana tuoteperhettä. Tämä on korjattu ja jatkossa tuoteperheiden lapset lisätään vain osana tuoteperhettä saldotarkistuksen yhteydessä.