### PR TITLE
Valmistuksen peruutus: yksi raaka-aine, monta valmistetta

### DIFF
--- a/peru_valmistus.php
+++ b/peru_valmistus.php
@@ -180,7 +180,7 @@ if ($id != 0) {
       $tapares2 = pupe_query($query);
       $taparow2 = mysql_fetch_array($tapares2);
 
-      if ($rivirow["tyyppi"] == "W" or $rivirow["tyyppi"] == "L" or $rivirow["tyyppi"] == "M") {
+      if ($rivirow["tyyppi"] == "W" or $rivirow["tyyppi"] == "L" or $rivirow["tyyppi"] == "M" or $rivirow["tyyppi"] == "V") {
         $voidaankopoistaa = "";
 
         if ($isa_voidaankopoistaa == "EI") {


### PR DESCRIPTION
Mikäli valmistuksen valmisteperheen isätuotteena oli raaka-aine, niin tämän raaka-aineen kohdalla ei osattu oikein tehdä tarkistusta siitä voiko kyseisen tapahtuman peruuttaa. Tällöin siis kyllä peruttiin kaikki muut tapahtumat, mutta isä-raaka-aineen tapahtumat jäivät olemaan mikä sotki asioita. Korjattu nyt niin, että myös isä-raaka-aineelle tarkistus osattaisiin tehdä.