### PR TITLE
Yläpalkin linkit

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,6 +10,10 @@ if (isset($_REQUEST['go'])) {
 
   $go = $_REQUEST['go'];
 
+  if (isset($_REQUEST['laji'])) {
+    $go .= "&laji={$_REQUEST["laji"]}";
+  }
+
   if (strpos($go, '?')) {
     $go .= "&indexvas=1";
   }


### PR DESCRIPTION
Yläpalkin linkeissä ei osattu aina mennä oikeaan ohjelman versioon. Esimerkiksi avoimet laskut-ohjelmassa voidaan katsella myyntilaskuja ja ostolaskuja. Kun linkki oli tehty avoimiin ostolaskuihin niin vei linkki silti avoimiin myyntilaskuihin. Tämä on nyt korjattu ja avoimiin ostolaskuihin pääsee linkistä käsiksi.