### PR TITLE
Pienviilaus myyntierään

### DIFF
--- a/tilauskasittely/lisaarivi.inc
+++ b/tilauskasittely/lisaarivi.inc
@@ -1862,6 +1862,8 @@ if ($rivityyppi != 'O' and trim($var) == "" and $trow["tuoteno"] != "") {
                 $ale_kaikki_array['ale'.$alepostfix] = ${'ale'.$alepostfix};
               }
 
+              $trow['myynti_era'] = $trow['myynti_era'] <= 0 ? 1 : $trow['myynti_era'];
+
               // Sisääntuleva lavakeraystyyppinen tilaus
               // Ollaanko vikalla kierroksella?
               // Myytävissä oin vähemän kuin mitä tarvitaan ja halutaan myydä vain kokonaisia myyntieriä


### PR DESCRIPTION
Myyntierä != 0 tai alle tässä keississä, jossa katsotaan täysiä myyntieriä loopin sisällä. Ei haluta ikuista looppia.