### PR TITLE
Työmääräykset: jako luontitavan mukaan

### DIFF
--- a/muokkaatilaus.php
+++ b/muokkaatilaus.php
@@ -1272,8 +1272,8 @@ elseif ($toim == 'SUPER' or $toim == 'SUPERTEHDASPALAUTUKSET' or $toim == "SUPER
                  AND lasku.tila            IN ('L', 'N')
                  AND lasku.alatila        != 'X'
                  AND lasku.clearing       != 'EXTENNAKKO'
-                 #{$_ei_ollenkaan_tyomaarayksia_arraylisa}
-                 #{$_ei_tyomaarays_tyomaarayksia_arraylisa}
+                 {$_ei_ollenkaan_tyomaarayksia_arraylisa}
+                 {$_ei_tyomaarays_tyomaarayksia_arraylisa}
                  {$sumhaku}";
     $sumresult = pupe_query($sumquery);
     $sumrow = mysql_fetch_assoc($sumresult);

--- a/muokkaatilaus.php
+++ b/muokkaatilaus.php
@@ -338,12 +338,12 @@ echo "  <script type='text/javascript' language='JavaScript'>
 
 $toim = strtoupper($toim);
 
-if ($toim == "" or $toim == "SUPER" or $toim == "SUPER_EITYOM" or $toim == "LASKUTUSKIELTO" or $toim == "KESKEN" or $toim == "TOSI_KESKEN" or $toim == 'KESKEN_TAI_TOIMITETTAVISSA') {
+if ($toim == "" or $toim == "SUPER" or $toim == "SUPER_EITYOM" or $toim == "SUPER_EILUONTITAPATYOM" or $toim == "LASKUTUSKIELTO" or $toim == "KESKEN" or $toim == "TOSI_KESKEN" or $toim == 'KESKEN_TAI_TOIMITETTAVISSA') {
   $pika_oikeu = tarkista_oikeus('tilaus_myynti.php', 'PIKATILAUS');
   $rivi_oikeu = tarkista_oikeus('tilaus_myynti.php', 'RIVISYOTTO');
 }
 
-if ($toim == "" or $toim == "SUPER" or $toim == "SUPER_EITYOM" or $toim == "KESKEN") {
+if ($toim == "" or $toim == "SUPER" or $toim == "SUPER_EITYOM" or $toim == "SUPER_EILUONTITAPATYOM" or $toim == "KESKEN") {
   $otsikko = t("myyntitilausta");
 }
 elseif ($toim == "ENNAKKO") {
@@ -575,7 +575,7 @@ if (strpos($_SERVER['SCRIPT_NAME'], "muokkaatilaus.php") !== FALSE) {
   if ($toim != "MYYNTITILITOIMITA" and $toim != "EXTRANET" and $toim != "VALMISTUSMYYNTI" and $toim != "VALMISTUSMYYNTISUPER") {
     if (isset($eresult) and  mysql_num_rows($eresult) > 0) {
       // tehd‰‰n aktivoi nappi.. kaikki mit‰ n‰ytet‰‰n saa aktvoida, joten tarkkana queryn kanssa.
-      if ($toim == "" or $toim == "SUPER" or $toim == "SUPER_EITYOM" or $toim == "LASKUTUSKIELTO" or $toim == "KESKEN" or $toim == "TOSI_KESKEN" or $toim == 'KESKEN_TAI_TOIMITETTAVISSA') {
+      if ($toim == "" or $toim == "SUPER" or $toim == "SUPER_EITYOM" or $toim == "SUPER_EILUONTITAPATYOM" or $toim == "LASKUTUSKIELTO" or $toim == "KESKEN" or $toim == "TOSI_KESKEN" or $toim == 'KESKEN_TAI_TOIMITETTAVISSA') {
 
         if (isset($pika_oikeu) and $pika_oikeu and !$rivi_oikeu) {
           $aputoim1 = "PIKATILAUS";
@@ -719,7 +719,7 @@ if (strpos($_SERVER['SCRIPT_NAME'], "muokkaatilaus.php") !== FALSE) {
 
       echo "</select></td>";
 
-      if ($aputoim2 != "" and ($toim == "" or $toim == "SUPER" or $toim == "SUPER_EITYOM" or $toim == "ENNAKKO" or $toim == "LASKUTUSKIELTO" or $toim == "KESKEN" or $toim == "TOSI_KESKEN" or $toim == 'KESKEN_TAI_TOIMITETTAVISSA')) {
+      if ($aputoim2 != "" and ($toim == "" or $toim == "SUPER" or $toim == "SUPER_EITYOM" or $toim == "SUPER_EILUONTITAPATYOM" or $toim == "ENNAKKO" or $toim == "LASKUTUSKIELTO" or $toim == "KESKEN" or $toim == "TOSI_KESKEN" or $toim == 'KESKEN_TAI_TOIMITETTAVISSA')) {
         echo "<td class='back'><input type='submit' name='$aputoim2' value='$lisa2' $button_disabled></td>";
       }
 
@@ -1214,6 +1214,83 @@ elseif ($toim == "SUPER_EITYOM") {
         {$tilausrivin_lisatiedot_join}
         WHERE lasku.yhtio = '$kukarow[yhtio]' and lasku.tila in ('L', 'N') and lasku.alatila != 'X' and lasku.clearing != 'EXTENNAKKO'
         AND lasku.tilaustyyppi != 'A'
+        $haku
+        $tepalisa
+        GROUP BY lasku.tunnus
+        $mt_order_by
+        $rajaus";
+
+  // haetaan tilausten arvo
+  if ($kukarow['hinnat'] == 0) {
+    $sumquery = "SELECT
+                 round(sum(if(lasku.alatila = 'X', 0, tilausrivi.hinta
+                   / if('$yhtiorow[alv_kasittely]'  = '' AND tilausrivi.alv < 500,
+                     (1 + tilausrivi.alv / 100),
+                     1)
+                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
+                   * {$query_ale_lisa})), 2) AS arvo,
+                 round(sum(if(lasku.alatila = 'X', 0, tilausrivi.hinta
+                   * if('$yhtiorow[alv_kasittely]' != '' AND tilausrivi.alv < 500,
+                     (1 + tilausrivi.alv / 100),
+                     1)
+                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
+                   * {$query_ale_lisa})), 2) AS summa,
+                 round(sum(if(lasku.alatila != 'X', 0, tilausrivi.hinta
+                   / if('$yhtiorow[alv_kasittely]'  = '' AND tilausrivi.alv < 500,
+                     (1 + tilausrivi.alv / 100),
+                     1)
+                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
+                   * {$query_ale_lisa})), 2) AS jt_arvo,
+                 round(sum(if(lasku.alatila != 'X', 0, tilausrivi.hinta
+                   * if('$yhtiorow[alv_kasittely]' != '' AND tilausrivi.alv < 500,
+                     (1 + tilausrivi.alv / 100),
+                     1)
+                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
+                   * {$query_ale_lisa})), 2) AS jt_summa,
+                 count(distinct lasku.tunnus) kpl
+                 FROM lasku use index (tila_index)
+                 JOIN tilausrivi use index (yhtio_otunnus) ON (tilausrivi.yhtio = lasku.yhtio
+                   AND tilausrivi.otunnus  = lasku.tunnus
+                   AND tilausrivi.tyyppi  != 'D')
+                 WHERE lasku.yhtio         = '{$kukarow['yhtio']}'
+                 AND lasku.tila            IN ('L', 'N')
+                 AND lasku.alatila        != 'X'
+                 AND lasku.clearing       != 'EXTENNAKKO'
+                 {$sumhaku}";
+    $sumresult = pupe_query($sumquery);
+    $sumrow = mysql_fetch_assoc($sumresult);
+  }
+
+  $miinus = 7;
+}
+elseif ($toim == "SUPER_EILUONTITAPATYOM") {
+
+  $query = "  SELECT DISTINCT lasku.tunnus tilaus, $asiakasstring asiakas, lasku.luontiaika, if(kuka1.kuka is null, lasku.laatija, if (kuka1.kuka!=kuka2.kuka, concat_ws('<br>', kuka1.nimi, kuka2.nimi), kuka1.nimi)) laatija, lasku.viesti tilausviite, ";
+
+  if ($kukarow['hinnat'] == 0) {
+    $query .= " round(sum(tilausrivi.hinta
+                  / if('$yhtiorow[alv_kasittely]'  = '' AND tilausrivi.alv < 500,
+                    (1 + tilausrivi.alv / 100),
+                    1)
+                  * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
+                  * {$query_ale_lisa}), 2) AS arvo,
+                round(sum(tilausrivi.hinta
+                  * if('$yhtiorow[alv_kasittely]' != '' AND tilausrivi.alv < 500,
+                    (1 + tilausrivi.alv / 100),
+                    1)
+                  * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
+                  * {$query_ale_lisa}), 2) AS summa, ";
+  }
+
+  $query .= "  $toimaikalisa alatila, tila, lasku.tunnus, lasku.mapvm, lasku.tilaustyyppi, lasku.label, lasku.varasto
+        FROM lasku use index (tila_index)
+        LEFT JOIN kuka as kuka1 ON (kuka1.yhtio = lasku.yhtio and kuka1.kuka = lasku.laatija)
+        LEFT JOIN kuka as kuka2 ON (kuka2.yhtio = lasku.yhtio and kuka2.tunnus = lasku.myyja)
+        LEFT JOIN tilausrivi use index (yhtio_otunnus) on (tilausrivi.yhtio = lasku.yhtio and tilausrivi.otunnus = lasku.tunnus and tilausrivi.tyyppi != 'D')
+        LEFT JOIN laskun_lisatiedot ON (laskun_lisatiedot.yhtio = lasku.yhtio AND laskun_lisatiedot.otunnus = lasku.tunnus)
+        {$tilausrivin_lisatiedot_join}
+        WHERE lasku.yhtio = '$kukarow[yhtio]' and lasku.tila in ('L', 'N') and lasku.alatila != 'X' and lasku.clearing != 'EXTENNAKKO'
+        AND laskun_lisatiedot.luontitapa != 'tyomaarays'
         $haku
         $tepalisa
         GROUP BY lasku.tunnus
@@ -2836,7 +2913,7 @@ if (mysql_num_rows($result) != 0) {
       $excelrivi++;
 
       // tehd‰‰n aktivoi nappi.. kaikki mit‰ n‰ytet‰‰n saa aktvoida, joten tarkkana queryn kanssa.
-      if ($whiletoim == "" or $whiletoim == "SUPER" or $whiletoim == "SUPER_EITYOM" or $whiletoim == "KESKEN" or $toim == "KESKEN_TAI_TOIMITETTAVISSA" or $toim == "TOSI_KESKEN" or $whiletoim == "EXTRANET" or $whiletoim == "JTTOIMITA" or $whiletoim == "LASKUTUSKIELTO"or (($whiletoim == "VALMISTUSMYYNTI" or $whiletoim == "VALMISTUSMYYNTISUPER") and $row["tila"] != "V")) {
+      if ($whiletoim == "" or $whiletoim == "SUPER" or $whiletoim == "SUPER_EITYOM" or $whiletoim == "SUPER_EILUONTITAPATYOM" or $whiletoim == "KESKEN" or $toim == "KESKEN_TAI_TOIMITETTAVISSA" or $toim == "TOSI_KESKEN" or $whiletoim == "EXTRANET" or $whiletoim == "JTTOIMITA" or $whiletoim == "LASKUTUSKIELTO"or (($whiletoim == "VALMISTUSMYYNTI" or $whiletoim == "VALMISTUSMYYNTISUPER") and $row["tila"] != "V")) {
 
         if (isset($pika_oikeu) and $pika_oikeu and !$rivi_oikeu) {
           $aputoim1 = "PIKATILAUS";
@@ -3068,7 +3145,7 @@ if (mysql_num_rows($result) != 0) {
 
       $_class = $whiletoim == "EXTRANET" ? "check_kesken" : "";
 
-      if ($aputoim2 != "" and ($whiletoim == "" or $whiletoim == "SUPER" or $whiletoim == "SUPER_EITYOM" or $whiletoim == "KESKEN" or $toim == "KESKEN_TAI_TOIMITETTAVISSA" or $toim == "TOSI_KESKEN" or $whiletoim == "EXTRANET" or $whiletoim == "JTTOIMITA" or $whiletoim == "LASKUTUSKIELTO" or (($whiletoim == "VALMISTUSMYYNTI" or $whiletoim == "VALMISTUSMYYNTISUPER") and $row["tila"] != "V"))) {
+      if ($aputoim2 != "" and ($whiletoim == "" or $whiletoim == "SUPER" or $whiletoim == "SUPER_EITYOM" or $whiletoim == "SUPER_EILUONTITAPATYOM" or $whiletoim == "KESKEN" or $toim == "KESKEN_TAI_TOIMITETTAVISSA" or $toim == "TOSI_KESKEN" or $whiletoim == "EXTRANET" or $whiletoim == "JTTOIMITA" or $whiletoim == "LASKUTUSKIELTO" or (($whiletoim == "VALMISTUSMYYNTI" or $whiletoim == "VALMISTUSMYYNTISUPER") and $row["tila"] != "V"))) {
         echo "<input type='submit' class='{$_class}' name='$aputoim2' value='$lisa2' $button_disabled>";
       }
 

--- a/muokkaatilaus.php
+++ b/muokkaatilaus.php
@@ -1187,83 +1187,19 @@ if ($toim == 'HYPER') {
 
   $miinus = 6;
 }
-elseif ($toim == "SUPER_EITYOM") {
+elseif ($toim == 'SUPER' or $toim == 'SUPERTEHDASPALAUTUKSET' or $toim == "SUPER_EITYOM" or $toim == "SUPER_EILUONTITAPATYOM") {
 
-  $query = "  SELECT DISTINCT lasku.tunnus tilaus, $asiakasstring asiakas, lasku.luontiaika, if(kuka1.kuka is null, lasku.laatija, if (kuka1.kuka!=kuka2.kuka, concat_ws('<br>', kuka1.nimi, kuka2.nimi), kuka1.nimi)) laatija, lasku.viesti tilausviite, ";
+  $_ei_ollenkaan_tyomaarayksia_arraylisa = "";
 
-  if ($kukarow['hinnat'] == 0) {
-    $query .= " round(sum(tilausrivi.hinta
-                  / if('$yhtiorow[alv_kasittely]'  = '' AND tilausrivi.alv < 500,
-                    (1 + tilausrivi.alv / 100),
-                    1)
-                  * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                  * {$query_ale_lisa}), 2) AS arvo,
-                round(sum(tilausrivi.hinta
-                  * if('$yhtiorow[alv_kasittely]' != '' AND tilausrivi.alv < 500,
-                    (1 + tilausrivi.alv / 100),
-                    1)
-                  * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                  * {$query_ale_lisa}), 2) AS summa, ";
+  if ($toim == "SUPER_EITYOM") {
+    $_ei_ollenkaan_tyomaarayksia_arraylisa = "AND lasku.tilaustyyppi != 'A'";
   }
 
-  $query .= "  $toimaikalisa alatila, tila, lasku.tunnus, lasku.mapvm, lasku.tilaustyyppi, lasku.label, lasku.varasto
-        FROM lasku use index (tila_index)
-        LEFT JOIN kuka as kuka1 ON (kuka1.yhtio = lasku.yhtio and kuka1.kuka = lasku.laatija)
-        LEFT JOIN kuka as kuka2 ON (kuka2.yhtio = lasku.yhtio and kuka2.tunnus = lasku.myyja)
-        LEFT JOIN tilausrivi use index (yhtio_otunnus) on (tilausrivi.yhtio = lasku.yhtio and tilausrivi.otunnus = lasku.tunnus and tilausrivi.tyyppi != 'D')
-        {$tilausrivin_lisatiedot_join}
-        WHERE lasku.yhtio = '$kukarow[yhtio]' and lasku.tila in ('L', 'N') and lasku.alatila != 'X' and lasku.clearing != 'EXTENNAKKO'
-        AND lasku.tilaustyyppi != 'A'
-        $haku
-        $tepalisa
-        GROUP BY lasku.tunnus
-        $mt_order_by
-        $rajaus";
+  $_ei_tyomaarays_tyomaarayksia_arraylisa = "";
 
-  // haetaan tilausten arvo
-  if ($kukarow['hinnat'] == 0) {
-    $sumquery = "SELECT
-                 round(sum(if(lasku.alatila = 'X', 0, tilausrivi.hinta
-                   / if('$yhtiorow[alv_kasittely]'  = '' AND tilausrivi.alv < 500,
-                     (1 + tilausrivi.alv / 100),
-                     1)
-                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                   * {$query_ale_lisa})), 2) AS arvo,
-                 round(sum(if(lasku.alatila = 'X', 0, tilausrivi.hinta
-                   * if('$yhtiorow[alv_kasittely]' != '' AND tilausrivi.alv < 500,
-                     (1 + tilausrivi.alv / 100),
-                     1)
-                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                   * {$query_ale_lisa})), 2) AS summa,
-                 round(sum(if(lasku.alatila != 'X', 0, tilausrivi.hinta
-                   / if('$yhtiorow[alv_kasittely]'  = '' AND tilausrivi.alv < 500,
-                     (1 + tilausrivi.alv / 100),
-                     1)
-                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                   * {$query_ale_lisa})), 2) AS jt_arvo,
-                 round(sum(if(lasku.alatila != 'X', 0, tilausrivi.hinta
-                   * if('$yhtiorow[alv_kasittely]' != '' AND tilausrivi.alv < 500,
-                     (1 + tilausrivi.alv / 100),
-                     1)
-                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                   * {$query_ale_lisa})), 2) AS jt_summa,
-                 count(distinct lasku.tunnus) kpl
-                 FROM lasku use index (tila_index)
-                 JOIN tilausrivi use index (yhtio_otunnus) ON (tilausrivi.yhtio = lasku.yhtio
-                   AND tilausrivi.otunnus  = lasku.tunnus
-                   AND tilausrivi.tyyppi  != 'D')
-                 WHERE lasku.yhtio         = '{$kukarow['yhtio']}'
-                 AND lasku.tila            IN ('L', 'N')
-                 AND lasku.alatila        != 'X'
-                 AND lasku.clearing       != 'EXTENNAKKO'
-                 {$sumhaku}";
-    $sumresult = pupe_query($sumquery);
-    $sumrow = mysql_fetch_assoc($sumresult);
+  if ($toim == "SUPER_EILUONTITAPATYOM") {
+    $_ei_tyomaarays_tyomaarayksia_arraylisa = "AND laskun_lisatiedot.luontitapa != 'tyomaarays'";
   }
-
-  $miinus = 7;
-}
-elseif ($toim == "SUPER_EILUONTITAPATYOM") {
 
   $query = "  SELECT DISTINCT lasku.tunnus tilaus, $asiakasstring asiakas, lasku.luontiaika, if(kuka1.kuka is null, lasku.laatija, if (kuka1.kuka!=kuka2.kuka, concat_ws('<br>', kuka1.nimi, kuka2.nimi), kuka1.nimi)) laatija, lasku.viesti tilausviite, ";
 
@@ -1290,7 +1226,8 @@ elseif ($toim == "SUPER_EILUONTITAPATYOM") {
         LEFT JOIN laskun_lisatiedot ON (laskun_lisatiedot.yhtio = lasku.yhtio AND laskun_lisatiedot.otunnus = lasku.tunnus)
         {$tilausrivin_lisatiedot_join}
         WHERE lasku.yhtio = '$kukarow[yhtio]' and lasku.tila in ('L', 'N') and lasku.alatila != 'X' and lasku.clearing != 'EXTENNAKKO'
-        AND laskun_lisatiedot.luontitapa != 'tyomaarays'
+        {$_ei_ollenkaan_tyomaarayksia_arraylisa}
+        {$_ei_tyomaarays_tyomaarayksia_arraylisa}
         $haku
         $tepalisa
         GROUP BY lasku.tunnus
@@ -1329,85 +1266,14 @@ elseif ($toim == "SUPER_EILUONTITAPATYOM") {
                  JOIN tilausrivi use index (yhtio_otunnus) ON (tilausrivi.yhtio = lasku.yhtio
                    AND tilausrivi.otunnus  = lasku.tunnus
                    AND tilausrivi.tyyppi  != 'D')
+                 LEFT JOIN laskun_lisatiedot ON (laskun_lisatiedot.yhtio = lasku.yhtio
+                   AND laskun_lisatiedot.otunnus = lasku.tunnus)
                  WHERE lasku.yhtio         = '{$kukarow['yhtio']}'
                  AND lasku.tila            IN ('L', 'N')
                  AND lasku.alatila        != 'X'
                  AND lasku.clearing       != 'EXTENNAKKO'
-                 {$sumhaku}";
-    $sumresult = pupe_query($sumquery);
-    $sumrow = mysql_fetch_assoc($sumresult);
-  }
-
-  $miinus = 7;
-}
-elseif ($toim == 'SUPER' or $toim == 'SUPERTEHDASPALAUTUKSET') {
-
-  $query = "  SELECT DISTINCT lasku.tunnus tilaus, $asiakasstring asiakas, lasku.luontiaika, if(kuka1.kuka is null, lasku.laatija, if (kuka1.kuka!=kuka2.kuka, concat_ws('<br>', kuka1.nimi, kuka2.nimi), kuka1.nimi)) laatija, lasku.viesti tilausviite, ";
-
-  if ($kukarow['hinnat'] == 0) {
-    $query .= " round(sum(tilausrivi.hinta
-                  / if('$yhtiorow[alv_kasittely]'  = '' AND tilausrivi.alv < 500,
-                    (1 + tilausrivi.alv / 100),
-                    1)
-                  * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                  * {$query_ale_lisa}), 2) AS arvo,
-                round(sum(tilausrivi.hinta
-                  * if('$yhtiorow[alv_kasittely]' != '' AND tilausrivi.alv < 500,
-                    (1 + tilausrivi.alv / 100),
-                    1)
-                  * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                  * {$query_ale_lisa}), 2) AS summa, ";
-  }
-
-  $query .= "  $toimaikalisa alatila, tila, lasku.tunnus, lasku.mapvm, lasku.tilaustyyppi, lasku.label, lasku.varasto
-        FROM lasku use index (tila_index)
-        LEFT JOIN kuka as kuka1 ON (kuka1.yhtio = lasku.yhtio and kuka1.kuka = lasku.laatija)
-        LEFT JOIN kuka as kuka2 ON (kuka2.yhtio = lasku.yhtio and kuka2.tunnus = lasku.myyja)
-        LEFT JOIN tilausrivi use index (yhtio_otunnus) on (tilausrivi.yhtio = lasku.yhtio and tilausrivi.otunnus = lasku.tunnus and tilausrivi.tyyppi != 'D')
-        {$tilausrivin_lisatiedot_join}
-        WHERE lasku.yhtio = '$kukarow[yhtio]' and lasku.tila in ('L', 'N') and lasku.alatila != 'X' and lasku.clearing != 'EXTENNAKKO'
-        $haku
-        $tepalisa
-        GROUP BY lasku.tunnus
-        $mt_order_by
-        $rajaus";
-
-  // haetaan tilausten arvo
-  if ($kukarow['hinnat'] == 0) {
-    $sumquery = "SELECT
-                 round(sum(if(lasku.alatila = 'X', 0, tilausrivi.hinta
-                   / if('$yhtiorow[alv_kasittely]'  = '' AND tilausrivi.alv < 500,
-                     (1 + tilausrivi.alv / 100),
-                     1)
-                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                   * {$query_ale_lisa})), 2) AS arvo,
-                 round(sum(if(lasku.alatila = 'X', 0, tilausrivi.hinta
-                   * if('$yhtiorow[alv_kasittely]' != '' AND tilausrivi.alv < 500,
-                     (1 + tilausrivi.alv / 100),
-                     1)
-                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                   * {$query_ale_lisa})), 2) AS summa,
-                 round(sum(if(lasku.alatila != 'X', 0, tilausrivi.hinta
-                   / if('$yhtiorow[alv_kasittely]'  = '' AND tilausrivi.alv < 500,
-                     (1 + tilausrivi.alv / 100),
-                     1)
-                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                   * {$query_ale_lisa})), 2) AS jt_arvo,
-                 round(sum(if(lasku.alatila != 'X', 0, tilausrivi.hinta
-                   * if('$yhtiorow[alv_kasittely]' != '' AND tilausrivi.alv < 500,
-                     (1 + tilausrivi.alv / 100),
-                     1)
-                   * (tilausrivi.varattu + tilausrivi.jt + tilausrivi.kpl)
-                   * {$query_ale_lisa})), 2) AS jt_summa,
-                 count(distinct lasku.tunnus) kpl
-                 FROM lasku use index (tila_index)
-                 JOIN tilausrivi use index (yhtio_otunnus) ON (tilausrivi.yhtio = lasku.yhtio
-                   AND tilausrivi.otunnus  = lasku.tunnus
-                   AND tilausrivi.tyyppi  != 'D')
-                 WHERE lasku.yhtio         = '{$kukarow['yhtio']}'
-                 AND lasku.tila            IN ('L', 'N')
-                 AND lasku.alatila        != 'X'
-                 AND lasku.clearing       != 'EXTENNAKKO'
+                 #{$_ei_ollenkaan_tyomaarayksia_arraylisa}
+                 #{$_ei_tyomaarays_tyomaarayksia_arraylisa}
                  {$sumhaku}";
     $sumresult = pupe_query($sumquery);
     $sumrow = mysql_fetch_assoc($sumresult);

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -4011,6 +4011,13 @@ if (isset($jatka)) {
     //Kun tehdään uusi tilaus niin nollataan aina tilat ja alatilat
     $alatila = "";
     $ylatila = "";
+
+    if ($toim == "PIKATILAUS" or $toim == "RIVISYOTTO") {
+      $luontitapa = "myynti";
+    }
+    elseif ($toim == "TYOMAARAYS") {
+      $luontitapa = "tyomaarays";
+    }
   }
   else {
     // Jos ollaan piilottamassa tarjouksen toimitusaikaa niin pitää nollata nämä tiedot myös tilausriveiltä
@@ -4841,8 +4848,13 @@ if (isset($jatka)) {
                          sopimus_numero           = '$sopimus_numero', ";
       }
 
+      if (isset($luontitapa)) {
+        $luontitapa_arraylisa = "luontitapa = '{$luontitapa}',";
+      }
+
       $query3 .= "laskun_lisatiedot SET
             yhtio            = '$kukarow[yhtio]',
+            {$luontitapa_arraylisa}
             sopimus_kk          = '$sopimus_kk',
             sopimus_pp          = '$sopimus_pp',
             yllapito_kuukausihinnoittelu = '{$kuukausihinnoittelu}',

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -4012,10 +4012,7 @@ if (isset($jatka)) {
     $alatila = "";
     $ylatila = "";
 
-    if ($toim == "PIKATILAUS" or $toim == "RIVISYOTTO") {
-      $luontitapa = "myynti";
-    }
-    elseif ($toim == "TYOMAARAYS") {
+    if ($toim == "TYOMAARAYS") {
       $luontitapa = "tyomaarays";
     }
   }
@@ -4847,6 +4844,8 @@ if (isset($jatka)) {
                          sopimus_lisatietoja2     = '$sopimus_lisatietoja2',
                          sopimus_numero           = '$sopimus_numero', ";
       }
+
+      $luontitapa_arraylisa = "";
 
       if (isset($luontitapa)) {
         $luontitapa_arraylisa = "luontitapa = '{$luontitapa}',";


### PR DESCRIPTION
Työmääräyksiä pystyy luomaan sekä työmääräys- että myynti-valikoiden kautta. Aiemmin eri valikoista tehtyjä työmääräyksiä ei ole pystynyt erottelemaan toisistaan vaan työmääräykset ovat olleet samassa tilassa ja käytännössä samankaltaisia kaikkien tietojen suhteen. Nyt on lisätty kommenttikenttä luontitapa, johon tallennetaan tieto siitä missä työmääräys on luotu sen mukaan onko kyseessä työmääräys-valikosta tehty työmääräys vai myynti-valikosta tehty työmääräys.

Lisätty kenttä: laskun_lisatiedot.luontitapa