### PR TITLE
Katteen pyöristys riveille

### DIFF
--- a/inc/kate_jyvita_riveille.inc
+++ b/inc/kate_jyvita_riveille.inc
@@ -37,7 +37,7 @@ function laske_tilausriveille_uudet_hinnat($uusi_kate, $tilausnumero = 0, $tilau
             WHERE yhtio = '{$kukarow['yhtio']}'
             {$tilausrivi_where}";
   $result = pupe_query($query);
-echo "32 $query <br><br>";
+
   $tilausrivit = array();
   while ($tilausrivi = mysql_fetch_assoc($result)) {
     $tilausrivit[] = $tilausrivi;
@@ -53,11 +53,11 @@ echo "32 $query <br><br>";
     }
 
     $rivin_alennus = generoi_alekentta_php($tilausrivi, 'M', 'kerto');
-echo "48 rivin_alennus $rivin_alennus tilausriviKehahin {$tilausrivi["kehahin"]} <br><br>";
+
     //Jos rivill‰ on alennuksia, niin kahahinnan p‰‰lle pit‰‰ laskea rivin alennukset, jotta uuden katteen laskenta menee oikein.
     $kehahin_plus_alennus = $tilausrivi['kehahin'] / $rivin_alennus;
     $uusi_hinta = $kehahin_plus_alennus / ( 1 - ( $uusi_kate / 100 ));
-echo "52 uusi_hinta $uusi_hinta = kehahin_plus_alennus $kehahin_plus_alennus / (1 - (uusi_kate $uusi_kate / 100)) // yhtiAlvKasittely {$yhtiorow['alv_kasittely']} <br><br>";
+
     //Jos alv_kasittely on p‰‰ll‰, tarkoittaa se,
     //ett‰ myyntihinnoissa on alv laskettuna myyntihinnan sis‰lle.
     //Verrattuna verottomaan myyntihintaan,
@@ -65,7 +65,7 @@ echo "52 uusi_hinta $uusi_hinta = kehahin_plus_alennus $kehahin_plus_alennus / (
     if ($yhtiorow['alv_kasittely'] == '') {
       $uusi_hinta = $uusi_hinta * (1 + ($tilausrivi['alv'] / 100));
     }
-echo "60 uusi_hinta $uusi_hinta <br><br><br><br>";
+
     $uusi_hinta = hintapyoristys($uusi_hinta);
 
     $summa += $uusi_hinta;

--- a/inc/kate_jyvita_riveille.inc
+++ b/inc/kate_jyvita_riveille.inc
@@ -22,14 +22,22 @@ function laske_tilausriveille_uudet_hinnat($uusi_kate, $tilausnumero = 0, $tilau
   }
 
   $query = "SELECT tilausrivi.*,
-            tuote.kehahin
+                   if (tuote.epakurantti100pvm = '0000-00-00',
+                     if (tuote.epakurantti75pvm = '0000-00-00',
+                       if (tuote.epakurantti50pvm = '0000-00-00',
+                         if (tuote.epakurantti25pvm = '0000-00-00',
+                          tuote.kehahin,
+                         tuote.kehahin * 0.75),
+                       tuote.kehahin * 0.5),
+                     tuote.kehahin * 0.25),
+                   0) AS kehahin
             FROM tilausrivi
             JOIN tuote
             USING (yhtio, tuoteno)
             WHERE yhtio = '{$kukarow['yhtio']}'
             {$tilausrivi_where}";
   $result = pupe_query($query);
-
+echo "32 $query <br><br>";
   $tilausrivit = array();
   while ($tilausrivi = mysql_fetch_assoc($result)) {
     $tilausrivit[] = $tilausrivi;
@@ -45,11 +53,11 @@ function laske_tilausriveille_uudet_hinnat($uusi_kate, $tilausnumero = 0, $tilau
     }
 
     $rivin_alennus = generoi_alekentta_php($tilausrivi, 'M', 'kerto');
-
+echo "48 rivin_alennus $rivin_alennus tilausriviKehahin {$tilausrivi["kehahin"]} <br><br>";
     //Jos rivill‰ on alennuksia, niin kahahinnan p‰‰lle pit‰‰ laskea rivin alennukset, jotta uuden katteen laskenta menee oikein.
     $kehahin_plus_alennus = $tilausrivi['kehahin'] / $rivin_alennus;
     $uusi_hinta = $kehahin_plus_alennus / ( 1 - ( $uusi_kate / 100 ));
-
+echo "52 uusi_hinta $uusi_hinta = kehahin_plus_alennus $kehahin_plus_alennus / (1 - (uusi_kate $uusi_kate / 100)) // yhtiAlvKasittely {$yhtiorow['alv_kasittely']} <br><br>";
     //Jos alv_kasittely on p‰‰ll‰, tarkoittaa se,
     //ett‰ myyntihinnoissa on alv laskettuna myyntihinnan sis‰lle.
     //Verrattuna verottomaan myyntihintaan,
@@ -57,7 +65,7 @@ function laske_tilausriveille_uudet_hinnat($uusi_kate, $tilausnumero = 0, $tilau
     if ($yhtiorow['alv_kasittely'] == '') {
       $uusi_hinta = $uusi_hinta * (1 + ($tilausrivi['alv'] / 100));
     }
-
+echo "60 uusi_hinta $uusi_hinta <br><br><br><br>";
     $uusi_hinta = hintapyoristys($uusi_hinta);
 
     $summa += $uusi_hinta;


### PR DESCRIPTION
Katteen pyöristyksessä riveille ei osattu ottaa huomioon tuotteen epäkuranttiustilaa vaan katepyöristys laskettiin aina tuotteen täydellä keskihankintahinnalla. Tämän seurauksena, kun tilausrivinäkymässä kun kate laskettiin rivikohtaisesti ei kate ollutkaan sama kuin mihin kate "pyöristettiin", koska tässä kohtaa epäkuranttiustila osattiin ottaa huomioon. Tämä on nyt korjattu, että katteen pyöristys osaa tuotteen epäkuranttiustilan ottaa huomioon.