### PR TITLE
Lähete ilman ytunnusta

### DIFF
--- a/tilauskasittely/tulosta_lahete.inc
+++ b/tilauskasittely/tulosta_lahete.inc
@@ -418,16 +418,16 @@ if (!function_exists('alku_lahete')) {
       if ($laskurow['rahtivapaa'] == 'o' and onko_rahtituote_syotetty($laskurow) == 0) {
         $rahtivapaa = "Rahtivapaa";
       }
-      
+
       if ($tyyppi == "TILAUSVAHVISTUS") {
         if ($laskurow["osatoimitus"] == 'o') {
           $kokonaistoimitus = '/ Kokonaistoimitus';
         }
         else  {
           $kokonaistoimitus = '';
-        } 
+        }
       }
-  
+
       if ($extranet_tilausvahvistus != 1) {
         if ($laskurow["kohdistettu"] == "K" or $lahetetyyppi_avainsana == 1) {
           // Käytetään LÄHETTÄJÄN rahtisopimusta, EI näytetä lähettäjän sopparinumeroa.
@@ -3675,14 +3675,14 @@ if (!function_exists('loppu_lahete')) {
       $pdf->draw_text(257, 35, $y_www, $thispage, $pieni);
 
       $piilota_tiedot = (isset($lahete_piilota_ytunnus_toimipaikka));
-      $piilota_tiedot = ($piilota_tiedot and in_array($laskurow["yhtio_toimipaikka"], $lahete_piilota_ytunnus_toimipaikka);
+      $piilota_tiedot = ($piilota_tiedot and in_array($laskurow["yhtio_toimipaikka"], $lahete_piilota_ytunnus_toimipaikka));
 
       if (!$piilota_tiedot) {
-        
+
         $pdf->draw_text(404, 55, t("Y-tunnus", $kieli).":", $thispage, $pieni);
-        
+
         if ($yhtiorow["maa"] == 'EE') {
-          $pdf->draw_text(444, 55, tulosta_ytunnus($yhtiorow["ytunnus"], $yhtiorow["maa"], $laskurow["vienti"]), $thispage, $ pieni);
+          $pdf->draw_text(444, 55, tulosta_ytunnus($yhtiorow["ytunnus"], $yhtiorow["maa"], $laskurow["vienti"]), $thispage, $pieni);
         }
         else {
           $pdf->draw_text(444, 55, tulosta_ytunnus($y_vatnumero, $y_maa, $laskurow["vienti"]), $thispage, $pieni);

--- a/tilauskasittely/tulosta_lahete.inc
+++ b/tilauskasittely/tulosta_lahete.inc
@@ -3516,7 +3516,7 @@ if (!function_exists('rivi_viivakoodi_lahete_ean13')) {
 
 if (!function_exists('loppu_lahete')) {
   function loppu_lahete($params) {
-    global $kukarow, $yhtiorow;
+    global $kukarow, $yhtiorow, $lahete_piilota_ytunnus_toimipaikka;
 
     if (skippa_lahete_pdf($params)) {
       // Luodaan palautettavat
@@ -3674,16 +3674,24 @@ if (!function_exists('loppu_lahete')) {
       $pdf->draw_text(217, 35, t("Web", $kieli).":", $thispage, $pieni);
       $pdf->draw_text(257, 35, $y_www, $thispage, $pieni);
 
-      $pdf->draw_text(404, 55, t("Y-tunnus", $kieli).":", $thispage, $pieni);
-      if ($yhtiorow["maa"] == 'EE') {
-        $pdf->draw_text(444, 55, tulosta_ytunnus($yhtiorow["ytunnus"], $yhtiorow["maa"], $laskurow["vienti"]), $thispage, $pieni);
+      $piilota_tiedot = (isset($lahete_piilota_ytunnus_toimipaikka));
+      $piilota_tiedot = ($piilota_tiedot and in_array($laskurow["yhtio_toimipaikka"], $lahete_piilota_ytunnus_toimipaikka);
+
+      if (!$piilota_tiedot) {
+        
+        $pdf->draw_text(404, 55, t("Y-tunnus", $kieli).":", $thispage, $pieni);
+        
+        if ($yhtiorow["maa"] == 'EE') {
+          $pdf->draw_text(444, 55, tulosta_ytunnus($yhtiorow["ytunnus"], $yhtiorow["maa"], $laskurow["vienti"]), $thispage, $ pieni);
+        }
+        else {
+          $pdf->draw_text(444, 55, tulosta_ytunnus($y_vatnumero, $y_maa, $laskurow["vienti"]), $thispage, $pieni);
+        }
+
+        $pdf->draw_text(404, 45, t("Kotipaikka", $kieli).":", $thispage, $pieni);
+        $pdf->draw_text(444, 45, $y_kotipaikka, $thispage, $pieni);
+        $pdf->draw_text(404, 35, t("Alv.rek", $kieli), $thispage, $pieni);
       }
-      else {
-        $pdf->draw_text(444, 55, tulosta_ytunnus($y_vatnumero, $y_maa, $laskurow["vienti"]), $thispage, $pieni);
-      }
-      $pdf->draw_text(404, 45, t("Kotipaikka", $kieli).":", $thispage, $pieni);
-      $pdf->draw_text(444, 45, $y_kotipaikka, $thispage, $pieni);
-      $pdf->draw_text(404, 35, t("Alv.rek", $kieli), $thispage, $pieni);
     }
 
     if ($tots == 1 and $summa != 0) {


### PR DESCRIPTION
Voidaan asettaa salasanat.php:ssä tietty toimipaikka semmoiseksi, ettei kyseisen toimipaikan tilausvahvistukselle ja lähetteelle tulosteta lähete-pohjan footerissa olevaa ytunnusta ja kotipaikkaa.

Esim $lahete_piilota_ytunnus_toimipaikka = array(1); jossa 1 on valitun toimipaikan tunnus.