### PR TITLE
Editilaus hyväksyttäväksi, jos virheitä

### DIFF
--- a/tilauskasittely/editilaus_in.inc
+++ b/tilauskasittely/editilaus_in.inc
@@ -50,7 +50,7 @@ if ($php_cli) {
     $edi_tyyppi = 'woo';
   }
 
-  // tunnistetaan woo commerce -tyyppinen k‰sittely tiedostonimest‰
+  // tunnistetaan apix-edi -tyyppinen k‰sittely tiedostonimest‰
   if ($edi_tyyppi == 'futursoft' and preg_match("/^apix_/", $verkkokauppa_filename) === 1) {
     $edi_tyyppi = 'apix_edi';
   }
@@ -321,7 +321,7 @@ if ($edi_tyyppi == "futursoft") {
 elseif ($edi_tyyppi == "apix_edi") {
   $edi_subj = "Sis‰‰ntuleva Apix-EDI -tilaus";
   $edi_laatija = "Apix";
-  $edi_tyyppi == "futursoft";
+  $edi_tyyppi = "futursoft";
 }
 elseif ($edi_tyyppi == "ahkio") {
   $edi_subj = "Sis‰‰ntuleva Ahkio -tilaus";

--- a/tilauskasittely/editilaus_in.inc
+++ b/tilauskasittely/editilaus_in.inc
@@ -50,6 +50,11 @@ if ($php_cli) {
     $edi_tyyppi = 'woo';
   }
 
+  // tunnistetaan woo commerce -tyyppinen käsittely tiedostonimestä
+  if ($edi_tyyppi == 'futursoft' and preg_match("/^apix_/", $verkkokauppa_filename) === 1) {
+    $edi_tyyppi = 'apix_edi';
+  }
+
   // Pupeasennuksen root
   $pupe_root_polku = dirname(dirname(__FILE__));
 }
@@ -199,6 +204,7 @@ $edi_kommentti                = "";
 $editilaus_alatila            = "";
 $editilaus_eilahetetta        = "";
 $editilaus_hyvaksyttava       = "";
+$editilaus_hyvaksyttavaksi    = "";
 $editilaus_kassalipas         = "";
 $editilaus_liitetiedosto      = "";
 $editilaus_loppuhinta         = "";
@@ -311,6 +317,11 @@ $editilaus_hakemisto = dirname(realpath($filename));
 if ($edi_tyyppi == "futursoft") {
   $edi_subj = "Sisääntuleva Futursoft-tilaus";
   $edi_laatija = "FuturSoft";
+}
+elseif ($edi_tyyppi == "apix_edi") {
+  $edi_subj = "Sisääntuleva Apix-EDI -tilaus";
+  $edi_laatija = "Apix";
+  $edi_tyyppi == "futursoft";
 }
 elseif ($edi_tyyppi == "ahkio") {
   $edi_subj = "Sisääntuleva Ahkio -tilaus";
@@ -2438,6 +2449,18 @@ while ($tietue = fgets($fd)) {
             $var = "H";
           }
 
+          // salasanat.php:ssä ylläpidettävä muuttuja, jolla pakotetaan
+          // tilaus hyväksyttäväksi jos tuotetta ei löydy tai myytävissä loppu
+          if ($edi_tyyppi != "magento" and isset($editilaus_hyvaksyttavaksi_jos_virhe) and $editilaus_hyvaksyttavaksi_jos_virhe == "JOO") {
+
+            list($chk_saldo, $chk_hyllyssa, $chk_myytavissa, $chk_true) = saldo_myytavissa($tuoteno, "", $verkkokauppavarasto);
+
+            if ($chk_myytavissa < $kpl) {
+              $editilaus_hyvaksyttavaksi = "JOO";
+              $editilaus_hyvaksyttava = "JOO";
+            }
+          }
+
           // jos tullaan magentosta ja hinta on tiedossa ja kyseessä on rahtikulu, niin uskalletaan luottaa magenton antamaan hintaan
           if ($edi_tyyppi == "magento" and ((isset($verkkokauppa_hinnatedifailista) and $verkkokauppa_hinnatedifailista == "JOO") or strtolower($tuoteno) == strtolower($yhtiorow['rahti_tuotenumero'])) and $editilaus_hinta > 0) {
             $hinta = $editilaus_hinta;
@@ -2606,6 +2629,13 @@ while ($tietue = fgets($fd)) {
 
       } // end jos tuote on löydetty oikein
       else {
+
+        // salasanat.php:ssä ylläpidettävä muuttuja, jolla pakotetaan
+        // tilaus hyväksyttäväksi jos tuotetta ei löydy tai myytävissä loppu
+        if ($edi_tyyppi != "magento" and isset($editilaus_hyvaksyttavaksi_jos_virhe) and $editilaus_hyvaksyttavaksi_jos_virhe == "JOO") {
+          $editilaus_hyvaksyttavaksi = "JOO";
+          $editilaus_hyvaksyttava = "JOO";
+        }
 
         if ($tuoteerror == 2) {
           // Tilausrivin systeemikommentti
@@ -2813,6 +2843,17 @@ while ($tietue = fgets($fd)) {
     }
     elseif ($editilaus_otsikko_ok == "HYVAKSYTTAVAKSI") {
       $edi_ulos .= "\n".t("Merkittiin tilaus hyväksyttäväksi").": {$laskurow['tunnus']}.\n\n";
+
+      // merkitään otsikko hyväksyntäjonoon, ei ole
+      // välttämättä alunperin mennyt
+      if ($editilaus_hyvaksyttavaksi == "JOO") {
+        $query = "UPDATE lasku SET
+                  alatila     = 'F'
+                  WHERE yhtio = '$kukarow[yhtio]'
+                  AND tunnus  = '$id'";
+        pupe_query($query);
+      }
+
     }
     elseif ($editilaus_otsikko_ok == "HYVAKJONOON") {
       $edi_ulos .= "\n".t("Merkittiin tilaus hyväksyttäväksi").": {$laskurow['tunnus']}.\n\n";
@@ -2841,6 +2882,8 @@ while ($tietue = fgets($fd)) {
     $edi_kommentti                = "";
     $editilaus_alatila            = "";
     $editilaus_eilahetetta        = "";
+    $editilaus_hyvaksyttava       = "";
+    $editilaus_hyvaksyttavaksi    = "";
     $editilaus_kassalipas         = "";
     $editilaus_liitetiedosto      = "";
     $editilaus_loppuhinta         = "";

--- a/tilauskasittely/tilaus_in.php
+++ b/tilauskasittely/tilaus_in.php
@@ -70,6 +70,14 @@ if (move_uploaded_file($_FILES['userfile']['tmp_name'], $filename)) {
     echo "</pre>";
   }
 
+  if ($tyyppi == 'apix_edi') {
+    // tarvitaan $filename
+    echo "<pre>";
+    $edi_tyyppi = "apix_edi";
+    require "editilaus_in.inc";
+    echo "</pre>";
+  }
+
   if ($tyyppi == 'magento' or $tyyppi == 'presta' or $tyyppi == 'ahkio' or $tyyppi == 'woo') {
     // tarvitaan $filename
     echo "<pre>";
@@ -119,6 +127,7 @@ else {
          <option value='edi'>".t("Editilaus")."</option>
          <option value='ahkio'>Ahkio</option>
          <option value='futursoft'>Futursoft</option>
+         <option value='apix_edi'>Apix-EDI</option>
          <option value='magento'>Magento</option>
          <option value='presta'>PrestaShop</option>
          <option value='woo'>WooCommerce</option>


### PR DESCRIPTION
Voidaan asettaa salasanat.php:hen muuttuja + arvo $editilaus_hyvaksyttavaksi_jos_virhe = "JOO", joka pistää jatkossa editilaukset (mm futursoft ja apix_edi, ei kuitenkaan mm magentoa) hyväksyttäväksi Pupesoftin hyväksyttävät tilaukset -ohjelmaan, mikäli tilauksella on seuraavia asioita:

- tilattiin tuntematonta tuotetta
- myytävissä määrä ei riittänyt

Jos millä tahansa tilauksen rivillä esiintyy jompikumpi, niin tilaus menee hyväksyttäväksi.