### PR TITLE
Useita tilauksia samalle rahtikirjalle

### DIFF
--- a/rahtikirja.php
+++ b/rahtikirja.php
@@ -707,7 +707,10 @@ if ($tee == 'add') {
           if (count($kiloja) > 1) {
             $kollit[$i] = 1;
           }
-
+          // Jos yhditetty tilauksia rahtikirjalle, sortataan ne sellaiseen järjestykseen, että
+          // kollit ja kilot tulee sille tilaukselle, jolla otsikkonro=rahtikijranro,
+          // niin ollaan Unifaun-yhteensopivia
+          asort($tilaukset);
           foreach ($tilaukset as $otsikkonro) {
 
             foreach ($kiloja as $yksikilo) {


### PR DESCRIPTION
Kollit päivitetään sille tilaukselle, jonka numeroa käytetään rahtikirjanrona, niin että saadaan siirrettyä tarvittaessa tiedot oikein Unifauniin