### PR TITLE
Korvaavien tuotteiden alv-käsittely extranetissa

### DIFF
--- a/tilauskasittely/tuote_selaus_haku.php
+++ b/tilauskasittely/tuote_selaus_haku.php
@@ -885,6 +885,7 @@ if ($submit_button != '' and ($lisa != '' or $lisa_parametri != '')) {
                 tuote.epakurantti50pvm,
                 tuote.epakurantti75pvm,
                 tuote.epakurantti100pvm,
+                tuote.alv,
                 (SELECT group_concat(distinct tuotteen_toimittajat.toim_tuoteno ORDER BY tuotteen_toimittajat.tunnus separator '<br>') FROM tuotteen_toimittajat use index (yhtio_tuoteno) WHERE tuote.yhtio = tuotteen_toimittajat.yhtio and tuote.tuoteno = tuotteen_toimittajat.tuoteno) toim_tuoteno,
                 tuote.sarjanumeroseuranta
                 FROM {$tvk_taulu}
@@ -929,6 +930,7 @@ if ($submit_button != '' and ($lisa != '' or $lisa_parametri != '')) {
                   tuote.epakurantti50pvm,
                   tuote.epakurantti75pvm,
                   tuote.epakurantti100pvm,
+                  tuote.alv,
                   (SELECT group_concat(distinct tuotteen_toimittajat.toim_tuoteno order by tuotteen_toimittajat.tunnus separator '<br>') FROM tuotteen_toimittajat use index (yhtio_tuoteno) WHERE tuote.yhtio = tuotteen_toimittajat.yhtio and tuote.tuoteno = tuotteen_toimittajat.tuoteno) toim_tuoteno,
                   tuote.sarjanumeroseuranta,
                   tuoteperhe.tyyppi


### PR DESCRIPTION
Korvaaville tuotteille sama alv-käsittely kuin normituotteille extranetissa:
 - jos asiakkaalle näytetään verottomat hinnat, niin myös korvaavat tuotteet näytetään verottomalla hinnalla
