### PR TITLE
Ostolaskut: summan muuttaminen valuuttalaskulla

### DIFF
--- a/inc/muutosite.inc
+++ b/inc/muutosite.inc
@@ -746,6 +746,13 @@ if ($tila == 'Q') {
     }
   }
 
+  // Katsotaan onko kyseessä valuuttalasku
+  // ja jos on niin muutetaan laskun summa yhtiön valuuttaan
+  // koska tiliöinnit on joka tapauksessa yhtiön valuutassa
+  if ($lasrow["vienti_kurssi"] != 1) {
+    $lasrow["summa"] = round($lasrow["summa"] * $lasrow["vienti_kurssi"], 2);
+  }
+
   mysql_data_seek($xres, 0);
 
   while ($xrow = mysql_fetch_assoc($xres)) {


### PR DESCRIPTION
Ostolaskun summan muuttaminen ei muuttanut laskun tiliöintejä mikäli kyseessä oli valuttalasku. Tämä johtui siitä, että tiliöinnit on tallennettu yhtiön valuuttaan, mutta laskun summa on laskun valuutassa ja tässä vertailussa ei osattu ottaa tätä huomioon. Korjattu nyt niin, että tämä osataa huomioida vertailussa ja tiliöinnit osataa muuttaa laskun summan muuttamisen yhteydessä oikein.