### PR TITLE
Pelkistetty tarjouspohja, ehdot

### DIFF
--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -306,6 +306,8 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "LABEL") $ulos .= "<option value='LABEL' {$avain_sel['LABEL']}>".t("Myyntitilauksen luokitus")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "OSTOTIL_TILTYYP") $ulos .= "<option value='OSTOTIL_TILTYYP' {$avain_sel['OSTOTIL_TILTYYP']}>".t("Ostotilauksen tilaustyyppi")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "TARJOUS_VAKIOTE") $ulos .= "<option value='TARJOUS_VAKIOTE' {$avain_sel['TARJOUS_VAKIOTE']}>".t("Tarjouksen vakioteksti")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "TARJOUS_EHDOT") $ulos .= "<option value='TARJOUS_EHDOT' {$avain_sel['TARJOUS_EHDOT']}>".t("Pelkistetyn tarjouksen kauppaehdot")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "TARJOUS_KAUPEHD") $ulos .= "<option value='TARJOUS_KAUPEHD' {$avain_sel['TARJOUS_KAUPEHD']}>".t("Pelkistetyn tarjouksen lopun kauppaehdot (kohdat (3 ja 4)")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "KATEISOTTO") $ulos .= "<option value='KATEISOTTO' {$avain_sel['KATEISOTTO']}>".t("Käteisoton luonne")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "KOHDE_TYYPPI") $ulos .= "<option value='KOHDE_TYYPPI' {$avain_sel['KOHDE_TYYPPI']}>".t("Kohteen tyyppi")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "MYYNNISTA_OSTO") $ulos .= "<option value='MYYNNISTA_OSTO' {$avain_sel['MYYNNISTA_OSTO']}>".t("Ostotilauksen käsittely myyntitilauksella")."</option>";
@@ -709,6 +711,12 @@ if (mysql_field_name($result, $i) == "kieli") {
 if ($avain_sel["TARJOUS_VAKIOTE"] == "SELECTED" and ($_selite or $_selitetark_2 or $_selitetark_3 or $_selitetark_4)) {
   $tyyppi = 0;
 }
+if ($avain_sel["TARJOUS_EHDOT"] == "SELECTED" and ($_selite or $_selitetark_2 or $_selitetark_3 or $_selitetark_4)) {
+  $tyyppi = 0;
+}
+if ($avain_sel["TARJOUS_KAUPEHD"] == "SELECTED" and ($_selite or $_selitetark_2 or $_selitetark_3 or $_selitetark_4)) {
+  $tyyppi = 0;
+}
 
 if ($avain_sel["KERAYSLISTA"] == "SELECTED" and $_selite) {
 
@@ -1032,6 +1040,8 @@ if (($avain_sel["KARHUVIESTI"] == "SELECTED"
     or $avain_sel["TV_LISATIETO"] == "SELECTED"
     or $avain_sel['KAANTALVVIESTI'] == "SELECTED"
     or $avain_sel['TARJOUS_VAKIOTE'] == "SELECTED"
+    or $avain_sel['TARJOUS_EHDOT'] == "SELECTED"
+    or $avain_sel['TARJOUS_KAUPEHD'] == "SELECTED"
     or $avain_sel["SALDOVAHVISTUS"] == "SELECTED"
     or $avain_sel["MYYNTITILASTO"] == "SELECTED")
   and $_selitetark) {

--- a/tilauskasittely/tulosta_tarjous.inc
+++ b/tilauskasittely/tulosta_tarjous.inc
@@ -1062,7 +1062,7 @@ if (!function_exists('tarjous_rivi_hinta_ale')) {
       $pohja = $pdf_tarjous->draw_paragraph($kala+$norm["height"], 45, 60, 480, $row["perhe_kommentti"],  $page_tarjous[$sivu], $norm);
       if (is_numeric($pohja)) {
         $kala = $pohja - $rivinkorkeus;
-      } 
+      }
       else {
         $kala = 0;
       }
@@ -1187,7 +1187,7 @@ if (!function_exists('tarjous_rivi_hinta_ale')) {
         $pohja = $pdf_tarjous->draw_paragraph($kala+$norm["height"]+2, 80, 60, 575, $row["kommentti"], $page_tarjous[$sivu], $norm);
         if (is_numeric($pohja)) {
           $kala = $pohja - $rivinkorkeus;
-        } 
+        }
         else {
           $kala = 0;
         }
@@ -1197,10 +1197,10 @@ if (!function_exists('tarjous_rivi_hinta_ale')) {
         $pohja = $pdf_tarjous->draw_paragraph($kala+$norm["height"], 80, 60, 575, $row["perhe_kommentti"],  $page_tarjous[$sivu], $norm);
         if (is_numeric($pohja)) {
           $kala = $pohja - $rivinkorkeus -10;
-        } 
+        }
         else {
           $kala = 0;
-        }      
+        }
       }
     }
     else {
@@ -1212,10 +1212,10 @@ if (!function_exists('tarjous_rivi_hinta_ale')) {
       $pohja = $pdf_tarjous->draw_paragraph($kala+$norm["height"]+2, 45, 60, 480, $row["kommentti"], $page_tarjous[$sivu], $norm);
       if (is_numeric($pohja)) {
         $kala = $pohja - $rivinkorkeus;
-      } 
+      }
       else {
         $kala = 0;
-      }    
+      }
     }
 
     $kala = $kala - 5;
