### PR TITLE
Factoring-viitteiden sisäänluku

### DIFF
--- a/factoring_viite.php
+++ b/factoring_viite.php
@@ -1,0 +1,248 @@
+<?php
+
+// Kutsutaanko CLI:stä
+$php_cli = FALSE;
+
+if (php_sapi_name() == 'cli') {
+  $php_cli = TRUE;
+}
+
+$ok = 0;
+
+if (!function_exists("kasittele_factoring_viite")) {
+  function kasittele_factoring_viite($aineistotunnus, $kassatili) {
+    global $kukarow, $yhtiorow, $palvelin2, $lopp_pvm, $lopp_tilino, $lopp_tyyppi, $kuitattu_checked;
+
+    $tee_selvittely = false;
+    $tee_viitemaksu_kohdistus = false;
+    $vastavienti = 0;
+    $vastavienti_valuutassa = 0;
+
+    $tilioteselailu_oikrow = tarkista_oikeus("tilioteselailu.php", "%", "", "OK");
+
+    // Otetaan talteen, koska täällä muutellaan
+    $kukarow_talteen = $kukarow;
+
+    // Käsitellään uudet tietueet
+    $query = "SELECT *
+              FROM tiliotedata
+              WHERE aineisto = {$aineistotunnus}
+              ORDER BY aineisto, tunnus";
+    $tiliotedataresult = pupe_query($query);
+
+    $tilioterivilaskuri = 1;
+    $tilioterivimaara = mysql_num_rows($tiliotedataresult);
+
+    // Haetaan kannan isoin lasku.tunnus, nin voidaan tehdän sanity-checki EndToEndId:lle.
+    $query = "SELECT max(tunnus) maxEndToEndId
+              FROM lasku";
+    $meteidres = pupe_query($query);
+    $meteidrow = mysql_fetch_assoc($meteidres);
+
+    $tiliotedatarow = mysql_fetch_assoc($tiliotedataresult);
+    mysql_data_seek($tiliotedataresult, 0);
+
+    $query = "SELECT *
+              FROM yriti
+              WHERE tilino = '{$tiliotedatarow['tilino']}'";
+    $yriti_result = pupe_query($query);
+    $yritirow = mysql_fetch_assoc($yriti_result);
+    $yhtiorow = hae_yhtion_parametrit($yritirow['yhtio']);
+ 
+    while ($tiliotedatarow = mysql_fetch_assoc($tiliotedataresult)) {
+      $tietue = $tiliotedatarow['tieto'];
+
+      // Setataan kukarow-yhtiö
+      $kukarow["yhtio"] = $yritirow["yhtio"];
+
+      if ($tiliotedatarow['tyyppi'] == 3) {
+        $tee_viitemaksu_kohdistus = true;
+        require "inc/viitemaksut.inc";
+      }
+
+      // merkataan tämä tiliotedatarivi käsitellyksi
+      $query = "UPDATE tiliotedata
+                SET kasitelty = now()
+                WHERE tunnus = '$tiliotedatarow[tunnus]'";
+      $updatekasitelty = pupe_query($query);
+
+      $tilioterivilaskuri++;
+    }
+
+    if ($tee_selvittely) {
+      $tkesken = 0;
+      $maara = $vastavienti;
+      $kohdm = $vastavienti_valuutassa;
+
+      echo "<tr><td colspan = '6'>";
+      require "inc/teeselvittely.inc";
+      echo "</td></tr>";
+      echo "</table><br>\n<br>\n";
+    }
+
+    if ($tee_viitemaksu_kohdistus) {
+      // Tässä tarvitaan kukarow[yhtio], joten ajetaan tämä kaikille firmoille
+      $query = "SELECT yhtio from yhtio";
+      $yhtiores = pupe_query($query);
+
+      while ($yhtiorow = mysql_fetch_assoc($yhtiores)) {
+        // Setataan yhtiorow
+        $yhtiorow = hae_yhtion_parametrit($yhtiorow['yhtio']);
+
+        // Setataan kukarow-yhtiö
+        $kukarow["yhtio"] = $yhtiorow["yhtio"];
+
+        require "inc/factoring_viitteet_kohdistus.inc";
+        require "myyntires/suoritus_asiakaskohdistus_kaikki.php";
+      }
+
+      echo "<br><br>";
+    }
+
+    // Palautetan kukarow
+    $kukarow = $kukarow_talteen;
+  }
+}
+
+
+// tehdään tällänen häkkyrä niin voidaan scriptiä kutsua vaikka perlistä..
+if ($php_cli) {
+
+  if (!isset($argv[1]) or $argv[1] != 'perl') {
+    echo "Parametri väärin!!!\n";
+    die;
+  }
+
+  if (!isset($argv[2]) or $argv[2] == '') {
+    echo "Anna tiedosto!!!\n";
+    die;
+  }
+
+  // otetaan includepath aina rootista
+  ini_set("include_path", ini_get("include_path").PATH_SEPARATOR.dirname(__FILE__).PATH_SEPARATOR."/usr/share/pear");
+  error_reporting(E_ALL ^E_WARNING ^E_NOTICE);
+  ini_set("display_errors", 0);
+
+  require "inc/connect.inc";
+  require "inc/functions.inc";
+
+  // Logitetaan ajo
+  cron_log($argv[2]);
+
+  $userfile = trim($argv[2]);
+  $filenimi = $userfile;
+  $ok = 1;
+  $palvelin2 = "";
+
+  ob_start();
+}
+else {
+  require "inc/parametrit.inc";
+
+  echo "<font class='head'>Factoring viitemaksujen käsittely</font><hr><br>\n<br>\n";
+
+  echo "<form enctype='multipart/form-data' name='sendfile' method='post'>";
+  echo "<table>";
+  echo "  <tr>
+        <th>".t("Pankin aineisto").":</th>
+        <td><input type='file' name='userfile'></td></tr>
+        <tr><th>".t("Oletusrahatili").":</th>
+        <td><input type='text' name='kassatili'></td>
+        <td class='back'><input type='submit' value='".t("Käsittele tiedosto")."'></td>
+      </tr>";
+  echo "</table>";
+  echo "</form><br>\n<br>\n";
+
+  echo "  <script type='text/javascript' language='JavaScript'>
+      <!--
+        function verify() {
+          msg = '".t("Oletko varma?")."';
+
+          if (confirm(msg)) {
+            return true;
+          }
+          else {
+            skippaa_tama_submitti = true;
+            return false;
+          }
+        }
+      -->
+      </script>";
+}
+
+$forceta = false;
+
+// Napataan alkuperäinen kukarow
+$tiliote_kukarow = $kukarow;
+
+// katotaan onko faili uploadattu
+if (isset($_FILES['userfile']['tmp_name']) and is_uploaded_file($_FILES['userfile']['tmp_name'])) {
+  $userfile  = $_FILES['userfile']['name'];
+  $filenimi  = $_FILES['userfile']['tmp_name'];
+  $ok      = 1;
+}
+elseif (isset($virhe_file) and file_exists("/tmp/".basename($virhe_file))) {
+  $userfile  = "/tmp/".basename($virhe_file);
+  $filenimi  = "/tmp/".basename($virhe_file);
+  $ok      = 1;
+  $forceta   = true;
+}
+if (isset($kassatili)) {
+  $query = "SELECT tilino
+            FROM tili
+            WHERE yhtio  = '$kukarow[yhtio]'
+            and tilino = $kassatili";
+  $result = pupe_query($query);
+  
+  if (mysql_num_rows($result) != 1) {
+    $ok == 0;
+  }    
+}
+    
+if ($ok == 1) {
+
+  $fd = fopen($filenimi, "r");
+
+  if (!($fd)) {
+    echo "<font class='message'>Tiedosto '$filenimi' ei auennut!</font>";
+    exit;
+  }
+
+  $tietue = fgets($fd);
+
+  // Tiliote- tai viiteaineisto
+  fclose($fd);
+
+  $aineistotunnus = tallenna_tiliote_viite($filenimi, $forceta);
+
+  if ($aineistotunnus !== false) {
+    
+    $query = "SELECT *
+              FROM tiliotedata
+              WHERE aineisto = {$aineistotunnus}
+              ORDER BY aineisto, tunnus LIMIT 1";
+    $tdataresult = pupe_query($query);
+    $tdatarow = mysql_fetch_assoc($tdataresult);
+    
+    if ($tdatarow['tyyppi'] == 3) {
+      kasittele_factoring_viite($aineistotunnus, $kassatili);
+    }    
+  }
+
+}
+
+if (!$php_cli) {
+  // Palautetaan alkuperäinen kukarow
+  $kukarow = $tiliote_kukarow;
+
+  require "inc/footer.inc";
+}
+else {
+  $ulosputti = ob_get_contents();
+  $ulosputti = str_ireplace(array("<br>", "<br/>", "</tr>"), "\n", $ulosputti);
+  $ulosputti = strip_tags($ulosputti);
+  ob_end_clean();
+
+  echo $ulosputti;
+}
+

