### PR TITLE
Dokumenttien listauksen järjestelynapit

### DIFF
--- a/dokumentti_raportti.php
+++ b/dokumentti_raportti.php
@@ -84,7 +84,7 @@ if ($tee == "raportoi") {
             ORDER BY hd.tunnus";
   $result = pupe_query($query);
 
-  pupe_DataTables(array(array($pupe_DataTables, 7, 7)));
+  pupe_DataTables(array(array($pupe_DataTables, 8, 8)));
 
   echo "<table class='display dataTable' id='$pupe_DataTables'>";
   echo "<thead>";


### PR DESCRIPTION
Dokumenttien listauksessa sarakkeiden otsikossa olevat järjestelypainikkeet eivät toimineet. Ne korjataan tässä, joten jatkossa nuolilla taas voi sarakkeissa vaikuttaa listauksen järjestykseen.