@@ -1241,10 +1241,10 @@ if (!function_exists('tarjous_rivi_custom')) {
       $pohja = $pdf_tarjous->draw_paragraph($kala+$norm["height"], 150, 60, 480, $row["perhe_kommentti"],  $page_tarjous[$sivu], $norm);
       if (is_numeric($pohja)) {
         $kala = $pohja - $rivinkorkeus;
-      } 
+      }
       else {
         $kala = 0;
-      }    
+      }
     }
 
     if ($naytetaanko_tuoteno == '') {
@@ -1359,10 +1359,10 @@ if (!function_exists('tarjous_rivi_custom')) {
       $pohja = $pdf_tarjous->draw_paragraph($kala+$norm["height"], 150, 60, 480, $row["perhe_kommentti"],  $page_tarjous[$sivu], $norm);
       if (is_numeric($pohja)) {
         $kala = $pohja - $rivinkorkeus;
-      } 
+      }
       else {
         $kala = 0;
-      }    
+      }
     }
 
     $kala = $kala - 5;
@@ -1557,8 +1557,32 @@ if (!function_exists('loppu_tarjous')) {
           $pdf_tarjous->draw_text(200, $kala-51, t($laskurow['maksuehto'], $kieli)." ".t("tai erillisen maksupostiohjelman mukaan", $kieli), $page_tarjous[$sivu], $norm);
 
           $pdf_tarjous->draw_text(50, $kala-64, t("Myynti- ja toimitusehdot", $kieli), $page_tarjous[$sivu], $boldi);
-          $pdf_tarjous->draw_text(200, $kala-64, $yhtiorow['nimi'].t(":n yleiset kauppaehdot", $kieli)." 30.6.2014", $page_tarjous[$sivu], $norm);
-          $pdf_tarjous->draw_text(200, $kala-77, $yhtiorow['nimi'].':n '.t("tilaajavastuulain mukaiset asiakirjat löydät www.tilaajavastuulaki.fi", $kieli), $page_tarjous[$sivu], $norm);
+
+          $result = t_avainsana('TARJOUS_EHDOT', $kieli);
+          $vakioteksti_row = mysql_fetch_assoc($result);
+          $vakioteksti = $vakioteksti_row['selitetark'];
+
+          if (!empty($vakioteksti)) {
+            $_y = $kala - 64;
+
+            if (strlen($vakioteksti) > 100) {
+              $vakioteksti = wordwrap($vakioteksti, 100, "\n");
+              foreach (explode("\n", $vakioteksti) as $teksi) {
+                $pdf_tarjous->draw_text(200,  $_y, $teksi, $page_tarjous[$sivu], $norm);
+                $_y = $_y - 13;
+              }
+            }
+            else {
+              $pdf_tarjous->draw_text(200,  $_y, $vakioteksti, $page_tarjous[$sivu], $norm);
+              $_y = $_y - 13;
+            }
+
+            $kala = $_y + 90;
+          }
+          else {
+            $pdf_tarjous->draw_text(200, $kala-64, $yhtiorow['nimi'].t(":n yleiset kauppaehdot", $kieli)." 30.6.2014", $page_tarjous[$sivu], $norm);
+            $pdf_tarjous->draw_text(200, $kala-77, $yhtiorow['nimi'].':n '.t("tilaajavastuulain mukaiset asiakirjat löydät www.tilaajavastuulaki.fi", $kieli), $page_tarjous[$sivu], $norm);
+          }
 
           $pdf_tarjous->draw_text(50, $kala-90, t("Salassapito", $kieli), $page_tarjous[$sivu], $boldi);
           $pdf_tarjous->draw_text(200, $kala-90, t("Tämä asiakirja liitteineen on luottamuksellinen eikä sitä saa ilman ", $kieli).$yhtiorow['nimi'].':n ', $page_tarjous[$sivu], $norm);
@@ -1588,8 +1612,39 @@ if (!function_exists('loppu_tarjous')) {
           $pdf_tarjous->draw_text(50, $kala-130, t("Sopimusasiakirjojen etusijajärjestys on seuraava", $kieli).':', $page_tarjous[$sivu], $pieni);
           $pdf_tarjous->draw_text(50, $kala-140, '1. '.t("Tilausvahvistus", $kieli), $page_tarjous[$sivu], $pieni);
           $pdf_tarjous->draw_text(50, $kala-150, '2. '.t("Allekirjoitettu tarjous", $kieli), $page_tarjous[$sivu], $pieni);
-          $pdf_tarjous->draw_text(50, $kala-160, "3. $yhtiorow[nimi]".t(":n yleiset kauppaehdot", $kieli)." 30.6.2014", $page_tarjous[$sivu], $pieni);
-          $pdf_tarjous->draw_text(50, $kala-170, "4. ".t("Rakennustuotteiden yleisiä hankinta- ja toimitusehtoja (RYHT 2000) ja betonielementtien asennusehdot", $kieli).'.', $page_tarjous[$sivu], $pieni);
+
+          $result = t_avainsana('TARJOUS_KAUPEHD', $kieli);
+          $vakioteksti_row = mysql_fetch_assoc($result);
+          $vakioteksti = $vakioteksti_row['selitetark'];
+
+          if (!empty($vakioteksti)) {
+            $_y = $kala - 160;
+
+            if (strlen($vakioteksti) > 150) {
+              $vakioteksti = wordwrap($vakioteksti, 150, "\n");
+              foreach (explode("\n", $vakioteksti) as $teksi) {
+                $pdf_tarjous->draw_text(50,  $_y, $teksi, $page_tarjous[$sivu], $pieni);
+                $_y = $_y - 10;
+              }
+            }
+            else {
+              if (strpos($vakioteksti, "\n") !== false) {
+                foreach (explode("\n", $vakioteksti) as $teksi) {
+                  $pdf_tarjous->draw_text(50,  $_y, $teksi, $page_tarjous[$sivu], $pieni);
+                  $_y = $_y - 10;
+                }
+              }
+              else {
+                $pdf_tarjous->draw_text(50,  $_y, $vakioteksti, $page_tarjous[$sivu], $pieni);
+                $_y = $_y - 10;
+              }
+            }
+            $kala = $_y + 190;
+          }
+          else {
+            $pdf_tarjous->draw_text(50, $kala-160, "3. $yhtiorow[nimi]".t(":n yleiset kauppaehdot", $kieli)." 30.6.2014", $page_tarjous[$sivu], $pieni);
+            $pdf_tarjous->draw_text(50, $kala-170, "4. ".t("Rakennustuotteiden yleisiä hankinta- ja toimitusehtoja (RYHT 2000) ja betonielementtien asennusehdot", $kieli).'.', $page_tarjous[$sivu], $pieni);
+          }
 
           $pdf_tarjous->draw_text(50, $kala-190, t("Olen tutustunut", $kieli)." $yhtiorow[nimi]".t(":n yleisiin sopimusehtoihin ja hyväksyn ne sellaisenaan").'.', $page_tarjous[$sivu], $pieni);
 


### PR DESCRIPTION
Siirretty pelkistetyn tarjouspohjan muutama ehtoihin liittyvä kohta avainsanoihin, jossa tekstiä voi itse määritellä. Ilman avainsanoja toimii oletusteksteillä kuten ennenkin.