### PR TITLE
Rahtimaksujen käsittely toisessa valuutassa

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -11617,6 +11617,11 @@ if (!function_exists("hae_rahtimaksu")) {
       $hirow = mysql_fetch_assoc($rares);
       $ale_kaikki_array = array();
 
+      // Rahtimaksut ovat yhtion valuutassa, se pit‰‰ muuttaa laskun valuuttaan
+      if ($laskurow["valkoodi"] != '' and trim(strtoupper($laskurow["valkoodi"])) != trim(strtoupper($yhtiorow["valkoodi"]))) {
+        $hirow['rahtihinta'] = round(laskuval($hirow['rahtihinta'], $laskurow["vienti_kurssi"]), 2);
+      }
+
       if ($rahtituoteno_toimitustavalta) {
         // Etsit‰‰n spessuhintaa/alennuksia jos toimitustavan takana oli oma rahti_tuotenumero
         list($lis_hinta, $lis_netto, $lis_ale_kaikki, $alehinta_alv, $alehinta_val) = alehinta($laskurow, $rahti_tuoteno_row, 1, '', '', '');

--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -11617,7 +11617,7 @@ if (!function_exists("hae_rahtimaksu")) {
       $hirow = mysql_fetch_assoc($rares);
       $ale_kaikki_array = array();
 
-      // Rahtimaksut ovat yhtion valuutassa, se pitää muuttaa laskun valuuttaan
+      // Rahtimaksut ovat yhtion valuutassa, se pitää muuttaa laskun valuuttaan, koska alehinta funktio käsittelee hintoja kuin ne olisi syötetty laskun valuutassa
       if ($laskurow["valkoodi"] != '' and trim(strtoupper($laskurow["valkoodi"])) != trim(strtoupper($yhtiorow["valkoodi"]))) {
         $hirow['rahtihinta'] = round(laskuval($hirow['rahtihinta'], $laskurow["vienti_kurssi"]), 2);
       }

--- a/tilauskasittely/valitse_laskutettavat_tilaukset.php
+++ b/tilauskasittely/valitse_laskutettavat_tilaukset.php
@@ -668,8 +668,16 @@ if ($tee == "VALITSE") {
           }
         }
 
+        // Muutetaan rahtihinta laskun valuuttaan, koska rahtihinta tulee matriisista aina yhtiön kotivaluutassa
+        if ($row["valkoodi"] != '' and trim(strtoupper($row["valkoodi"])) != trim(strtoupper($yhtiorow["valkoodi"]))) {
+          $rah_hinta_laskun_valuutassa = round(laskuval($rah_hinta, $row["vienti_kurssi"]), 2);
+        }
+        else {
+          $rah_hinta_laskun_valuutassa = $rah_hinta;
+        }
+
         if ($row["kohdistettu"] == "K") {
-          $rahti_hinta = "(" . (float) $rah_hinta ." $row[valkoodi]$rah_alet)";
+          $rahti_hinta = "(" . (float) $rah_hinta_laskun_valuutassa ." $row[valkoodi]$rah_alet)";
         }
         else {
           $rahti_hinta = "(".t("vastaanottaja").")";
@@ -1376,6 +1384,7 @@ function hae_tilaukset_result($query_ale_lisa, $tunnukset, $alatilat, $vientilis
             lasku.liitostunnus,
             lasku.tila,
             lasku.vienti,
+            lasku.vienti_kurssi,
             lasku.alv,
             lasku.kohdistettu,
             lasku.jaksotettu,


### PR DESCRIPTION
Rahtimaksun käsittelyssä haettaessa rahtimaksu matriisista sitä käsiteltiin niin kuin se olisi ollut laskun valuutassa vaikka todellisuudessa rahtimatriisissa on hinnat yhtiön valuutassa. Muutetaan tarpeellisissa kohdin hinta siihen valuuttaa jossa sitä käsitellään.