### PR TITLE
Pupeshop synonyymit

### DIFF
--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -340,6 +340,8 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "PIIRI_ALENNUS") $ulos .= "<option value='PIIRI_ALENNUS' {$avain_sel['PIIRI_ALENNUS']}>".t("Piiriin sidottu hinnoittelu")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "MESSENGER_RYHMA") $ulos .= "<option value='MESSENGER_RYHMA' {$avain_sel['MESSENGER_RYHMA']}>".t("Messenger käyttäjäryhmä")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "VALM_FAKTA") $ulos .= "<option value='VALM_FAKTA' {$avain_sel['VALM_FAKTA']}>".t("Valmistuslistan faktan fonttikoko")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "PSHOP_SYNONYMS") $ulos .= "<option value='PSHOP_SYNONYMS' {$avain_sel['PSHOP_SYNONYMS']}>".t("Pupeshop tuotehaun synonyymit")."</option>";
+
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
   if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Verkkokaupan avainsanat")."'>";
@@ -1068,6 +1070,11 @@ if (($avain_sel["OSASTO"] == "SELECTED"
   $jatko = 0;
 }
 
+if (($avain_sel["PSHOP_SYNONYMS"] == "SELECTED") and $_selitetark) {
+  $ulos = "<td><textarea rows=10 cols=50 name='$nimi'>$trow[$i]</textarea></td>";
+  $jatko = 0;
+}
+
 if (($avain_sel['LASKUTUS_SAATE'] == "SELECTED" or $avain_sel['PALAUTUS_SAATE'] == "SELECTED" or $avain_sel['KAANTALVVIESTI'] == "SELECTED") and $_selitetark_2) {
   $ulos = "<td><textarea rows=30 cols=50 name='$nimi'>$trow[$i]</textarea></td>";
   $jatko = 0;
@@ -1677,7 +1684,7 @@ if ($avain_sel["VALM_FAKTA"] == "SELECTED") {
 
     $sel = array();
     $sel[$trow[$i]] = "SELECTED";
-    
+
     $ulos = "<td><select name = '$nimi'>";
     $ulos .= "<option value = '8' $sel[8]>".'8'."</option>";
     $ulos .= "<option value = '6' $sel[6]>".'6'."</option>";
@@ -1689,7 +1696,7 @@ if ($avain_sel["VALM_FAKTA"] == "SELECTED") {
 
     $sel = array();
     $sel[$trow[$i]] = "SELECTED";
-    
+
     $ulos = "<td><select name = '$nimi'>";
     $ulos .= "<option value = '12' $sel[12]>".'12'."</option>";
     $ulos .= "<option value = '10' $sel[10]>".'10'."</option>";


### PR DESCRIPTION
Voidaan tehdä avainsanoissa synonyymejä Pupeshopin tuotehakuun. Esim synonyymejä voisivat olla fillari ja polkupyörä.

Selite voisi olla Polkupyörä ja selitetark tekstilaatikkoon synonyymit pilkulla eroteltuna, mikäli useita.