### PR TITLE
Myynninseuranta kohteittain

### DIFF
--- a/raportit/myyntiseuranta.php
+++ b/raportit/myyntiseuranta.php
@@ -284,6 +284,7 @@ if ($lopetus == "") {
   if ($ruksit[130] != '')     $ruk130chk         = "CHECKED";
   if ($ruksit[140] != '')     $ruk140chk         = "CHECKED";
   if ($ruksit[150] != '')     $ruk150chk         = "CHECKED";
+  if ($ruksit[160] != '')     $ruk160chk         = "CHECKED";
 
   if ($nimitykset != '')       $nimchk           = "CHECKED";
   if ($mitat != '')        $mitatchk        = "CHECKED";
@@ -496,6 +497,13 @@ if ($lopetus == "") {
     <td><input type='text' name='jarjestys[150]' size='2' value='{$jarjestys[150]}'></td>
     <td><input type='checkbox' name='ruksit[150]' value='toimitusehdoittain' {$ruk150chk}></td>
     <td><input type='text' name='rajaus[150]' value='{$rajaus[150]}'></td>
+    <td class='back'>", t("(Toimii vain jos ajat raporttia tilauksista)"), "</td>
+    </tr>
+    <tr>
+    <th>", t("Listaa kohteittain"), "</th>
+    <td><input type='text' name='jarjestys[160]' size='2' value='{$jarjestys[160]}'></td>
+    <td><input type='checkbox' name='ruksit[160]' value='kohteittain' {$ruk160chk}></td>
+    <td><input type='text' name='rajaus[160]' value='{$rajaus[160]}'></td>
     <td class='back'>", t("(Toimii vain jos ajat raporttia tilauksista)"), "</td>
     </tr>
     <tr>
@@ -1600,6 +1608,19 @@ if ((isset($aja_raportti) or isset($valitse_asiakas)) and count($_REQUEST) > 0) 
         }
       }
       //**  Toimitusehdoittain loppu **//
+
+      //**  Kohteittain start **//
+      if ($mukaan == "kohteittain") {
+        $group .= ",lasku.kohde";
+        $select .= "lasku.kohde, ";
+        $order  .= "lasku.kohde,";
+        $gluku++;
+
+        if ($rajaus[$i] != "") {
+          $lisa .= " and lasku.kohde LIKE '%{$rajaus[$i]}%' ";
+        }
+      }
+      //**  Kohteittain loppu **//
     }
 
     // Näytetään tilausrivin kommentit ja groupataan tilausriveittäin
@@ -3134,11 +3155,11 @@ if ((isset($aja_raportti) or isset($valitse_asiakas)) and count($_REQUEST) > 0) 
               if ($ken_nimi == "laskutuspvm") {
                 $row[$ken_nimi] = tv1dateconv($kentta);
               }
-              
+
               if ($ken_nimi == "maksupvm") {
                 $row[$ken_nimi] = tv1dateconv($kentta);
               }
-              
+
               // jos kyseessa on asiakasosasto, haetaan sen nimi
               if ($ken_nimi == "asiakasosasto") {
                 $osre = t_avainsana("ASIAKASOSASTO", "", "and avainsana.selite  = '{$row[$ken_nimi]}'", $yhtio);

--- a/raportit/myyntiseuranta.php
+++ b/raportit/myyntiseuranta.php
@@ -504,7 +504,6 @@ if ($lopetus == "") {
     <td><input type='text' name='jarjestys[160]' size='2' value='{$jarjestys[160]}'></td>
     <td><input type='checkbox' name='ruksit[160]' value='kohteittain' {$ruk160chk}></td>
     <td><input type='text' name='rajaus[160]' value='{$rajaus[160]}'></td>
-    <td class='back'>", t("(Toimii vain jos ajat raporttia tilauksista)"), "</td>
     </tr>
     <tr>
     <td class='back'><br></td>

--- a/tilauskasittely/editilaus_in.inc
+++ b/tilauskasittely/editilaus_in.inc
@@ -689,6 +689,12 @@ while ($tietue = fgets($fd)) {
   case 'OSTOTIL.OT_VIITTEEMME' :
     //Asiakkaan viite
     $viite .= $tieto. ' ';
+
+    // laitetaan tämä myös kohde-kenttään jos se on ennestään tyhjä
+    if (empty($ot_verkkokauppa_kohde)) {
+      $ot_verkkokauppa_kohde = $tieto;
+    }
+
     break;
 
   case 'OSTOTIL.OT_TILAUSVIESTI' :


### PR DESCRIPTION
Voidaan ottaa myynninseurannan tulosta jatkossa tilauksen
kohde-kentällä rajattuna tai kohteittain. Lisäksi editilauksen
vastaanotossa laitetaan OSTOTIL.OT_VIITTEEMME sisältö kohteeseen, jos
kohdetta ei ole aikaisemmin saatu.