### PR TITLE
Unifaun VAK painot fix

### DIFF
--- a/inc/unifaun_send.inc
+++ b/inc/unifaun_send.inc
@@ -1201,8 +1201,17 @@ class Unifaun {
           $uni_par_val->addAttribute('n', "count");
         }
 
+        // VAK tiedot annetaan aina lähetyskohtaisesti. Jos on useampi kolli, niin tiedot menee per kolli lähetykseen,
+        // joten painot pitää jakaa kollien määrällä, jottei painot moninkertaistu
+        if (isset($pakkaustiedot['rahtikirjan_kollit_yhteensa']) and $pakkaustiedot['rahtikirjan_kollit_yhteensa'] > 1) {
+          $_jakaja = $pakkaustiedot['rahtikirjan_kollit_yhteensa'];
+        }
+        else {
+          $_jakaja = 1;
+        }
+
         if (isset($vak['kpl_paino']) and $vak['kpl_paino'] != '') {
-          $uni_par_val = $uni_article->addChild('val', utf8_encode($vak['kpl_paino'])); // UN-number for ADR. Supplied as a 4 digit code.
+          $uni_par_val = $uni_article->addChild('val', utf8_encode($vak['kpl_paino'] / $_jakaja)); // UN-number for ADR. Supplied as a 4 digit code.
           $uni_par_val->addAttribute('n', "weight");
         }
 
@@ -1258,6 +1267,7 @@ class Unifaun {
 
         if (isset($vak['paino']) and $vak['paino'] != '') {
 
+          $vak['paino'] = $vak['paino'] / $_jakaja;
           $vak['paino'] = $vak['paino'] < 1 ? 1 : $vak['paino'];
 
           // Net weight for ADR goods class I (usually explosive contents). Always mandatory for DBSchenker, regardless of class. Defined in kg.

--- a/tilauskasittely/rahtikirja_unifaun_uo_siirto.inc
+++ b/tilauskasittely/rahtikirja_unifaun_uo_siirto.inc
@@ -122,7 +122,8 @@ if ($yhtiorow['kerayserat'] != 'K' and $kollityht > 0) {
         'syvyys'        => $pakkaus_row['syvyys'],
         'vakkoodi'      => $vak_tiedot,
         'kuutiot'       => $kuutiot[$indeksi],
-        'lavametri'     => $lavametri[$indeksi]
+        'lavametri'     => $lavametri[$indeksi],
+        'rahtikirjan_kollit_yhteensa' => $kollityht,
       );
 
       /* VOIDAAN LÄHETTÄÄ MYÖS MONTA CONTAINER-ROWTA PER SANOMA! YKSI HEADER */


### PR DESCRIPTION
Unifauniin siirtyvät vak-tuotteiden painot jaettu rahtikirjan kollien lukumäärällä, ettei vak-painot moninkertaistu.