### PR TITLE
Ei hyväksyjiä käytössä: laskun liitteen poisto

### DIFF
--- a/inc/liitetiedostot.inc
+++ b/inc/liitetiedostot.inc
@@ -63,7 +63,7 @@ if ($lukitse_laji == "lasku" and $lukitse_avaimeen > 0) {
     $poistolukko = "";
   }
 
-  if ($del == 1 or ($tunnus != "" and $_FILES["liite_data"]["size"] > 0)) {
+  if (laskun_hyvaksyjia() and ($del == 1 or ($tunnus != "" and $_FILES["liite_data"]["size"] > 0))) {
     if (in_array($lasrow['tila'], array('H', 'M')) and $kukarow["taso"] != 3) {
 
       $komm = "(" . $kukarow['nimi'] . "@" . date('Y-m-d') .") ".t("Lasku palautettiin hyväksyntään koska laskun liitteitä muutettiin.")."<br>";


### PR DESCRIPTION
Mikäli ostolaskujen hyväksyntää ei ole käytössä eli ketään käyttäjistä ei ole merkitty laskujen hyväksyjäksi ei laskua pitäisi missään vaiheessa hyväksyttäväksi laittaa. Nyt kuitenkin, jos meni laskulta liitetiedoston poistamaan niin tässä tapauksessa lasku laitettiin hyväksyttäväksi. Korjattu nyt niin, että jos hyväksyjiä ei ole niin ei laskua myöskään tässä tapauksessa hyväksyttäväksi laiteta.