### PR TITLE
Ohitetaan toimitussanomat rahtikirjakopiossa (oletus)

### DIFF
--- a/rahtikirja-kopio.php
+++ b/rahtikirja-kopio.php
@@ -355,6 +355,10 @@ if ($tee == 'valitse' and $real_submit != '') {
 
     echo "</select><br><br>";
 
+    echo "<table><th>",t("Tulosta Desadv-sanomat kopioista"),"</th>";
+    echo "<th><input type='checkbox' name='tulosta_desadv' value='JOO' ></th></table>";
+    echo "<br>";
+
     echo "<br><input type='submit' value='".t("Tulosta valitut")."'>";
     echo "</form>";
   }

--- a/rahtikirja-kopio.php
+++ b/rahtikirja-kopio.php
@@ -355,7 +355,7 @@ if ($tee == 'valitse' and $real_submit != '') {
 
     echo "</select><br><br>";
 
-    echo "<table><th>",t("Tulosta Desadv-sanomat kopioista"),"</th>";
+    echo "<table><th>",t("Tulosta toimitussanomat rahtikirjakopioista"),"</th>";
     echo "<th><input type='checkbox' name='tulosta_desadv' value='JOO' ></th></table>";
     echo "<br>";
 

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -1096,6 +1096,9 @@ if ($tee == 'tulosta') {
       }
 
       $_desadv = (strpos($rakir_row['toimitusvahvistus'], 'desadv') !== false);
+      $_rahtikirjakopio = (strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-kopio.php") !== FALSE);
+      $_rahtikirjakopio_desadv = ($_rahtikirjakopio and isset($tulosta_desadv) and $tulosta_desadv == 'JOO');
+      $_desadv = ($_desadv and (!$_rahtikirjakopio or $_rahtikirjakopio_desadv));
 
       // L‰hetet‰‰n toimitusvahvistus
       if ($rakir_row['toimitusvahvistus'] != '' and (!$_onko_unifaun or $_onko_unifaun_xp or $_desadv)) {

--- a/rahtikirja-tulostus.php
+++ b/rahtikirja-tulostus.php
@@ -1096,12 +1096,12 @@ if ($tee == 'tulosta') {
       }
 
       $_desadv = (strpos($rakir_row['toimitusvahvistus'], 'desadv') !== false);
-      $_rahtikirjakopio = (strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-kopio.php") !== FALSE);
-      $_rahtikirjakopio_desadv = ($_rahtikirjakopio and isset($tulosta_desadv) and $tulosta_desadv == 'JOO');
-      $_desadv = ($_desadv and (!$_rahtikirjakopio or $_rahtikirjakopio_desadv));
+      $_ra_kopio_check = (strpos($_SERVER['SCRIPT_NAME'], "rahtikirja-kopio.php") !== false);
+      $_ra_kopio_desadv = ($_ra_kopio_check and isset($tulosta_desadv) and $tulosta_desadv == 'JOO');
+      $_ra_kopio = (!$_ra_kopio_check or $_ra_kopio_desadv);
 
       // L‰hetet‰‰n toimitusvahvistus
-      if ($rakir_row['toimitusvahvistus'] != '' and (!$_onko_unifaun or $_onko_unifaun_xp or $_desadv)) {
+      if ($rakir_row['toimitusvahvistus'] != '' and (!$_onko_unifaun or $_onko_unifaun_xp or $_desadv) and $_ra_kopio) {
         pupesoft_toimitusvahvistus($otunnukset, $tunnukset, $rahtikirjanro);
       }
 


### PR DESCRIPTION
Voidaan ottaa toimitussanomat tarvittaessa rahtikirjakopioissa. Aikaisemmin ne otettiin aina automaattisesti, mutta nyt se on valinnainen. Oletuksena ei oteta.
  