### PR TITLE
Tarjoustulostus: vakioviestille enempi tilaa

### DIFF
--- a/tilauskasittely/tulosta_tarjous.inc
+++ b/tilauskasittely/tulosta_tarjous.inc
@@ -1851,6 +1851,8 @@ if (!function_exists('loppu_tarjous')) {
               $pdf_tarjous->draw_text(30,  $_y, $teksi, $page_tarjous[$sivu], $norm);
               $_y = $_y - 10;
             }
+
+            $kuha = $_y;
           }
           else {
             $pdf_tarjous->draw_text(30,  $kuha-24, $vakioteksti, $page_tarjous[$sivu], $norm);


### PR DESCRIPTION
Tarjouksen avainsanoista tuleva vakioviesti saattoi mennä muiden tarjouksen tekstien päälle, mikäli kyseinen teksti oli pitkä. Tätä on nyt korjattu niin, että tekstille annetaan enemmän tilaa sen pituuden mukaan.