### PR TITLE
Unifaun ennakkoilmoitus

### DIFF
--- a/inc/toimitustavan_avainsanat.inc
+++ b/inc/toimitustavan_avainsanat.inc
@@ -1,0 +1,9 @@
+<?php
+
+$otsikko     = 'Toimitustavan avainsanat';
+$otsikko_nappi   = 'toimitustavan avainsanat';
+
+// HUOM HUOM: ethän muuta näitä ilman, että korjaat myös yllapito.php:ssä iframen lukitse_avaimeen muuttujat
+$kentat = 'tunnus, liitostunnus, kieli, laji, selite, selitetark';
+
+$jarjestys = 'laji, kieli, selite, selitetark';

--- a/inc/toimitustavan_avainsanatrivi.inc
+++ b/inc/toimitustavan_avainsanatrivi.inc
@@ -1,0 +1,88 @@
+<?php
+
+$ulos = "";
+$jatko = 1; // oletetaan normaali k‰sittely
+$tyyppi = 1; // oletetaan rivin n‰kyvyys
+
+//yhtiˆt‰ ei n‰ytet‰
+if (mysql_field_name($result, $i) == "yhtio") {
+  $tyyppi = 0;
+}
+
+if (mysql_field_name($result, $i) == "laji") {
+
+  $sel = array($trow[$i] => "SELECTED");
+
+  $tem_laji = $trow[$i];
+
+  $ulos = "<td><select name='$nimi' onchange='submit();'>";
+  $ulos .= "<option value=''>".t("Valitse")."</option>";
+  $ulos .= "<option value='unifaun_lisapalvelu' $sel[unifaun_lisapalvelu]>".t("Unifaun lis‰palvelu")."</option>";
+  $ulos .= "</select></td>";
+  $jatko = 0;
+}
+
+if (mysql_field_name($result, $i) == "liitostunnus") {
+  if ($lukitse_avaimeen != "") {
+    $ulos = "<td><input type='hidden' name='$nimi' value='$lukitse_avaimeen'>$lukitse_avaimeen</td>";
+    $jatko = 0;
+  }
+  elseif (isset($alasveto[$i])) {
+    $ulos = "<td>".$alasveto[$i]."</td>";
+    $jatko = 0;
+  }
+}
+
+if (mysql_field_name($result, $i) == "selite") {
+
+  $tem_selite = $trow[$i];
+
+  if ($tem_laji == 'unifaun_lisapalvelu') {
+
+    $sel = array($trow[$i] => "SELECTED");
+    //$tem_selite = $trow[$i];
+    $ulos = "<td><select name='$nimi' onchange='submit();'>";
+    $ulos .= "<option value=''>".t("Valitse")."</option>";
+    $ulos .= "<option value='enot' $sel[enot]>".t("Unifaun ennakkoilmoitus")."</option>";
+    $ulos .= "</select></td>";
+    $jatko = 0;
+  }
+  else {
+    $ulos = "<td><textarea rows=10 cols=50 name='$nimi'>{$trow[$i]}</textarea></td>";
+    $jatko = 0;
+  }
+}
+
+if (mysql_field_name($result, $i) == "selitetark") {
+
+  if ($tem_selite == 'enot') {
+    $sel = array($trow[$i] => "SELECTED");
+    $ulos = "<td><select name='$nimi' onchange='submit();'>";
+    $ulos .= "<option value='e'>".t("Ei p‰‰ll‰")."</option>";
+    $ulos .= "<option value='k' $sel[k]>".t("P‰‰ll‰")."</option>";
+    $ulos .= "</select></td>";
+    $jatko = 0;
+  }
+  else {
+    $ulos = "<td><textarea rows=10 cols=50 name='$nimi'>{$trow[$i]}</textarea></td>";
+  }
+}
+
+if (mysql_field_name($result, $i) == "kieli") {
+  $ulos = "<td><select name='$nimi' ".js_alasvetoMaxWidth($nimi, 300).">";
+
+  foreach ($GLOBALS["sanakirja_kielet"] as $sanakirja_kieli => $sanakirja_kieli_nimi) {
+    $sel = "";
+    if ($trow[$i] == $sanakirja_kieli) {
+      $sel = "selected";
+    }
+    elseif ($trow[$i] == "" and $sanakirja_kieli == $yhtiorow["kieli"]) {
+      $sel = "selected";
+    }
+
+    $ulos .= "<option value='$sanakirja_kieli' $sel>".t($sanakirja_kieli_nimi)."</option>";
+  }
+
+  $ulos .= "</select></td>";
+  $jatko = 0;
+}