--- a/inc/factoring_viitteet_kohdistus.inc
+++ b/inc/factoring_viitteet_kohdistus.inc
@@ -1,0 +1,566 @@
+<?php
+
+//#####################################
+//
+// automaattikohdistetaan viitemaksut
+//
+//#####################################
+
+// Oletuksena asiakkaan maksama summa on oltava täsmälleen oikein
+$Viitemaksujen_kohdistus_sallittu_heitto = 0.01;
+
+if ($yhtiorow["viitemaksujen_kohdistus_sallittu_heitto"] > 0 and $yhtiorow["viitemaksujen_kohdistus_sallittu_heitto"] <= 1.00) {
+  $Viitemaksujen_kohdistus_sallittu_heitto = $yhtiorow["viitemaksujen_kohdistus_sallittu_heitto"];
+}
+
+$maksusopparit = array();
+
+echo "<font class='message'>".t("Automaattikohdistetaan viitemaksuja").": $yhtiorow[nimi]</font><br>\n";
+
+$query = "SELECT
+          suoritus.tunnus suoritunnus,
+          suoritus.yhtio suoriyhtio,
+          suoritus.kirjpvm kirjpvm,
+          suoritus.summa suoritettu,
+          suoritus.kurssi suorituskurssi,
+          suoritus.tilino stilino,
+          suoritus.valkoodi suoritusvaluutta,
+          lasku.summa-lasku.saldo_maksettu laskutettu,
+          lasku.summa_valuutassa-lasku.saldo_maksettu_valuutassa laskutettu_valuutassa,
+          lasku.tunnus laskutunnus,
+          lasku.tapvm tapvm,
+          lasku.summa laskusumma,
+          lasku.summa_valuutassa laskusumma_valuutassa,
+          lasku.kapvm kapvm,
+          lasku.saldo_maksettu saldo_maksettu,
+          lasku.saldo_maksettu_valuutassa saldo_maksettu_valuutassa,
+          lasku.kasumma kasumma,
+          lasku.kasumma_valuutassa kasumma_valuutassa,
+          lasku.valkoodi laskuvaluutta,
+          lasku.vienti_kurssi laskukurssi,
+          lasku.jaksotettu,
+          yhtio.myynninkassaale alennustili,
+          yhtio.myyntisaamiset myyntisaamiset,
+          yhtio.konsernimyyntisaamiset konsernimyyntisaamiset,
+          yhtio.factoringsaamiset factoringsaamiset,
+          yhtio.alv alvtili,
+          yhtio.varasto varasto,
+          yhtio.varastonmuutos varastomuu,
+          yhtio.pyoristys pyoristys,
+          yhtio.valkoodi yhtiovaluutta,
+          yhtio.myynninvaluuttaero valuuttaerotili,
+          yhtio.selvittelytili,
+          yriti.factoring factoring,
+          yriti.oletus_rahatili kassatili,
+          yriti.oletus_selvittelytili,
+          factoring.pankki_tili ftilino,
+          (SELECT count(*) FROM tiliointi WHERE tiliointi.yhtio = suoritus.yhtio AND tiliointi.ltunnus = lasku.tunnus AND tiliointi.tilino in (yhtio.factoringsaamiset, yhtio.myyntisaamiset, yhtio.konsernimyyntisaamiset)) saamisetkpl
+          FROM yhtio
+          JOIN lasku use index (yhtio_tila_mapvm) ON (lasku.yhtio = yhtio.yhtio and lasku.tila = 'U' and lasku.alatila = 'X' and lasku.mapvm = '0000-00-00')
+          JOIN yriti ON (yriti.yhtio = yhtio.yhtio)
+          JOIN suoritus use index (yhtio_viite) ON (suoritus.yhtio = lasku.yhtio and suoritus.viite = lasku.viite and suoritus.valkoodi = lasku.valkoodi and suoritus.tilino = yriti.tilino and suoritus.kohdpvm = '0000-00-00' and suoritus.ltunnus = 0)
+          JOIN maksuehto ON (maksuehto.yhtio = lasku.yhtio and maksuehto.tunnus = lasku.maksuehto)
+          LEFT JOIN factoring ON (factoring.yhtio = lasku.yhtio and factoring.valkoodi = lasku.valkoodi and factoring.tunnus = maksuehto.factoring_id)
+          WHERE yhtio.yhtio = '$kukarow[yhtio]'
+          AND ((yriti.factoring!='' and maksuehto.factoring_id is not null) or (yriti.factoring='' and maksuehto.factoring_id is null))
+          HAVING saamisetkpl > 0 and (
+          (laskuvaluutta  = yhtiovaluutta and (((kapvm >= adddate(kirjpvm,-4) and abs(laskusumma-saldo_maksettu-kasumma-suoritettu)                              < $Viitemaksujen_kohdistus_sallittu_heitto)) or (abs(laskusumma-saldo_maksettu-suoritettu)                       < $Viitemaksujen_kohdistus_sallittu_heitto))) or
+          (laskuvaluutta != yhtiovaluutta and (((kapvm >= adddate(kirjpvm,-4) and abs(laskusumma_valuutassa-saldo_maksettu_valuutassa-kasumma_valuutassa-suoritettu) < $Viitemaksujen_kohdistus_sallittu_heitto)) or (abs(laskusumma_valuutassa-saldo_maksettu_valuutassa-suoritettu) < $Viitemaksujen_kohdistus_sallittu_heitto))) or
+          (laskuvaluutta  = yhtiovaluutta and (((kapvm >= adddate(kirjpvm,-4) and abs(laskusumma-saldo_maksettu-kasumma-suoritettu)                                  < $Viitemaksujen_kohdistus_sallittu_heitto)) or (abs(laskusumma-saldo_maksettu-suoritettu)                       < $Viitemaksujen_kohdistus_sallittu_heitto))) or
+          (laskuvaluutta != yhtiovaluutta and (((kapvm >= adddate(kirjpvm,-4) and abs(laskusumma_valuutassa-saldo_maksettu_valuutassa-kasumma_valuutassa-suoritettu) < $Viitemaksujen_kohdistus_sallittu_heitto)) or (abs(laskusumma_valuutassa-saldo_maksettu_valuutassa-suoritettu) < $Viitemaksujen_kohdistus_sallittu_heitto))))";
+$suorires = pupe_query($query);
+
+while ($row = mysql_fetch_assoc($suorires)) {
+
+  // Setataan kukarow-yhtiö
+  $kukarow["yhtio"] = $row["suoriyhtio"];
+
+  if (strtoupper($row["suoritusvaluutta"]) != strtoupper($row['yhtiovaluutta'])) {
+    $alennus = round(($row["laskutettu_valuutassa"] - $row["suoritettu"]) * $row["suorituskurssi"], 2);
+    $alennus_valuutassa = round($row["laskutettu_valuutassa"] - $row["suoritettu"], 2);
+  }
+  else {
+    $alennus = round($row["laskutettu"] - $row["suoritettu"], 2);
+    $alennus_valuutassa = round($row["laskutettu"] - $row["suoritettu"], 2);
+  }
+
+  // Katsotaan ensin, ettei tätä laskua ole jo suoritettu/maksettu
+  // Eli keissi jossa asiakas maksaa saman laskun kahteen kertaan samassa viiteaineistossa
+  $query = "SELECT tunnus, liitostunnus, maksuehto
+            FROM lasku
+            WHERE yhtio = '$kukarow[yhtio]'
+            and tunnus  = '$row[laskutunnus]'
+            and mapvm   = '0000-00-00'";
+  $lasresult = pupe_query($query);
+
+  // Katsotaan ensin, ettei tätä suoritusta ei oo vielä käytetty
+  // Eli keissi jossa asiakkaalla on useampi lasku samalla summa/viitteellä auki reskontrassa
+  $query = "SELECT tunnus
+            FROM suoritus
+            WHERE yhtio = '$kukarow[yhtio]'
+            and tunnus  = '$row[suoritunnus]'
+            and kohdpvm = '0000-00-00'
+            and ltunnus = 0";
+  $surresult = pupe_query($query);
+
+  if (mysql_num_rows($lasresult) == 1 and mysql_num_rows($surresult) == 1 and ($row["ftilino"] == $row["stilino"] or $row["ftilino"] == "")) {
+    $malaskurow = mysql_fetch_assoc($lasresult);
+
+    // Etsitään asiakas, jos se olisi konsernin jäsen
+    $query = "SELECT konserniyhtio
+              FROM asiakas
+              WHERE yhtio        = '$kukarow[yhtio]'
+              and tunnus         = '$malaskurow[liitostunnus]'
+              and konserniyhtio != ''";
+    $asresult = pupe_query($query);
+
+    if (mysql_num_rows($asresult) > 0) {
+      $row["myyntisaamiset"] = $row["konsernimyyntisaamiset"];
+    }
+
+    // Onko tämä sittenkin factoringia
+    if ($row["factoring"] != "") {
+      $row["myyntisaamiset"] = $row["factoringsaamiset"];
+    }
+
+    // Haetaan myyntisaamistiliöinnin kustannuspaikka
+    $query = "SELECT kustp, kohde, projekti
+              FROM tiliointi
+              WHERE yhtio  = '$kukarow[yhtio]'
+              AND ltunnus  = '$row[laskutunnus]'
+              AND tilino   = '$row[myyntisaamiset]'
+              AND korjattu = ''";
+    $asresult = pupe_query($query);
+    $mskustprow = mysql_fetch_assoc($asresult);
+
+    // Tarkenteet kopsataan alkuperäiseltä tiliöinniltä, mutta jos alkuperäinen tiliöinti on ilman tarkenteita, niin mennään tilin defaulteilla
+    list($kustp_ins, $kohde_ins, $projekti_ins) = kustannuspaikka_kohde_projekti($row["myyntisaamiset"], $mskustprow["kustp"], $mskustprow["kohde"], $mskustprow["projekti"]);
+
+    // Myyntisaamiset
+    $query = "INSERT INTO tiliointi SET
+              yhtio            = '$kukarow[yhtio]',
+              laatija          = 'automaatti',
+              laadittu         = now(),
+              tapvm            = '$row[kirjpvm]',
+              ltunnus          = '$row[laskutunnus]',
+              tilino           = '$row[myyntisaamiset]',
+              kustp            = '{$kustp_ins}',
+              kohde            = '{$kohde_ins}',
+              projekti         = '{$projekti_ins}',
+              summa            = -$row[laskutettu],
+              summa_valuutassa = -$row[laskutettu_valuutassa],
+              valkoodi         = '$row[laskuvaluutta]',
+              selite           = 'Automaattikohdistettu asiakkaan suoritus'";
+    pupe_query($query);
+
+    if (strtoupper($row["suoritusvaluutta"]) != strtoupper($row['yhtiovaluutta'])) {
+      $suoritettu_kassaan = round($row["suoritettu"] * $row["suorituskurssi"], 2);
+      $suoritettu_kassaan_valuutassa = $row["suoritettu"];
+    }
+    else {
+      $suoritettu_kassaan = $row["suoritettu"];
+      $suoritettu_kassaan_valuutassa = $row["suoritettu"];
+    }
+
+    list($kustp_ins, $kohde_ins, $projekti_ins) = kustannuspaikka_kohde_projekti($kassatili);
+
+    // Kassatili = oletusrahatili, joka factoring-viitteille annetaan käyttöliittymästä
+    $query = "INSERT INTO tiliointi SET
+              yhtio            = '$kukarow[yhtio]',
+              laatija          = 'automaatti',
+              laadittu         = now(),
+              tapvm            = '$row[kirjpvm]',
+              ltunnus          = '$row[laskutunnus]',
+              tilino           = '$kassatili',
+              kustp            = '{$kustp_ins}',
+              kohde            = '{$kohde_ins}',
+              projekti         = '{$projekti_ins}',
+              summa            = $suoritettu_kassaan,
+              summa_valuutassa = '$suoritettu_kassaan_valuutassa',
+              valkoodi         = '$row[suoritusvaluutta]',
+              selite           = 'Automaattikohdistettu asiakkaan suoritus'";
+    pupe_query($query);
+
+    // Mahdollinen kassa-alennus
+    if ($alennus != 0) {
+
+      // Kassa-alessa on huomioitava alv, joka voi olla useita vientejä
+      $totkasumma = 0;
+      $totkasumma_valuutassa = 0;
+
+      // Etsitään myynti-tiliöinnit
+      $query = "SELECT tiliointi.summa, tiliointi.vero, tiliointi.kustp, tiliointi.kohde, tiliointi.projekti, tiliointi.summa_valuutassa, tiliointi.valkoodi
+                FROM tiliointi use index (tositerivit_index)
+                JOIN tili ON (tiliointi.yhtio = tili.yhtio and tiliointi.tilino = tili.tilino)
+                LEFT JOIN taso ON (tili.yhtio = taso.yhtio and tili.ulkoinen_taso = taso.taso and taso.tyyppi = 'U')
+                WHERE tiliointi.yhtio  = '$kukarow[yhtio]'
+                AND tiliointi.ltunnus  = '$row[laskutunnus]'
+                AND tiliointi.tapvm    = '$row[tapvm]'
+                AND abs(tiliointi.summa) <> 0
+                AND tiliointi.tilino   not in ('$row[myyntisaamiset]','$row[konsernimyyntisaamiset]','$row[alvtili]','$row[varasto]','$row[varastomuu]','$row[pyoristys]','$row[alennustili]','$row[factoringsaamiset]')
+                AND tiliointi.korjattu = ''
+                AND (taso.kayttotarkoitus is null or taso.kayttotarkoitus  in ('','M'))";
+      $tilres = pupe_query($query);
+
+      if (mysql_num_rows($tilres) == 0) {
+
+        list($kustp_ins, $kohde_ins, $projekti_ins) = kustannuspaikka_kohde_projekti($row["alennustili"]);
+
+        $query = "INSERT INTO tiliointi
+                  SET yhtio      = '$kukarow[yhtio]',
+                  laatija          = 'automaatti',
+                  laadittu         = now(),
+                  tapvm            = '$row[kirjpvm]',
+                  ltunnus          = '$row[laskutunnus]',
+                  tilino           = '$row[alennustili]',
+                  kustp            = '{$kustp_ins}',
+                  kohde            = '{$kohde_ins}',
+                  projekti         = '{$projekti_ins}',
+                  summa            = '$alennus',
+                  summa_valuutassa = '$alennus_valuutassa',
+                  valkoodi         = '$row[suoritusvaluutta]',
+                  vero             = 0,
+                  selite           = 'Automaattikohdistettu asiakkaan suoritus (alv ongelma)'";
+        pupe_query($query);
+      }
+      else {
+
+        $aputunnus = 0;
+
+        while ($tiliointirow = mysql_fetch_assoc($tilres)) {
+          $alv       = 0;
+          $alv_valuutassa = 0;
+
+          $summa         = round($tiliointirow["summa"] * -1 * (1+$tiliointirow["vero"]/100) / $row["laskusumma"] * $alennus, 2);
+          $summa_valuutassa = round($tiliointirow["summa_valuutassa"] * -1 * (1+$tiliointirow["vero"]/100) / $row["laskusumma_valuutassa"] * $alennus_valuutassa, 2);
+
+          if ($tiliointirow["vero"] != 0) {
+            // Netotetaan alvi
+            // $alv:ssa on alennuksen alv:n maara
+            $alv = round($summa - $summa / (1 + ($tiliointirow["vero"] / 100)), 2);
+            $alv_valuutassa = round($summa_valuutassa - $summa_valuutassa / (1 + ($tiliointirow["vero"]/100)), 2);
+
+            //$summa on alviton alennus
+            $summa -= $alv;
+            $summa_valuutassa -= $alv_valuutassa;
+          }
+
+          // Kuinka paljon olemme kumulatiivisesti tiliöineet
+          $totkasumma += $summa + $alv;
+          $totkasumma_valuutassa += $summa_valuutassa + $alv_valuutassa;
+
+          // Tarkenteet kopsataan alkuperäiseltä tiliöinniltä, mutta jos alkuperäinen tiliöinti on ilman tarkenteita, niin mennään tilin defaulteilla
+          list($kustp_ins, $kohde_ins, $projekti_ins) = kustannuspaikka_kohde_projekti($row["alennustili"], $tiliointirow["kustp"], $tiliointirow["kohde"], $tiliointirow["projekti"]);
+
+          // Lisätään myynnin kassa-alennuskirjaus ilman veroa
+          $query = "INSERT INTO tiliointi
+                    SET yhtio      = '$kukarow[yhtio]',
+                    laatija          = 'automaatti',
+                    laadittu         = now(),
+                    tilino           = '$row[alennustili]',
+                    kustp            = '{$kustp_ins}',
+                    kohde            = '{$kohde_ins}',
+                    projekti         = '{$projekti_ins}',
+                    tapvm            = '$row[kirjpvm]',
+                    ltunnus          = '$row[laskutunnus]',
+                    summa            = '$summa',
+                    summa_valuutassa = '$summa_valuutassa',
+                    vero             = '$tiliointirow[vero]',
+                    valkoodi         = '$row[suoritusvaluutta]',
+                    selite           = 'Automaattikohdistettu asiakkaan suoritus (Kassa-Alennus)'";
+          pupe_query($query);
+          $aputunnus = mysql_insert_id($GLOBALS["masterlink"]);
+
+          // Etsitään korjattava vienti
+          if ($alv != 0) {
+            //Kirjataan myös kassa-alennuksen arvonlisäverot
+            $query = "INSERT into tiliointi
+                      SET yhtio       = '$kukarow[yhtio]',
+                      ltunnus          = '$row[laskutunnus]',
+                      tilino           = '$row[alvtili]',
+                      kustp            = 0,
+                      kohde            = 0,
+                      projekti         = 0,
+                      tapvm            = '$row[kirjpvm]',
+                      summa            = '$alv',
+                      summa_valuutassa = '$alv_valuutassa',
+                      valkoodi         = '$row[suoritusvaluutta]',
+                      vero             = 0,
+                      selite           = 'Automaattikohdistettu asiakkaan suoritus (Kassa-alennuksen alv)',
+                      lukko            = '1',
+                      laatija          = 'automaatti',
+                      laadittu         = now(),
+                      aputunnus        = '$aputunnus'";
+            pupe_query($query);
+          }
+        }
+
+        //Hoidetaan mahdolliset pyöristykset
+        $heitto = round($totkasumma - $alennus, 2);
+        $heitto_valuutassa = round($totkasumma_valuutassa - $alennus_valuutassa, 2);
+
+        if (abs($heitto) >= 0.01) {
+          $query = "UPDATE tiliointi SET
+                    summa            = summa - $heitto,
+                    summa_valuutassa = summa_valuutassa - $heitto_valuutassa
+                    WHERE tunnus     = '$aputunnus'
+                    and yhtio        = '$kukarow[yhtio]'";
+          pupe_query($query);
+
+          $aputunnus = 0;
+        }
+      }
+    }
+
+    // tuliko valuuttaeroa?
+    if (strtoupper($row["suoritusvaluutta"]) != strtoupper($row['yhtiovaluutta'])) {
+
+      $valero = round($row["laskutettu"] - $suoritettu_kassaan - $alennus, 2);
+
+      if (round($valero, 2) != 0) {
+
+        $totvesumma = 0;
+
+        // Etsitään myynti-tiliöinnit
+        $query = "SELECT tiliointi.summa, tiliointi.vero, tiliointi.kustp, tiliointi.kohde, tiliointi.projekti, tiliointi.summa_valuutassa, tiliointi.valkoodi
+                  FROM tiliointi use index (tositerivit_index)
+                  JOIN tili ON (tiliointi.yhtio = tili.yhtio and tiliointi.tilino = tili.tilino)
+                  LEFT JOIN taso ON (tili.yhtio = taso.yhtio and tili.ulkoinen_taso = taso.taso and taso.tyyppi = 'U')
+                  WHERE tiliointi.yhtio  = '$kukarow[yhtio]'
+                  AND tiliointi.ltunnus  = '$row[laskutunnus]'
+                  AND tiliointi.tapvm    = '$row[tapvm]'
+                  AND abs(tiliointi.summa) <> 0
+                  AND tiliointi.tilino   not in ('$row[myyntisaamiset]','$row[konsernimyyntisaamiset]','$row[alvtili]','$row[varasto]','$row[varastomuu]','$row[pyoristys]','$row[alennustili]','$row[factoringsaamiset]')
+                  AND tiliointi.korjattu = ''
+                  AND (taso.kayttotarkoitus is null or taso.kayttotarkoitus  in ('','M'))";
+        $tilres = pupe_query($query);
+
+        if (mysql_num_rows($tilres) == 0) {
+
+          list($kustp_ins, $kohde_ins, $projekti_ins) = kustannuspaikka_kohde_projekti($row["valuuttaerotili"]);
+
+          $query = "INSERT INTO tiliointi SET
+                    yhtio    = '$kukarow[yhtio]',
+                    laatija  = 'automaatti',
+                    laadittu = now(),
+                    tapvm    = '$row[kirjpvm]',
+                    ltunnus  = '$row[laskutunnus]',
+                    tilino   = '$row[valuuttaerotili]',
+                    kustp    = '{$kustp_ins}',
+                    kohde    = '{$kohde_ins}',
+                    projekti = '{$projekti_ins}',
+                    summa    = $valero,
+                    selite   = 'Automaattikohdistettu asiakkaan suoritus'";
+          pupe_query($query);
+        }
+        else {
+          while ($tiliointirow = mysql_fetch_assoc($tilres)) {
+
+            // Kuinka paljon on tämän viennin osuus
+            $summa = round($tiliointirow['summa'] * (1+$tiliointirow['vero']/100) / $row["laskutettu"] * $vesumma, 2);
+
+            // Tarkenteet kopsataan alkuperäiseltä tiliöinniltä, mutta jos alkuperäinen tiliöinti on ilman tarkenteita, niin mennään tilin defaulteilla
+            list($kustp_ins, $kohde_ins, $projekti_ins) = kustannuspaikka_kohde_projekti($row["valuuttaerotili"], $tiliointirow["kustp"], $tiliointirow["kohde"], $tiliointirow["projekti"]);
+
+            $query = "INSERT INTO tiliointi SET
+                      yhtio    = '$kukarow[yhtio]',
+                      laatija  = 'automaatti',
+                      laadittu = now(),
+                      tapvm    = '$row[kirjpvm]',
+                      ltunnus  = '$row[laskutunnus]',
+                      tilino   = '$row[valuuttaerotili]',
+                      kustp    = '{$kustp_ins}',
+                      kohde    = '{$kohde_ins}',
+                      projekti = '{$projekti_ins}',
+                      summa    = $summa,
+                      selite   = 'Automaattikohdistettu asiakkaan suoritus'";
+            pupe_query($query);
+            $isa = mysql_insert_id($GLOBALS["masterlink"]);
+
+            $totvesumma += $summa;
+          }
+
+          //Hoidetaan mahdolliset pyöristykset
+          if ($totvesumma != $vesumma) {
+            $query = "UPDATE tiliointi
+                      SET summa = summa - $totvesumma + $vesumma
+                      WHERE tunnus = '$isa'
+                      and yhtio    = '$kukarow[yhtio]'";
+            pupe_query($query);
+          }
+        }
+      }
+    }
+
+    // Merkitään lasku maksetuksi
+    $query = "UPDATE lasku
+              SET mapvm = '$row[kirjpvm]',
+              saldo_maksettu = 0,
+              saldo_maksettu_valuutassa = 0
+              WHERE yhtio = '$kukarow[yhtio]'
+              and tunnus  = '$row[laskutunnus]'";
+    pupe_query($query);
+
+    // Vapautetaan holdissa olevat tilaukset, jos niillä on maksupositioita ja ennakkolaskut ovat maksettu
+    // Holdissa olevat tilaukset ovat tilassa N B
+    if ($yhtiorow['maksusopimus_toimitus'] == 'X' and $row["jaksotettu"] < 0) {
+      $query = "SELECT tunnus
+                FROM lasku
+                WHERE yhtio = '{$kukarow['yhtio']}'
+                AND tunnus  = '".($row['jaksotettu'] * -1)."'
+                AND tila    = 'N'
+                AND alatila = 'B'";
+      $pos_chk_result = pupe_query($query);
+
+      if (mysql_num_rows($pos_chk_result)) {
+        $maksusopparit[] = $row['jaksotettu'] * -1;
+      }
+    }
+
+    // Ja suoritus kirjatuksi
+    $query = "UPDATE suoritus
+              SET kohdpvm = '$row[kirjpvm]',
+              ltunnus     = '$row[laskutunnus]'
+              WHERE yhtio = '$kukarow[yhtio]'
+              and tunnus  = '$row[suoritunnus]'";
+    pupe_query($query);
+
+    // ja kohdistusrelaatio
+    $kohdistus_qry = "INSERT INTO suorituksen_kohdistus SET
+                      yhtio          = '{$kukarow['yhtio']}',
+                      suoritustunnus = '{$row['suoritunnus']}',
+                      laskutunnus    = '{$row['laskutunnus']}',
+                      kohdistuspvm   = NOW(),
+                      kirjauspvm     = '{$row['tapvm']}'";
+    pupe_query($kohdistus_qry);
+  }
+}
+
+//####################################
+//
+// siirretään feilanneet laskuiksi...
+//
+//####################################
+
+echo "<font class='message'>".t("Tehdään kohdistamattomista laskuja").": $yhtiorow[nimi]</font><br>\n";
+
+$query = "SELECT
+          suoritus.tunnus tunnus,
+          suoritus.yhtio yhtio,
+          suoritus.summa summa,
+          suoritus.kirjpvm,
+          suoritus.valkoodi suoritusvaluutta,
+          suoritus.kurssi suorituskurssi,
+          suoritus.nimi_maksaja,
+          yhtio.myyntisaamiset,
+          yhtio.valkoodi yhtiovaluutta,
+          yhtio.factoringsaamiset,
+          yhtio.selvittelytili,
+          yriti.factoring,
+          yriti.oletus_rahatili,
+          yriti.oletus_selvittelytili
+          FROM yhtio
+          JOIN yriti ON (yriti.yhtio = yhtio.yhtio)
+          JOIN suoritus ON (suoritus.yhtio = yhtio.yhtio AND suoritus.tilino = yriti.tilino AND suoritus.kohdpvm = '0000-00-00' AND suoritus.ltunnus = 0)
+          WHERE yhtio.yhtio = '$kukarow[yhtio]'
+          ORDER BY yhtio";
+$suorires = pupe_query($query);
+
+$laskut = array();
+
+while ($row = mysql_fetch_assoc($suorires)) {
+
+  if (strtoupper($row["suoritusvaluutta"]) != strtoupper($row['yhtiovaluutta'])) {
+    $summa = round($row["summa"] * $row["suorituskurssi"], 2);
+    $summa_valuutassa = $row["summa"];
+  }
+  else {
+    $summa = $row["summa"];
+    $summa_valuutassa = $row["summa"];
+  }
+
+  if (!isset($laskut[$row["yhtio"]])) {
+    $query = "INSERT into lasku
+              SET yhtio   = '$kukarow[yhtio]',
+              tapvm      = now(),
+              tila       = 'X',
+              laatija    = 'viitesiirrot',
+              luontiaika = now()";
+    pupe_query($query);
+
+    $laskut[$row["yhtio"]] = mysql_insert_id($GLOBALS["masterlink"]);
+  }
+
+  if ($laskut[$row["yhtio"]] > 0) {
+
+    // Onko tämä sittenkin factoringia
+    if ($row["factoring"] != "") {
+      $row["myyntisaamiset"] = $row["factoringsaamiset"];
+    }
+
+    // Jos meillä on oletus selvittelytili niin pistetään aina sinne tilille
+    if (!empty($row["oletus_selvittelytili"]) and $row["oletus_selvittelytili"] != $row["selvittelytili"]) {
+      $row["myyntisaamiset"] = $row["oletus_selvittelytili"];
+    }
+
+    $maksaja_espattu = mysql_real_escape_string($row["nimi_maksaja"]);
+
+    list($kustp_ins, $kohde_ins, $projekti_ins) = kustannuspaikka_kohde_projekti($row["myyntisaamiset"]);
+
+    // Myyntisaamiset tai selvittely
+    $query = "INSERT INTO tiliointi SET
+              yhtio            = '$kukarow[yhtio]',
+              laatija          = 'automaattikohdistus',
+              laadittu         = now(),
+              tapvm            = '$row[kirjpvm]',
+              ltunnus          = '{$laskut[$row["yhtio"]]}',
+              tilino           = '$row[myyntisaamiset]',
+              kustp            = '{$kustp_ins}',
+              kohde            = '{$kohde_ins}',
+              projekti         = '{$projekti_ins}',
+              summa            = -$summa,
+              summa_valuutassa = -$summa_valuutassa,
+              valkoodi         = '$row[suoritusvaluutta]',
+              selite           = '$maksaja_espattu maksoi viitteellä väärin',
+              lukko            = '1'";
+    pupe_query($query);
+    $tlast_id = mysql_insert_id($GLOBALS["masterlink"]);
+
+    list($kustp_ins, $kohde_ins, $projekti_ins) = kustannuspaikka_kohde_projekti($kassatili);
+
+    // Kassatili
+    $query = "INSERT INTO tiliointi SET
+              yhtio            = '$kukarow[yhtio]',
+              laatija          = 'automaattikohdistus',
+              laadittu         = now(),
+              tapvm            = '$row[kirjpvm]',
+              ltunnus          = '{$laskut[$row["yhtio"]]}',
+              tilino           = '$kassatili',
+              kustp            = '{$kustp_ins}',
+              kohde            = '{$kohde_ins}',
+              projekti         = '{$projekti_ins}',
+              summa            = $summa,
+              summa_valuutassa = $summa_valuutassa,
+              valkoodi         = '$row[suoritusvaluutta]',
+              selite           = '$maksaja_espattu maksoi viitteellä väärin',
+              aputunnus        = '$tlast_id',
+              lukko            = '1'";
+    pupe_query($query);
+
+    $query = "UPDATE suoritus
+              SET ltunnus = '$tlast_id'
+              WHERE yhtio = '$kukarow[yhtio]'
+              and tunnus  = '$row[tunnus]'";
+    pupe_query($query);
+  }
+  else {
+    echo "<font class='error'>VIRHE: Tositteen otsikkoa ei saatu luotua!</font><br>\n";
+  }
+}
+
+// Vapautetaan holdissa oleva tilaus, jos/kun ennakkolaskut on maksettu
+if (count($maksusopparit)) {
+  foreach ($maksusopparit as $soppari) {
+    vapauta_maksusopimus($soppari);
+  }
+}


### PR DESCRIPTION
Sisäänluvussa voidaan antaa kirjanpidon rahatili, jolle viitemaksut kirjataan oikean pankkitilin oletusrahatilin sijaan