### PR TITLE
Myynnistä ostotilaus: muokkausominaisuuksia molempiin suuntiin

### DIFF
--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -4766,7 +4766,7 @@ if ($tee == '') {
                 echo "<font class='error'>".t("Rivi poistettiin myös ostotilaukselta")."</font><br/><br/>";
               }
               else {
-                echo "<font class='error'>".t("Ostotilaus ei ollut enää kesken tilassa, ei voitu poistaa riviä ostolta ({$ostotilaus_tarkistus["tunnus"]})")."!</font><br/><br/>";
+                echo "<font class='error'>".t("Ostotilaus ei ollut enää kesken tilassa, ei voitu poistaa riviä ostolta")."!</font><br/><br/>";
               }
             }
           }

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -4745,26 +4745,29 @@ if ($tee == '') {
                     WHERE yhtio = '{$kukarow['yhtio']}'
                     AND tilausrivitunnus = '{$rivitunnus}'";
           $result = pupe_query($query);
-          $_ostorivi = mysql_fetch_assoc($result);
+          $_myyntirivi = mysql_fetch_assoc($result);
 
-          if (mysql_num_rows($result) == 1 and $_ostorivi["tilausrivilinkki"] != 0) {
-            // Tarkistetaan, ettei ostorivi ole jo tuloutettu,
-            // sillä jos rivi on jo tuloutettu sitä ei voida poistaa
-            $query = "SELECT kpl
+          if (mysql_num_rows($result) == 1 and $_myyntirivi["tilausrivilinkki"] != 0) {
+            // Tarkistetaan, että ostotilaus on vielä kesken,
+            // koska jos ei ole kesken on jo lähetetty eteenpäin
+            $query = "SELECT lasku.tila,
+                      lasku.alatila,
+                      lasku.tunnus
                       FROM tilausrivi
-                      WHERE yhtio = '{$kukarow['yhtio']}'
-                      AND tunnus = '{$_ostorivi["tilausrivilinkki"]}'";
-            $ostorivi_tarkistus = mysql_fetch_assoc(pupe_query($query));
+                        JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio AND lasku.tunnus = tilausrivi.otunnus)
+                      WHERE tilausrivi.yhtio = '{$kukarow['yhtio']}'
+                      AND tilausrivi.tunnus = '{$_myyntirivi["tilausrivilinkki"]}'";
+            $ostotilaus_tarkistus = mysql_fetch_assoc(pupe_query($query));
 
-            if ($ostorivi_tarkistus["kpl"] == 0) {
+            if ($ostotilaus_tarkistus["tila"] == "O" and $ostotilaus_tarkistus["alatila"] == "") {
               $query = "DELETE FROM tilausrivi
-                        WHERE tunnus = '{$_ostorivi["tilausrivilinkki"]}'";
+                        WHERE tunnus = '{$_myyntirivi["tilausrivilinkki"]}'";
               pupe_query($query);
 
               echo "<font class='error'>".t("Rivi poistettiin myös ostotilaukselta")."</font><br/><br/>";
             }
             else {
-              echo "<font class='error'>".t("Riviin liitetty ostorivi oli jo tuloutettu, ei voitu poistaa")."!</font><br/><br/>";
+              echo "<font class='error'>".t("Ostotilaus ei ollut enää kesken tilassa, ei voitu poistaa riviä ostolta ({$ostotilaus_tarkistus["tunnus"]})")."!</font><br/><br/>";
             }
           }
           // Poistetaan muokattava tilausrivi

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -4751,20 +4751,18 @@ if ($tee == '') {
             if (mysql_num_rows($result) == 1 and $_myyntirivi["tilausrivilinkki"] != 0) {
               // Tarkistetaan, että ostotilaus on vielä kesken,
               // koska jos ei ole kesken on jo lähetetty eteenpäin
-              $query = "SELECT lasku.tila,
-                        lasku.alatila,
-                        lasku.tunnus
+              $query = "DELETE tilausrivi.*
                         FROM tilausrivi
                           JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio AND lasku.tunnus = tilausrivi.otunnus)
                         WHERE tilausrivi.yhtio = '{$kukarow['yhtio']}'
-                        AND tilausrivi.tunnus = '{$_myyntirivi["tilausrivilinkki"]}'";
+                        AND tilausrivi.tunnus = '{$_myyntirivi["tilausrivilinkki"]}'
+                        AND lasku.tila = 'O'
+                        AND lasku.alatila = ''
+                        AND tilausrivi.tyyppi = 'O'
+                        AND tilausrivi.kpl = 0";
               $ostotilaus_tarkistus = mysql_fetch_assoc(pupe_query($query));
 
-              if ($ostotilaus_tarkistus["tila"] == "O" and $ostotilaus_tarkistus["alatila"] == "") {
-                $query = "DELETE FROM tilausrivi
-                          WHERE tunnus = '{$_myyntirivi["tilausrivilinkki"]}'";
-                pupe_query($query);
-
+              if (mysql_affected_rows() > 0) {
                 echo "<font class='error'>".t("Rivi poistettiin myös ostotilaukselta")."</font><br/><br/>";
               }
               else {

--- a/tilauskasittely/tilaus_myynti.php
+++ b/tilauskasittely/tilaus_myynti.php
@@ -4739,37 +4739,40 @@ if ($tee == '') {
           $_ei_jt_meilia = 'X';
         }
         elseif ($tapa != "POISJTSTA" and $tapa != "PUUTE" and $tapa != "JT") {
-          // Mikäli tilausriviin liittyy ostorivi, niin poistetaan myös se
-          $query = "SELECT tilausrivilinkki
-                    FROM tilausrivin_lisatiedot
-                    WHERE yhtio = '{$kukarow['yhtio']}'
-                    AND tilausrivitunnus = '{$rivitunnus}'";
-          $result = pupe_query($query);
-          $_myyntirivi = mysql_fetch_assoc($result);
+          if ($tapa == "POISTA") {
+            // Mikäli tilausriviin liittyy ostorivi, niin poistetaan myös se
+            $query = "SELECT tilausrivilinkki
+                      FROM tilausrivin_lisatiedot
+                      WHERE yhtio = '{$kukarow['yhtio']}'
+                      AND tilausrivitunnus = '{$rivitunnus}'";
+            $result = pupe_query($query);
+            $_myyntirivi = mysql_fetch_assoc($result);
 
-          if (mysql_num_rows($result) == 1 and $_myyntirivi["tilausrivilinkki"] != 0) {
-            // Tarkistetaan, että ostotilaus on vielä kesken,
-            // koska jos ei ole kesken on jo lähetetty eteenpäin
-            $query = "SELECT lasku.tila,
-                      lasku.alatila,
-                      lasku.tunnus
-                      FROM tilausrivi
-                        JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio AND lasku.tunnus = tilausrivi.otunnus)
-                      WHERE tilausrivi.yhtio = '{$kukarow['yhtio']}'
-                      AND tilausrivi.tunnus = '{$_myyntirivi["tilausrivilinkki"]}'";
-            $ostotilaus_tarkistus = mysql_fetch_assoc(pupe_query($query));
+            if (mysql_num_rows($result) == 1 and $_myyntirivi["tilausrivilinkki"] != 0) {
+              // Tarkistetaan, että ostotilaus on vielä kesken,
+              // koska jos ei ole kesken on jo lähetetty eteenpäin
+              $query = "SELECT lasku.tila,
+                        lasku.alatila,
+                        lasku.tunnus
+                        FROM tilausrivi
+                          JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio AND lasku.tunnus = tilausrivi.otunnus)
+                        WHERE tilausrivi.yhtio = '{$kukarow['yhtio']}'
+                        AND tilausrivi.tunnus = '{$_myyntirivi["tilausrivilinkki"]}'";
+              $ostotilaus_tarkistus = mysql_fetch_assoc(pupe_query($query));
 
-            if ($ostotilaus_tarkistus["tila"] == "O" and $ostotilaus_tarkistus["alatila"] == "") {
-              $query = "DELETE FROM tilausrivi
-                        WHERE tunnus = '{$_myyntirivi["tilausrivilinkki"]}'";
-              pupe_query($query);
+              if ($ostotilaus_tarkistus["tila"] == "O" and $ostotilaus_tarkistus["alatila"] == "") {
+                $query = "DELETE FROM tilausrivi
+                          WHERE tunnus = '{$_myyntirivi["tilausrivilinkki"]}'";
+                pupe_query($query);
 
-              echo "<font class='error'>".t("Rivi poistettiin myös ostotilaukselta")."</font><br/><br/>";
-            }
-            else {
-              echo "<font class='error'>".t("Ostotilaus ei ollut enää kesken tilassa, ei voitu poistaa riviä ostolta ({$ostotilaus_tarkistus["tunnus"]})")."!</font><br/><br/>";
+                echo "<font class='error'>".t("Rivi poistettiin myös ostotilaukselta")."</font><br/><br/>";
+              }
+              else {
+                echo "<font class='error'>".t("Ostotilaus ei ollut enää kesken tilassa, ei voitu poistaa riviä ostolta ({$ostotilaus_tarkistus["tunnus"]})")."!</font><br/><br/>";
+              }
             }
           }
+
           // Poistetaan muokattava tilausrivi
           $query = "DELETE FROM tilausrivi
                     WHERE tunnus = '$rivitunnus'";

--- a/tilauskasittely/tilaus_osto.php
+++ b/tilauskasittely/tilaus_osto.php
@@ -133,6 +133,8 @@ if (!isset($toim_nimitykset)) $toim_nimitykset = "";
 if (!isset($toim_tuoteno)) $toim_tuoteno = "";
 if (!isset($naytetaankolukitut)) $naytetaankolukitut = "";
 if (!isset($lopetus)) $lopetus = "";
+if (!isset($myyntitilaus_otsikot)) $myyntitilaus_otsikot = array();
+if (!isset($myyntitilaus_otsikot_string)) $myyntitilaus_otsikot_string = "";
 
 if ($tee == "lataa_tiedosto") {
   readfile("$pupe_root_polku/dataout/".basename($filenimi));
@@ -649,6 +651,72 @@ if ($tee != "" and $tee != "MUUOTAOSTIKKOA") {
     if ($lopetus != '') {
       lopetus($lopetus, "META");
     }
+  }
+
+  // Lis‰t‰‰n valittuun myyntiin ostoon lis‰tyt rivit
+  if ($tee == "lisaa_uudetostorivit_myyntiin") {
+
+    // Haetaan ostotilauksen kaikki rivit
+    // ja katsotaan sitten liittyv‰tkˆ ne jo johonkin myyntiin,
+    // jos eiv‰t niin lis‰t‰‰n vastaavat rivit valitulle myyntitilaukselle
+    $query = "SELECT *
+              FROM tilausrivi
+              WHERE yhtio = '{$kukarow["yhtio"]}'
+              AND otunnus = {$tilausnumero}";
+    $rivi_result = pupe_query($query);
+
+    while ($tilausrivi = mysql_fetch_assoc($rivi_result)) {
+      $query = "SELECT tilausrivilinkki
+                FROM tilausrivin_lisatiedot
+                WHERE yhtio = '{$kukarow["yhtio"]}'
+                AND tilausrivilinkki = {$tilausrivi["tunnus"]}";
+      $result = pupe_query($query);
+
+      if (!$myyntirivi = mysql_fetch_assoc($result)) {
+        // Haetaan tuotteen kaikki tiedot lisaarivi.inc varten
+        $query = "SELECT *
+                  FROM tuote
+                  WHERE yhtio = '{$kukarow["yhtio"]}'
+                  AND tuoteno =  '{$tilausrivi["tuoteno"]}'";
+        $trow = mysql_fetch_assoc(pupe_query($query));
+
+        // Settailaan tarpeellisia muuttujia lisaarivi.inc varten
+        $kpl = $tilausrivi["tilkpl"];
+        $tuoteno = $tilausrivi["tuoteno"];
+        $tilausrivilinkki = $tilausrivi["tunnus"];
+        $var = "J";
+
+        // Lis‰t‰‰n rivi myyntitilaukselle,
+        // joten otetaan oston tiedot talteen ja leikit‰‰n myyntitilausta
+        $ostolasku_kesken = $kukarow["kesken"];
+        $ostolaskurow = $laskurow;
+
+        $kukarow["kesken"] = $myyntitilaus_otsikot_string;
+
+        $query = "SELECT *
+                  FROM lasku
+                    JOIN laskun_lisatiedot ON (laskun_lisatiedot.yhtio = lasku.yhtio AND laskun_lisatiedot.otunnus = lasku.tunnus)
+                  WHERE lasku.yhtio = '{$kukarow["yhtio"]}'
+                  AND lasku.tunnus = {$myyntitilaus_otsikot_string}";
+        $laskurow = mysql_fetch_assoc(pupe_query($query));
+
+        // Lis‰t‰‰n vastaava rivi valitulle myyntitilaukselle
+        require 'lisaarivi.inc';
+
+        echo "<font class='error'> Tuote {$tilausrivi["tuoteno"]} lis‰tty myyntitilaukselle {$myyntitilaus_otsikot_string} </font> <br><br>";
+
+        // Palautetaan oston tiedot sinne minne ne kuuluu
+        // ja nollataan k‰ytetyt muuttujat
+        $kukarow["kesken"] = $ostolasku_kesken;
+        $laskurow = $ostolaskurow;
+
+        unset($kpl, $tuoteno, $tilausrivilinkki, $var);
+      }
+    }
+
+    $myyntitilaus_otsikot = array();
+    $myyntitilaus_otsikot_string = "";
+    $tee = "Y";
   }
 
   //Kuitataan OK-var riville
@@ -2012,13 +2080,19 @@ if ($tee != "" and $tee != "MUUOTAOSTIKKOA") {
           $tlrow = mysql_fetch_assoc($tlres);
 
           if (!empty($tlrow['tilausrivilinkki'])) {
-            $query = "SELECT tilausrivi.otunnus as otunnus, lasku.nimi as nimi
+            $query = "SELECT tilausrivi.otunnus as otunnus,
+                      lasku.nimi as nimi,
+                      lasku.tila
                       FROM tilausrivi
                       JOIN lasku ON (lasku.yhtio = tilausrivi.yhtio AND lasku.tunnus = tilausrivi.otunnus)
                       WHERE tilausrivi.yhtio = '{$kukarow['yhtio']}'
                       AND tilausrivi.tunnus  = '{$tlrow['tilausrivitunnus']}'";
             $linkattu_myyntitilaus_result = pupe_query($query);
             $linkattu_myyntitilaus_row = mysql_fetch_assoc($linkattu_myyntitilaus_result);
+
+            if (!$myyntitilaus_otsikot[$linkattu_myyntitilaus_row['otunnus']] and $linkattu_myyntitilaus_row["tila"] == "N") {
+              $myyntitilaus_otsikot[$linkattu_myyntitilaus_row['otunnus']] = $linkattu_myyntitilaus_row['otunnus'];
+            }
 
             if (trim($prow["kommentti"]) != "") echo "<br>";
             echo "<a href='{$palvelin2}tilauskasittely/tilaus_myynti.php?toim=RIVISYOTTO&tilausnumero={$linkattu_myyntitilaus_row['otunnus']}&lopetus={$myyntitilaus_lopetus}'>".t('N‰yt‰ myyntitilaus').": {$linkattu_myyntitilaus_row['nimi']}</a>";
@@ -2192,6 +2266,60 @@ if ($tee != "" and $tee != "MUUOTAOSTIKKOA") {
               </form>
               </td>";
         }
+      }
+
+      if (count($myyntitilaus_otsikot) > 0) {
+
+        // Tehd‰‰n ostoon liittyvist‰ myyntitilauksista alasvetovalikko,
+        // jos niit‰ on useampia, muuten echotetaan myynnin tilausnumero
+        if (count($myyntitilaus_otsikot) > 1) {
+
+          echo "<td>";
+          echo "Myyntitilausnumero: ";
+          echo "<select name='myyntitilausnumero_valinta' onchange='submit();'>";
+
+          foreach ($myyntitilaus_otsikot as $_myyntitilausnumeroavain => $_myyntitilausnumero) {
+
+            if ($myyntitilausnumero_valinta == $_myyntitilausnumeroavain or !isset($numero_valinta_sel)) {
+              $numero_valinta_sel = "selected";
+            }
+            else {
+              $numero_valinta_sel = "";
+            }
+
+            echo "<option value = '{$_myyntitilausnumeroavain}' {$numero_valinta_sel}>".t("{$_myyntitilausnumero}")."</option>";
+
+            if ($numero_valinta_sel == "selected") {
+              $myyntitilaus_otsikot_string = $_myyntitilausnumero;
+            }
+          }
+
+          echo "</select>";
+          echo "</td>";
+
+        }
+        else {
+          $myyntitilaus_otsikot_string = implode("", $myyntitilaus_otsikot);
+          echo "<td>";
+          echo "Myyntitilausnumero: {$myyntitilaus_otsikot_string}";
+          echo "</td>";
+        }
+
+
+        echo "  <td class='back'>
+          <form method='post' action='{$palvelin2}tilauskasittely/tilaus_osto.php'>
+          <input type='hidden' name='toim'          value = '$toim'>
+          <input type='hidden' name='lopetus'        value = '$lopetus'>
+          <input type='hidden' name='tilausnumero'      value = '$tilausnumero'>
+          <input type='hidden' name='toim_nimitykset'    value = '$toim_nimitykset'>
+          <input type='hidden' name='toim_tuoteno'     value = '$toim_tuoteno'>
+          <input type='hidden' name='naytetaankolukitut' value = '$naytetaankolukitut'>
+          <input type='hidden' name='toimittajaid'      value = '$laskurow[liitostunnus]'>
+          <input type='hidden' name='myyntitilaus_otsikot_string' value = '$myyntitilaus_otsikot_string'>
+          <input type='hidden' name='tee'          value = 'lisaa_uudetostorivit_myyntiin'>
+          <input type='submit' value='".t("Lis‰‰ uudet rivit myyntitilaukselle")."'>
+          </form>
+          </td>";
       }
     }
 

--- a/tilauskasittely/tilaus_osto.php
+++ b/tilauskasittely/tilaus_osto.php
@@ -662,7 +662,8 @@ if ($tee != "" and $tee != "MUUOTAOSTIKKOA") {
     $query = "SELECT *
               FROM tilausrivi
               WHERE yhtio = '{$kukarow["yhtio"]}'
-              AND otunnus = {$tilausnumero}";
+              AND otunnus = {$tilausnumero}
+              AND tyyppi = 'O'";
     $rivi_result = pupe_query($query);
 
     while ($tilausrivi = mysql_fetch_assoc($rivi_result)) {
@@ -703,7 +704,7 @@ if ($tee != "" and $tee != "MUUOTAOSTIKKOA") {
         // Lis‰t‰‰n vastaava rivi valitulle myyntitilaukselle
         require 'lisaarivi.inc';
 
-        echo "<font class='error'> Tuote {$tilausrivi["tuoteno"]} lis‰tty myyntitilaukselle {$myyntitilaus_otsikot_string} </font> <br><br>";
+        echo "<font class='error'>".t("Tuote {$tilausrivi["tuoteno"]} lis‰tty myyntitilaukselle {$myyntitilaus_otsikot_string}")." </font> <br><br>";
 
         // Palautetaan oston tiedot sinne minne ne kuuluu
         // ja nollataan k‰ytetyt muuttujat
@@ -2275,7 +2276,7 @@ if ($tee != "" and $tee != "MUUOTAOSTIKKOA") {
         if (count($myyntitilaus_otsikot) > 1) {
 
           echo "<td>";
-          echo "Myyntitilausnumero: ";
+          echo t("Myyntitilausnumero").": ";
           echo "<select name='myyntitilausnumero_valinta' onchange='submit();'>";
 
           foreach ($myyntitilaus_otsikot as $_myyntitilausnumeroavain => $_myyntitilausnumero) {
@@ -2301,7 +2302,7 @@ if ($tee != "" and $tee != "MUUOTAOSTIKKOA") {
         else {
           $myyntitilaus_otsikot_string = implode("", $myyntitilaus_otsikot);
           echo "<td>";
-          echo "Myyntitilausnumero: {$myyntitilaus_otsikot_string}";
+          echo t("Myyntitilausnumero").": {$myyntitilaus_otsikot_string}";
           echo "</td>";
         }
 


### PR DESCRIPTION
Myynnistä pystyy tekemään ostotilauksia suoraan ja näiden tilausten tilausrivien välille syntyy linkki. Tilaukset ovat siis linkittyneet keskenään näiden tilausrivien kautta. Aika monet tilausriveille tehtävät muokkaukset siirtyivät jo suuntaan ja toiseen, mutta osa muokkauksista oli vielä sellaisia, että ne eivät linkittyneelle tilaukselle muuttuneet. Lisättiin alla listatut uudet yhteydet tilausten välille.

Myynti -> osto
- Mikäli tilausrivin poisti myyntitilaukselta niin ei se ostolta poistunut. Poistetaan myyntitilausriviin liitetty ostotilausrivi mikäli myyntirivi poistetaan, jos ostotilaus on vielä kesken.

Osto -> Myynti
- Oston puolelle lisättyjä uusia rivejä ei saanut lisättyä myyntiin millään. Lisätty uusi painike, jolla voi halutulle myyntitilaukselle uudet ostotilausrivit lisätä, mikäli myyntitilaus on vielä "Myyntitilaus kesken"-tilassa.