### PR TITLE
Extranet työmääräys maksuehto korjaus

### DIFF
--- a/extranet_tyomaaraykset.php
+++ b/extranet_tyomaaraykset.php
@@ -555,6 +555,7 @@ function tallenna_tyomaarays($request) {
              postino             = '{$asiakastiedot['postino']}',
              postitp             = '{$asiakastiedot['postitp']}',
              maa                 = '{$asiakastiedot['maa']}',
+             maksuehto           = '{$asiakastiedot['maksuehto']}',
              toim_nimi           = '{$request['osoite_parametrit']['toim_nimi']}',
              toim_nimitark       = '{$request['osoite_parametrit']['toim_nimitark']}',
              toim_osoite         = '{$request['osoite_parametrit']['toim_osoite']}',


### PR DESCRIPTION
Työmääräimen teko extranetin kautta toi maksuehdoksi oletuksena kaikille asiakkaille maksuehtolistan ensimmäisen maksuehdon.
Korjattu niin, että maksuehto haetaan asiakaan takaa.