### PR TITLE
Saapumiset: tuoteperheiden tulouttaminen

### DIFF
--- a/tilauskasittely/varastoon.inc
+++ b/tilauskasittely/varastoon.inc
@@ -186,9 +186,9 @@ elseif ($toiminto == "kalkyyli" and $tee == "varastoon") {
       if (mysql_num_rows($loytyiko_lapsi_res) == 0) {
 
         if ($chk_row["kerroin"] != 1) {
-          $chk_row["tilkpl"] = $chk_row["tilkpl"] * $chk_row["kerroin"];
-          $chk_row["varattu"] = $chk_row["varattu"] * $chk_row["kerroin"];
-          $chk_row["kpl"] = $chk_row["kpl"] * $chk_row["kerroin"];
+          $chk_row["tilkpl"] = round($chk_row["tilkpl"] * $chk_row["kerroin"], 2);
+          $chk_row["varattu"] = round($chk_row["varattu"] * $chk_row["kerroin"], 2);
+          $chk_row["kpl"] = round($chk_row["kpl"] * $chk_row["kerroin"], 2);
         }
 
         list($chk_hinta, , $chk_ale, ) = alehinta_osto($laskurow, $chk_row, $chk_row["varattu"]);

--- a/tilauskasittely/varastoon.inc
+++ b/tilauskasittely/varastoon.inc
@@ -148,6 +148,7 @@ elseif ($toiminto == "kalkyyli" and $tee == "varastoon") {
   // Satula-Runko case
   $query = "SELECT tuoteperhe.isatuoteno, tilausrivi.uusiotunnus,
             tuoteperhe.tuoteno,
+            tuoteperhe.kerroin,
             tuote.tuoteno, tuote.try,tuote.osasto,
             tuote.nimitys,tuote.yksikko,tuote.myyntihinta,
             tilausrivi.yhtio, tilausrivi.tyyppi,tilausrivi.toimaika, tilausrivi.kerayspvm,
@@ -183,6 +184,12 @@ elseif ($toiminto == "kalkyyli" and $tee == "varastoon") {
       $loytyiko_lapsi_res = pupe_query($query);
 
       if (mysql_num_rows($loytyiko_lapsi_res) == 0) {
+
+        if ($chk_row["kerroin"] != 1) {
+          $chk_row["tilkpl"] = $chk_row["tilkpl"] * $chk_row["kerroin"];
+          $chk_row["varattu"] = $chk_row["varattu"] * $chk_row["kerroin"];
+          $chk_row["kpl"] = $chk_row["kpl"] * $chk_row["kerroin"];
+        }
 
         list($chk_hinta, , $chk_ale, ) = alehinta_osto($laskurow, $chk_row, $chk_row["varattu"]);
 


### PR DESCRIPTION
Mikäli tuoteperheellä on määriteltynä ohita keräys-täppä niin tuoteperheen isää ostettaessa tuloutetaan isätuotteen saavutusvaiheessa myös lapsituotteita. Tähän ominaisuuteen tehtiin lisäys, että tuoteperheen lapsituotteiden määräkertoimet osataan ottaa tuloutusvaiheessa huomioon ja tuoteperheiden saldoja tuloutetaan perheen määräkertoimien mukaan.