### PR TITLE
Tarjous pdf asettelu & admin kaikki tarjoustyypit tulostus

### DIFF
--- a/inc/functions.inc
+++ b/inc/functions.inc
@@ -21042,6 +21042,19 @@ if (!function_exists("pupesoft_tilausvahvistustyypit")) {
   }
 }
 
+if (!function_exists("pupesoft_tarjoustyypit")) {
+  function pupesoft_tarjoustyypit() {
+    return array(
+      "0" => "Normaali tarjouspohja",
+      "2" => "Normaali tarjouspohja ei ALV",
+      "1" => "Pelkistetty tarjouspohja",
+      "3" => "Lyhyt tarjouspohja",
+      "4" => "Tarjouspohja, jossa ainoastaan nettohinnat",
+      "5" => "Kuvallinen tarjouspohja",
+    );
+  }
+}
+
 if (!function_exists("pupesoft_lahetetyyppi")) {
   function pupesoft_lahetetyyppi($laskutunnus, $asiakastunnus = 0) {
     global $kukarow;

--- a/tilauskasittely/tulosta_tarjous.inc
+++ b/tilauskasittely/tulosta_tarjous.inc
@@ -48,6 +48,14 @@ if (!function_exists('alku_tarjous')) {
 
     tulosta_logo_pdf($pdf_tarjous, $page_tarjous[$sivu], $laskurow);
 
+    if (!empty($laskurow['tarjouspohjateksti'])) {
+      $redboldi["height"] = 8;
+      $redboldi["font"] = "Times-Bold";
+      $redboldi["fillcolor"] = $pdf_tarjous->get_color("red");
+
+      $pdf_tarjous->draw_text(30, 750, $laskurow['tarjouspohjateksti'], $page_tarjous[$sivu], $redboldi);
+    }
+
     if ($yhtiorow['tarjoustyyppi'] == 1) {
       $otsikko_len = $pdf_tarjous->strlen(t("TARJOUS", $kieli), $iso);
       $pdf_tarjous->draw_text((595 / 2) - ($otsikko_len / 2), 760, t("TARJOUS", $kieli),   $page_tarjous[$sivu], $iso);
@@ -1688,9 +1696,9 @@ if (!function_exists('loppu_tarjous')) {
 
         $pdf_tarjous->draw_text(30,  $kuha, t("Tarjoamme teille ylläolevan tarjouksen kohteet hintaan:", $kieli),   $page_tarjous[$sivu], $boldi);
 
-        list($page_tarjous, $sivu, $kuha) = alvierittely($pdf_tarjous, $page_tarjous, $sivu, $laskurow, $total_tarjous, '', $verolliset_verottomat_hinnat, $kuha-10);
+        list($page_tarjous, $sivu, $kuha) = alvierittely($pdf_tarjous, $page_tarjous, $sivu, $laskurow, $total_tarjous, '', $verolliset_verottomat_hinnat, $kuha);
 
-        if ($kuha-165 <= 140) {
+        if ($kuha-165 <= 80) {
           list($page_tarjous, $sivu) = loppu_tarjous($pdf_tarjous, $laskurow, $kieli, $page_tarjous, $sivu, 0, $total_tarjous);
 
           $sivu++;
@@ -1833,6 +1841,10 @@ if (!function_exists('loppu_tarjous')) {
         }
         else {
           $kuha = 168;
+        }
+
+        if ($kuha-165 <= 140) {
+          list($page_tarjous[$sivu], $kuha) = uusi_sivu_tarjous($laskurow, $asiakasrow, $kieli, $pdf_tarjous);
         }
 
         if ($vikanrivin_sivu != $sivu and $naytetaanko_rivihinta != 'kokonaan_ilman_hintoja' and
@@ -2075,7 +2087,7 @@ if (!function_exists('print_pdf_tarjous')) {
 if (!function_exists('tulosta_tarjous')) {
   function tulosta_tarjous($otunnus, $komento, $kieli = "", $tee = "", $hinnat = "",
     $verolliset_verottomat_hinnat = "", $naytetaanko_rivihinta = '',
-    $naytetaanko_tuoteno = '', $liita_tuotetiedot = "", $naytetaanko_yhteissummarivi = "") {
+    $naytetaanko_tuoteno = '', $liita_tuotetiedot = "", $naytetaanko_yhteissummarivi = "", $seltarjoustyyppi = "") {
     global $yhtiorow, $kukarow, $norm, $pieni, $kala, $mista, $kaanteinen_verotus, $palvelin2;
 
     if ($komento == "-88") {
@@ -2108,6 +2120,14 @@ if (!function_exists('tulosta_tarjous')) {
               LIMIT 1";
     $result = pupe_query($query);
     $laskurow = mysql_fetch_assoc($result);
+
+    if (!empty($seltarjoustyyppi)) {
+      $_tarjoustyyppi = $seltarjoustyyppi;
+
+      if (strpos($seltarjoustyyppi, "##") !== FALSE) {
+        list($_tarjoustyyppi, $laskurow['tarjouspohjateksti']) = explode("##", $_tarjoustyyppi);
+      }
+    }
 
     $laskurow['tunnus'] = $otunnus;
 
@@ -2314,7 +2334,7 @@ if (!function_exists('alvierittely')) {
   function alvierittely($pdf_tarjous, $page_tarjous, $sivu, $laskurow, $total_tarjous=0, $kassa_ale = '', $verolliset_verottomat_hinnat, $kala) {
     global $yhtiorow, $kukarow, $toim, $rectparam, $norm, $pieni, $summa, $arvo, $kieli, $boldi;
 
-    if ($kala <= 150) {
+    if ($kala <= 145) {
 
       if ($kassa_ale == '') {
         list($page_tarjous, $sivu) = loppu_tarjous($pdf_tarjous, $laskurow, $kieli, $page_tarjous, $sivu, 0, $total_tarjous);

--- a/tilauskasittely/tulosta_tarjous.inc
+++ b/tilauskasittely/tulosta_tarjous.inc
@@ -1843,10 +1843,6 @@ if (!function_exists('loppu_tarjous')) {
           $kuha = 168;
         }
 
-        if ($kuha-165 <= 140) {
-          list($page_tarjous[$sivu], $kuha) = uusi_sivu_tarjous($laskurow, $asiakasrow, $kieli, $pdf_tarjous);
-        }
-
         if ($vikanrivin_sivu != $sivu and $naytetaanko_rivihinta != 'kokonaan_ilman_hintoja' and
           $naytetaanko_yhteissummarivi != "E"
         ) {
@@ -1862,6 +1858,10 @@ if (!function_exists('loppu_tarjous')) {
 
           $oikpos = $pdf_tarjous->strlen(sprintf("%.2f", $total_tarjous)." ".$laskurow["valkoodi"], $boldi);
           $pdf_tarjous->draw_text(575-$oikpos, $kuha, sprintf("%.2f", $total_tarjous)." ".$laskurow["valkoodi"], $page_tarjous[$sivu], $boldi);
+        }
+
+        if ($kuha-165 <= 80) {
+          list($page_tarjous[$sivu], $kuha) = uusi_sivu_tarjous($laskurow, $asiakasrow, $kieli, $pdf_tarjous);
         }
 
         $result = t_avainsana('TARJOUS_VAKIOTE', $kieli);

--- a/tilauskasittely/tulostakopio.php
+++ b/tilauskasittely/tulostakopio.php
@@ -1789,11 +1789,38 @@ if ($tee == "TULOSTA" or $tee == 'NAYTATILAUS') {
 
       require_once "tulosta_tarjous.inc";
 
-      tulosta_tarjous($otunnus, $komento["Tarjous"], $kieli, $tee, $hinnat,
-        $verolliset_verottomat_hinnat, $naytetaanko_rivihinta, $naytetaanko_tuoteno,
-        $liita_tuotetiedot, $naytetaanko_yhteissummarivi);
+      if ($kaikkilomakepohjat) {
 
-      $tee = '';
+        $tarjoukset = array();
+
+        foreach (pupesoft_tarjoustyypit() as $seltarjoustyyppi => $seltarjoustyyppiteksti) {
+          $tarjoukset[] = array($seltarjoustyyppi, "$seltarjoustyyppiteksti ($seltarjoustyyppi)");
+        }
+
+        $_tmp_yhtiorow_tarjoustyyppi = $yhtiorow['tarjoustyyppi'];
+
+        foreach ($tarjoukset as $tarjous) {
+          $seltarjoustyyppi = $tarjous[0]."##".$tarjous[1];
+
+          $yhtiorow['tarjoustyyppi'] = $tarjous[0];
+
+          tulosta_tarjous($otunnus, $komento["Tarjous"], $kieli, $tee, $hinnat,
+          $verolliset_verottomat_hinnat, $naytetaanko_rivihinta, $naytetaanko_tuoteno,
+          $liita_tuotetiedot, $naytetaanko_yhteissummarivi, $seltarjoustyyppi);
+
+          $tee = '';
+        }
+
+        $yhtiorow['tarjoustyyppi'] = $_tmp_yhtiorow_tarjoustyyppi;
+      }
+      else {
+
+        tulosta_tarjous($otunnus, $komento["Tarjous"], $kieli, $tee, $hinnat,
+          $verolliset_verottomat_hinnat, $naytetaanko_rivihinta, $naytetaanko_tuoteno,
+          $liita_tuotetiedot, $naytetaanko_yhteissummarivi);
+
+        $tee = '';
+      }
     }
 
     if ($toim == "MYYNTISOPIMUS" or $toim == "MYYNTISOPIMUS!!!VL" or $toim == "MYYNTISOPIMUS!!!BR") {


### PR DESCRIPTION
Korjattu tarjouksen tulostuksen asettelua, jotta tiedot eivät menisi päällekkäin ja ne olisivat helpommin luettavissa.

Samalla lisätty admin käyttäjälle mahdollisuus kaikkien tarjouspohjien tulostukseen.