### PR TITLE
Unifaun toim_email

### DIFF
--- a/inc/unifaun_send.inc
+++ b/inc/unifaun_send.inc
@@ -133,6 +133,10 @@ class Unifaun {
                 and tunnus  = '{$this->postirow['liitostunnus']}'";
       $asres = pupe_query($query);
       $this->asiakasrow = mysql_fetch_assoc($asres);
+
+      if (!empty($this->postirow['toim_email'])) {
+        $this->asiakasrow['email'] = $this->postirow['toim_email'];
+      }
     }
   }
 


### PR DESCRIPTION
Jos tilaukselle on asetettu erillinen toimitussähköposti, käytetään
sitä asiakkaan sähköpostina Unifauniin siirtyvässä aineistossa