### PR TITLE
Piiriin sidottu hinnoittelu

### DIFF
--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -333,6 +333,7 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "UNIFAUN_REF") $ulos .= "<option value='UNIFAUN_REF' {$avain_sel['UNIFAUN_REF']}>".t("Unifaun lähettäjän viite")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "KUITIN_VAKTEXT") $ulos .= "<option value='KUITIN_VAKTEXT' {$avain_sel['KUITIN_VAKTEXT']}>".t("Kuitin vakioteksti")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "STCK_LST_FLTR") $ulos .= "<option value='STCK_LST_FLTR' {$avain_sel['STCK_LST_FLTR']}>".t("Varastosaldoraportin rajaus")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "PIIRI_ALENNUS") $ulos .= "<option value='PIIRI_ALENNUS' {$avain_sel['PIIRI_ALENNUS']}>".t("Piiriin sidottu hinnoittelu")."</option>";
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
   if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Verkkokaupan avainsanat")."'>";
@@ -1311,6 +1312,23 @@ if ($avain_sel["HAE_JA_SELAA"] == "SELECTED" and $_selitetark_2) {
   $ulos .= "</select></td>";
 
   $jatko = 0;
+}
+
+if ($avain_sel["PIIRI_ALENNUS"] == "SELECTED") {
+  if ($_selite || $_jarjestys) {
+    $tyyppi = 0;
+  }
+  elseif ($_selitetark) {
+    $sel = array();
+    $sel[$trow[$i]] = "SELECTED";
+
+    $ulos = "<td><select name = '$nimi'>";
+    $ulos .= "<option value = 'A'>".t("Piiri katsotaan asiakkaan takaa ")."</option>";
+    $ulos .= "<option value = 'T' {$sel['T']}>".t("Piiri katsotaan ensisijaisesti tilauksen takaa")."</option>";
+    $ulos .= "</select></td>";
+
+    $jatko = 0;
+  }
 }
 
 if (mysql_field_name($result, $i) == "jarjestys") {

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -4922,6 +4922,15 @@ if (!function_exists("alehinta")) {
         }
       }
 
+      // Tarkistetaan vielä luetaanko piiri asiakkaalta vaiko tilaukselta
+      $piiricheck = t_avainsana("PIIRI_ALENNUS", "", "and selitetark = 'T'", "", "", "selitetark");
+
+      if ($piiricheck) {
+        $alehi_asrow['piiri'] = $laskurow['piiri'];
+      }
+
+      $piiricheck = mysql_fetch_assoc($piiricheck_result);
+
       // 6A. asiakas.piiri tuote.tuoteno nettohinta (asiakaspiirin tuotteen hinta) laskun valuutassa
       if ($hinta == 0 and trim(strtoupper($laskurow["valkoodi"])) != trim(strtoupper($yhtiorow["valkoodi"]))) {
 

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -4925,7 +4925,7 @@ if (!function_exists("alehinta")) {
       // Tarkistetaan vielä luetaanko piiri asiakkaalta vaiko tilaukselta
       $piiricheck = t_avainsana("PIIRI_ALENNUS", "", "and selitetark = 'T'", "", "", "selitetark");
 
-      if ($piiricheck) {
+      if ($piiricheck and !empty($laskurow['piiri'])) {
         $alehi_asrow['piiri'] = $laskurow['piiri'];
       }
 

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -4929,8 +4929,6 @@ if (!function_exists("alehinta")) {
         $alehi_asrow['piiri'] = $laskurow['piiri'];
       }
 
-      $piiricheck = mysql_fetch_assoc($piiricheck_result);
-
       // 6A. asiakas.piiri tuote.tuoteno nettohinta (asiakaspiirin tuotteen hinta) laskun valuutassa
       if ($hinta == 0 and trim(strtoupper($laskurow["valkoodi"])) != trim(strtoupper($yhtiorow["valkoodi"]))) {
 

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -4925,7 +4925,7 @@ if (!function_exists("alehinta")) {
       // Tarkistetaan vielä luetaanko piiri asiakkaalta vaiko tilaukselta
       $piiricheck = t_avainsana("PIIRI_ALENNUS", "", "and selitetark = 'T'", "", "", "selitetark");
 
-      if ($piiricheck and !empty($laskurow['piiri'])) {
+      if ($piiricheck and isset($laskurow['piiri'])) {
         $alehi_asrow['piiri'] = $laskurow['piiri'];
       }
 


### PR DESCRIPTION
Alehinta-funktio osaa jatkossa hakea piiriin sidottuja hinnoitteluja joko asiakkaan takaa (oletus, sama kuin ennenkin) tai uutena vaihtoehtona myös tilauksen takaa. 

Tilauksen takaa hakeminen pitää erikseen aktivoida avainsanoissa “Muut avainsanat / Piiriin sidottu hinnoittelu”.