--- a/inc/toimitustavan_avainsanattarkista.inc
+++ b/inc/toimitustavan_avainsanattarkista.inc
@@ -39,7 +39,7 @@ if (!function_exists("toimitustavan_avainsanattarkista")) {
         elseif (mysql_num_rows($sresult) == 1) {
 
           $_toimitustavan_tunnus = mysql_fetch_assoc($sresult);
-          $tem_liitostunnus = $tem_liitostunnus_i = $_toimitustavan_tunnus['tunnus'];
+          $tem_liitostunnus = $_toimitustavan_tunnus['tunnus'];
 
           $alasveto[$i] = "<select name='t[$i]'>";
           $alasveto[$i] .= "<option value='{$tem_liitostunnus}'>".$_toimitustavan_tunnus['selite']."</option>";

--- a/inc/toimitustavan_avainsanattarkista.inc
+++ b/inc/toimitustavan_avainsanattarkista.inc
@@ -107,10 +107,8 @@ if (!function_exists("toimitustavan_avainsanattarkista")) {
                 FROM toimitustavan_avainsanat
                 WHERE yhtio     = '$kukarow[yhtio]'
                 AND liitostunnus = '$tem_liitostunnus'
-                AND kieli       = '$tem_kieli'
                 AND laji        = '$tem_laji'
                 AND selite      = '$tem_selite'
-                AND selitetark  = '$tem_selitetark'
                 AND tunnus     != '$tunnus'";
       $results = pupe_query($query);
 

--- a/inc/toimitustavan_avainsanattarkista.inc
+++ b/inc/toimitustavan_avainsanattarkista.inc
@@ -1,0 +1,122 @@
+<?php
+
+if (!function_exists("toimitustavan_avainsanattarkista")) {
+  function toimitustavan_avainsanattarkista(&$t, $i, $result, $tunnus, &$virhe, $trow) {
+    global $kukarow, $yhtiorow, $alias_set, $alasveto;
+
+    static $tem_liitostunnus, $tem_liitostunnus_i, $tem_kieli, $tem_laji, $tem_selite, $tem_selitetark;
+
+    if (mysql_field_name($result, $i) == "liitostunnus") {
+      $tem_liitostunnus = trim($t[$i]);
+      $tem_liitostunnus_i = $i;
+
+      if ($tem_liitostunnus != '') {
+        $query = "SELECT tunnus, selite
+                  FROM toimitustapa
+                  WHERE yhtio = '$kukarow[yhtio]'
+                  AND (tunnus = '$t[$i]' or selite = '$t[$i]')";
+        $sresult = pupe_query($query);
+
+        if (mysql_num_rows($sresult) != 1 and $trow["luedata_toiminto"] != "POISTA") {
+
+          $query = "SELECT tunnus, selite
+                    FROM toimitustapa
+                    WHERE yhtio = '$kukarow[yhtio]'";
+          $sresult = pupe_query($query);
+
+          if (mysql_num_rows($sresult) > 0) {
+
+            $alasveto[$i] = "<select name='t[$i]'>";
+            $alasveto[$i] .= "<option value='0'>".t("Valitse toimitustapa")."</option>";
+            while ($toimtaparow = mysql_fetch_assoc($sresult)) {
+              $alasveto[$i] .= "<option value='{$toimtaparow['tunnus']}'>".$toimtaparow['selite']."</option>";
+            }
+            $alasveto[$i] .= "</select>";
+          }
+
+          $virhe[$i] = t("Toimitustapaa ei löydy!");
+        }
+        elseif (mysql_num_rows($sresult) == 1) {
+
+          $_toimitustavan_tunnus = mysql_fetch_assoc($sresult);
+          $tem_liitostunnus = $tem_liitostunnus_i = $_toimitustavan_tunnus['tunnus'];
+
+          $alasveto[$i] = "<select name='t[$i]'>";
+          $alasveto[$i] .= "<option value='{$tem_liitostunnus}'>".$_toimitustavan_tunnus['selite']."</option>";
+          $alasveto[$i] .= "</select>";
+        }
+      }
+      else {
+        $virhe[$i] = t("Toimitustapa puuttuu!");
+      }
+    }
+
+    if (mysql_field_name($result, $i) == "kieli") {
+
+      $tem_kieli = trim($t[$i]);
+
+      if ($tem_kieli == '') {
+        $virhe[$i] = t("Kieltä ei voi jättää tyhjäksi")."!";
+      }
+      else {
+        $loytyyko = FALSE;
+
+        foreach ($GLOBALS["sanakirja_kielet"] as $sanakirja_kieli => $sanakirja_kieli_nimi) {
+          if ($sanakirja_kieli == $t[$i]) {
+            $loytyyko = TRUE;
+            break;
+          }
+        }
+
+        if (!$loytyyko) {
+          $virhe[$i] = t("Virheellinen kieli")."!";
+        }
+      }
+    }
+
+    if (mysql_field_name($result, $i) == "laji") {
+
+      $tem_laji = trim($t[$i]);
+
+      if ($t[$i] == '') {
+        $virhe[$i] = t("Tieto puuttuu")."!";
+      }
+    }
+
+    if (mysql_field_name($result, $i) == "selite") {
+
+      $tem_selite = trim($t[$i]);
+
+      if ($t[$i] == '') {
+        $virhe[$i] = t("Tieto puuttuu")."!";
+      }
+    }
+
+    if (mysql_field_name($result, $i) == "selitetark") {
+
+      $tem_selitetark = trim($t[$i]);
+
+      if ($t[$i] == '') {
+        $virhe[$i] = t("Tieto puuttuu")."!";
+      }
+    }
+
+    if (mysql_field_name($result, $i) == 'tunnus') {
+
+      $query = "SELECT tunnus
+                FROM toimitustavan_avainsanat
+                WHERE yhtio     = '$kukarow[yhtio]'
+                AND liitostunnus = '$tem_liitostunnus'
+                AND kieli       = '$tem_kieli'
+                AND laji        = '$tem_laji'
+                AND selite      = '$tem_selite'
+                AND selitetark  = '$tem_selitetark'
+                AND tunnus     != '$tunnus'";
+      $results = pupe_query($query);
+
+      if (mysql_num_rows($results) > 0) {
+        $virhe[$tem_liitostunnus_i] = $virhe[$i] = t("Toimittajan avainsana annetuilla tiedoilla löytyy kannasta. Duplikaatit ovat kiellettyjä!");
+      }
+    }
+  }
+}

--- a/inc/unifaun_send.inc
+++ b/inc/unifaun_send.inc
@@ -1116,6 +1116,43 @@ class Unifaun {
     //  $uni_add_val = $uni_addon->addChild('val', ""); # Min. temperature allowed. Used by DBSchenker ColdSped.
     //  $uni_add_val->addAttribute('n', "tempmin");
 
+    // Katsotaan onko sähköinen ennakkoilmoitus käytössä
+    $query = "SELECT *
+              FROM toimitustavan_avainsanat
+              WHERE yhtio = '{$this->kukarow['yhtio']}'
+              AND liitostunnus   = '{$this->toitarow['tunnus']}'
+              AND laji = 'unifaun_lisapalvelu'
+              AND selite = 'enot'
+              AND selitetark = 'k'";
+    $toimitustavan_avainsanat_res = pupe_query($query);
+
+    if (mysql_num_rows($toimitustavan_avainsanat_res) == 1) {
+
+      $uni_ufonline = $uni_shipment->addChild('ufonline');
+      $uni_option = $uni_ufonline->addChild('option');
+      $uni_option->addAttribute('optid', utf8_encode('ENOT'));
+
+      $uni_opt_val = $uni_option->addChild('val', utf8_encode($this->yhtiorow["postittaja_email"]));
+      $uni_opt_val->addAttribute('n', "from");
+
+      $uni_opt_val = $uni_option->addChild('val', utf8_encode($this->asiakasrow["email"]));
+      $uni_opt_val->addAttribute('n', "to");
+
+      $uni_opt_val = $uni_option->addChild('val', "");
+      $uni_opt_val->addAttribute('n', "cc");
+
+      $uni_opt_val = $uni_option->addChild('val', "");
+      $uni_opt_val->addAttribute('n', "bcc");
+
+      /*
+      $uni_opt_val = $uni_option->addChild('val', "messagea tähän");
+      $uni_opt_val->addAttribute('n', "message");
+
+      $uni_opt_val = $uni_option->addChild('val', "template name");
+      $uni_opt_val->addAttribute('n', "mailtemplate");
+      */
+    }
+
     $this->xml = $xml;
   }
 

--- a/yllapito.php
+++ b/yllapito.php
@@ -2450,6 +2450,9 @@ if ($tunnus > 0 or $uusi != 0 or $errori != '') {
     if (($toikrow = tarkista_oikeus("yllapito.php", "toimitustavan_lahdot%", "", "OK", $toimi_array)) !== FALSE) {
       echo "<iframe id='toimitustavan_lahdot_iframe' name='toimitustavan_lahdot_iframe' src='yllapito.php?toim=$toikrow[alanimi]&from=yllapito&haku[1]=@$tunnus&ohje=off&lukitse_avaimeen=$tunnus' style='width: 600px; border: 0px; display: block;' frameborder='0'></iFrame>";
     }
+    if (($toikrow = tarkista_oikeus("yllapito.php", "toimitustavan_avainsanat%", "", "OK", $toimi_array)) !== FALSE) {
+      echo "<iframe id='toimitustavan_avainsanat_iframe' name='toimitustavan_avainsanat_iframe' src='yllapito.php?toim=$toikrow[alanimi]&from=yllapito&haku[1]=@$tunnus&ohje=off&lukitse_avaimeen=$tunnus' style='width: 600px; border: 0px; display: block;' frameborder='0'></iFrame>";
+    }
   }
 
   if ($trow["tunnus"] > 0 and $errori == '' and $from != "yllapito" and ($toim == 'lasku' or $toim == 'asiakas' or $toim == "sarjanumeron_lisatiedot" or $toim == "tuote" or $toim == "avainsana" or $toim == "toimi")) {
@@ -2551,6 +2554,7 @@ if ($tunnus > 0 or $uusi != 0 or $errori != '') {
     $toim == "rahtisopimukset" or
     $toim == "etaisyydet" or
     $toim == "tuotteen_avainsanat" or
+    $toim == "toimitustavan_avainsanat" or
     $toim == "toimittajaalennus" or
     $toim == "vaihtoehtoiset_verkkolaskutunnukset" or
     $toim == "toimittajahinta" or


### PR DESCRIPTION
Toimitustavan avainsanoissa voidaan jatkossa aktivoida Unifaun ennakkoilmoitus. Pupe ei tarkista onko ennakkoilmoituksen aktivointi toimitustavalle ok, eli se pitää itse varmistaa Unifaunilta, tai testata ennen laajempaa käyttöä.

Ennakkoilmoitus tehdään sähköpostitse, eli jos sitä ei tilauksella / asiakkaalla ole, tulee Unifaunissa errori.