### PR TITLE
Myyntitilaus: vaihdetaan asiakasta

### DIFF
--- a/inc/asiakashaku.inc
+++ b/inc/asiakashaku.inc
@@ -921,6 +921,10 @@ if ($monta != 1) {
     $asylloik1 = tarkista_oikeus("yllapito.php", "asiakas!!!VAHITTAISMYYNTI!!!true&laji=H", "X", TRUE);
     $asylloik2 = tarkista_oikeus("yllapito.php", "asiakas%", "X", TRUE);
 
+    $uusiasiakas = "uusiasiakas";
+
+    $ahlopetus .= "//uusiasiakas=$uusiasiakas";
+
     if ($monta != 1 and ($asylloik1 or $asylloik2)) {
 
       //Annetaan mahdollisuus perustaa uusi asiakas

--- a/tilauskasittely/otsik.inc
+++ b/tilauskasittely/otsik.inc
@@ -855,7 +855,7 @@ if ($tila == "" and !isset($jatka)) {
 
       $srow_from = "LASKU";
     }
-    elseif ($asiakasid != "" and $tiedot_laskulta == "") {
+    elseif (($asiakasid != "" and $tiedot_laskulta == "") or ($tiedot_laskulta == "YES" and isset($uusiasiakas) and $uusiasiakas == "uusiasiakas")) {
       // asiakashaussa pit‰‰ olla vakio columni kohdistettu, jonka arvo on O ett‰ saadaan OLETUS toimitustapa haettua asiakashaunkin yhteydess‰
       if ($toim == "TYOMAARAYS" or $toim == "TYOMAARAYS_ASENTAJA") {
         $puhlisa = " if (asiakas.puhelin!='', asiakas.puhelin, asiakas.gsm) kotipuh, asiakas.tyopuhelin tyopuh,";

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -780,7 +780,7 @@ if (isset($liitaasiakasnappi) and $kukarow["extranet"] == "") {
 }
 
 // Jos ylläpidossa on luotu uusi asiakas
-if (isset($from) and $from == "ASIAKASYLLAPITO" and $yllapidossa == "asiakas" and $yllapidontunnus != '' and $tilausnumero == '') {
+if (isset($from) and $from == "ASIAKASYLLAPITO" and $yllapidossa == "asiakas" and $yllapidontunnus != '' and ($tilausnumero == '' or (isset($uusiasiakas) and $uusiasiakas == "uusiasiakas"))) {
   $tee = "OTSIK";
   $asiakasid = $yllapidontunnus;
 }


### PR DESCRIPTION
Vaihdettaessa myyntitilaukselle asiakasta ja mikäli haettua asiakasta ei löytynyt tarjoaa Pupe vaihtoehdon että asiakkaan pystyy lennosta perustamaan. Mikäli asiakkaan perusti ja klikkasi "perusta asiakas" ei Pupe osannut käyttäjää tälle olemassa olevalle myyntitilaukselle palauttaa vaan näkyviin tuli uusi myyntitilaus-ruutu. Tätä on korjattu nyt niin, että Pupe käyttäjän takaisin myyntitilaukselle osaisi palauttaa.