### PR TITLE
Verkkolaskun valuuttakooodi

### DIFF
--- a/inc/verkkolasku-in.inc
+++ b/inc/verkkolasku-in.inc
@@ -562,7 +562,7 @@ if (!function_exists("verkkolasku_in")) {
         $valkoodi = $trow['oletus_valkoodi'];
       }
       elseif ($laskuttajan_valkoodi != "") {
-        $valkoodi = $laskuttajan_valkoodi;
+        $valkoodi = strtoupper($laskuttajan_valkoodi);
       }
       elseif ($trow['oletus_valkoodi'] != '') {
         $valkoodi = $trow['oletus_valkoodi'];


### PR DESCRIPTION
Sisään luetun verkkolaskun valuuttakoodi talletetaan isoilla kirjaimilla kantaan, koska pankki ei hyväksy valuuttakoodi, joka on kirjoitettu pienillä kirjaimilla