### PR TITLE
Uusi avainsanatyyppi verkkolaskun kenttien sisällön muokkaukseen

### DIFF
--- a/inc/avainsanarivi.inc
+++ b/inc/avainsanarivi.inc
@@ -119,7 +119,8 @@ if ($_selitetark_2 and
     $avain_sel["MYYNTITILASTO"] == "SELECTED" or
     $avain_sel["VALM_FAKTA"] == "SELECTED" or
     $avain_sel['Y'] == "SELECTED" or
-    $avain_sel["LITETY_LAATUAS"] == "SELECTED")) {
+    $avain_sel["LITETY_LAATUAS"] == "SELECTED" or
+    $avain_sel["VERKLASKKENTSIS"] == "SELECTED")) {
   $tyyppi = 1;
 }
 
@@ -208,6 +209,8 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "EXTASAVAINSANA") $ulos .= "<option value='EXTASAVAINSANA' $avain_sel[EXTASAVAINSANA]>".t("Extranet-asiakkaan avainsanojen laji")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "LAANI") $ulos .= "<option value='LAANI' $avain_sel[LAANI]>".t("Lääni")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "KUNTA") $ulos .= "<option value='KUNTA' $avain_sel[KUNTA]>".t("Kunta")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "VASTUUMYYJA") $ulos .= "<option value='VASTUUMYYJA' {$avain_sel['VASTUUMYYJA']}>".t("Asiakkaan vastuumyyjä")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "ASIAKASHINNASTO") $ulos .= "<option value='ASIAKASHINNASTO' {$avain_sel['ASIAKASHINNASTO']}>".t("Asiakashinnaston svh hinta-kenttä")."</option>";
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
   if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Yhtiön avainsanat")."'>";
@@ -277,6 +280,20 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "MAKSUEHTOKV") $ulos .= "<option value='MAKSUEHTOKV' $avain_sel[MAKSUEHTOKV]>".t("Maksuehdon kieliversio")."</option>";
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
+  if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Tilauksen avainsanat")."'>";
+  if ($lukitse_laji== "" or $lukitse_laji == "VAKIOVIESTI_TIL") $ulos .= "<option value='VAKIOVIESTI_TIL' {$avain_sel['VAKIOVIESTI_TIL']}>".t("Tilausvahvistuksen vakioviesti")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "KAANTALVVIESTI") $ulos .= "<option value='KAANTALVVIESTI' $avain_sel[KAANTALVVIESTI]>".t("Tilauksen/Laskun käänteisen verotuksen viesti")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "TIL-LITETY") $ulos .= "<option value='TIL-LITETY' ".$avain_sel["TIL-LITETY"].">".t("Tilauksen liitetiedostotyyppi")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "TRIVITYYPPI") $ulos .= "<option value='TRIVITYYPPI' $avain_sel[TRIVITYYPPI]>".t("Tilausrivin tyyppi")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "TILRIVI_VIILAUS") $ulos .= "<option value='TILRIVI_VIILAUS' $avain_sel[TILRIVI_VIILAUS]>".t("Tilausrivin ulkoasun muutos")."</option>";
+  if ($lukitse_laji== "") $ulos .= "</optgroup>";
+
+  if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Laskun avainsanat")."'>";
+  if ($lukitse_laji== "" or $lukitse_laji == "VAKIOVIESTI") $ulos .= "<option value='VAKIOVIESTI' $avain_sel[VAKIOVIESTI]>".t("Laskun vakioviesti")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "MAINOSTXT_LASKU") $ulos .= "<option value='MAINOSTXT_LASKU' {$avain_sel['MAINOSTXT_LASKU']}>".t("Laskun mainosteksti")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "LASKUTUS_SAATE") $ulos .= "<option value='LASKUTUS_SAATE' $avain_sel[LASKUTUS_SAATE]>".t("Laskun sähköpostisaatekirje asiakkaalle")."</option>";
+  if ($lukitse_laji== "") $ulos .= "</optgroup>";
+
   if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("CRM avainsanat")."'>";
   if ($lukitse_laji== "" or $lukitse_laji == "KALETAPA") $ulos .= "<option value='KALETAPA' $avain_sel[KALETAPA]>".t("CRM yhteydenottotapa")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "CRM_ROOLI") $ulos .= "<option value='CRM_ROOLI' $avain_sel[CRM_ROOLI]>".t("Yhteyshenkilön rooli")."</option>";
@@ -285,18 +302,14 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "CRM_TARJOUSPOIS") $ulos .= "<option value='CRM_TARJOUSPOIS' {$avain_sel['CRM_TARJOUSPOIS']}>".t("CRM viesti tarjouksen hylkäyksestä")."</option>";
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
+  if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Verkkokaupan avainsanat")."'>";
+  if ($lukitse_laji== "" or $lukitse_laji == "VERKKOKAULINKKI") $ulos .= "<option value='VERKKOKAULINKKI' $avain_sel[VERKKOKAULINKKI]>".t("Verkkokauppalinkki")."</option>";
+  if ($lukitse_laji== "") $ulos .= "</optgroup>";
+
   if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Muut avainsanat")."'>";
-  if ($lukitse_laji== "" or $lukitse_laji == "VAKIOVIESTI") $ulos .= "<option value='VAKIOVIESTI' $avain_sel[VAKIOVIESTI]>".t("Laskun vakioviesti")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "MAINOSTXT_LASKU") $ulos .= "<option value='MAINOSTXT_LASKU' {$avain_sel['MAINOSTXT_LASKU']}>".t("Laskun mainosteksti")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "VAKIOVIESTI_TIL") $ulos .= "<option value='VAKIOVIESTI_TIL' {$avain_sel['VAKIOVIESTI_TIL']}>".t("Tilausvahvistuksen vakioviesti")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "KAANTALVVIESTI") $ulos .= "<option value='KAANTALVVIESTI' $avain_sel[KAANTALVVIESTI]>".t("Tilauksen/Laskun käänteisen verotuksen viesti")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "LITETY") $ulos .= "<option value='LITETY' $avain_sel[LITETY]>".t("Liitetiedostotyyppi")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "TIL-LITETY") $ulos .= "<option value='TIL-LITETY' ".$avain_sel["TIL-LITETY"].">".t("Tilauksen liitetiedostotyyppi")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "JAKELULISTA") $ulos .= "<option value='JAKELULISTA' $avain_sel[JAKELULISTA]>".t("Email jakelulista")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "LUETTELO") $ulos .= "<option value='LUETTELO' $avain_sel[LUETTELO]>".t("Luettelotyyppi")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "TRIVITYYPPI") $ulos .= "<option value='TRIVITYYPPI' $avain_sel[TRIVITYYPPI]>".t("Tilausrivin tyyppi")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "TILRIVI_VIILAUS") $ulos .= "<option value='TILRIVI_VIILAUS' $avain_sel[TILRIVI_VIILAUS]>".t("Tilausrivin ulkoasun muutos")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "LASKUTUS_SAATE") $ulos .= "<option value='LASKUTUS_SAATE' $avain_sel[LASKUTUS_SAATE]>".t("Laskun sähköpostisaatekirje asiakkaalle")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "PALAUTUS_SAATE") $ulos .= "<option value='PALAUTUS_SAATE' $avain_sel[PALAUTUS_SAATE]>".t("Palautuksen sähköpostisaatekirje asiakkaalle")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "TV_LISATIETO") $ulos .= "<option value='TV_LISATIETO' $avain_sel[TV_LISATIETO]>".t("Tilausvahvistuksen lisätiedot")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "INVEN_LAJI") $ulos .= "<option value='INVEN_LAJI' $avain_sel[INVEN_LAJI]>".t("Inventoinnin laji")."</option>";
@@ -318,7 +331,6 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "HINNAT_CRON") $ulos .= "<option value='HINNAT_CRON' {$avain_sel['HINNAT_CRON']}>".t("Hinnat-cronin aikaleima (vvvv-kk-pp tt:mm:ss)")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "TUOTE_EXP_CRON") $ulos .= "<option value='TUOTE_EXP_CRON' {$avain_sel['TUOTE_EXP_CRON']}>".t("Tuote Export-cronin aikaleima (vvvv-kk-pp tt:mm:ss)")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "SALDOVAHVISTUS") $ulos .= "<option value='SALDOVAHVISTUS' {$avain_sel['SALDOVAHVISTUS']}>".t("Saldovahvistuksen viesti")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "ASIAKASHINNASTO") $ulos .= "<option value='ASIAKASHINNASTO' {$avain_sel['ASIAKASHINNASTO']}>".t("Asiakashinnaston svh hinta-kenttä")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "DPAVAINSANALAJI") $ulos .= "<option value='DPAVAINSANALAJI' {$avain_sel['DPAVAINSANALAJI']}>".t("Dynaamisen puun avainsanojen laji")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "LITETY_TKIRJAST") $ulos .= "<option value='LITETY_TKIRJAST' {$avain_sel['LITETY_TKIRJAST']}>".t("Tiedostokirjastossa selailtava tiedostotyyppi")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "TOIMIT_TKIRJAST") $ulos .= "<option value='TOIMIT_TKIRJAST' {$avain_sel['TOIMIT_TKIRJAST']}>".t("Tiedostokirjastossa näkyvä toimittaja")."</option>";
@@ -343,15 +355,10 @@ if (mysql_field_name($result, $i) == "laji") {
   if ($lukitse_laji== "" or $lukitse_laji == "MESSENGER_RYHMA") $ulos .= "<option value='MESSENGER_RYHMA' {$avain_sel['MESSENGER_RYHMA']}>".t("Messenger käyttäjäryhmä")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "VALM_FAKTA") $ulos .= "<option value='VALM_FAKTA' {$avain_sel['VALM_FAKTA']}>".t("Valmistuslistan faktan fonttikoko")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "PSHOP_SYNONYMS") $ulos .= "<option value='PSHOP_SYNONYMS' {$avain_sel['PSHOP_SYNONYMS']}>".t("Pupeshop tuotehaun synonyymit")."</option>";
-  if ($lukitse_laji== "" or $lukitse_laji == "VASTUUMYYJA") $ulos .= "<option value='VASTUUMYYJA' {$avain_sel['VASTUUMYYJA']}>".t("Asiakkaan vastuumyyjä")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "MAKSUKP") $ulos .= "<option value='MAKSUKP' {$avain_sel['MAKSUKP']}>".t("Maksatuksessa kustannuspaikka")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "MAKSUMS") $ulos .= "<option value='MAKSUMS' {$avain_sel['MAKSUMS']}>".t("Maksuteksti näkyviin avoimissa myyntilaskuissa")."</option>";
   if ($lukitse_laji== "" or $lukitse_laji == "MYYNTITILASTO") $ulos .= "<option value='MYYNTITILASTO' {$avain_sel['MYYNTITILASTO']}>".t("Myyntimittarin raja-arvot")."</option>";
-
-  if ($lukitse_laji== "") $ulos .= "</optgroup>";
-
-  if ($lukitse_laji== "") $ulos .= "<optgroup label='".t("Verkkokaupan avainsanat")."'>";
-  if ($lukitse_laji== "" or $lukitse_laji == "VERKKOKAULINKKI") $ulos .= "<option value='VERKKOKAULINKKI' $avain_sel[VERKKOKAULINKKI]>".t("Verkkokauppalinkki")."</option>";
+  if ($lukitse_laji== "" or $lukitse_laji == "VERKLASKKENTSIS") $ulos .= "<option value='VERKLASKKENTSIS' {$avain_sel['VERKLASKKENTSIS']}>".t("Verkkolaskukentän sisältö")."</option>";
   if ($lukitse_laji== "") $ulos .= "</optgroup>";
 
   $ulos .= "</select></td>";

--- a/tilauskasittely/verkkolasku_finvoice_201.inc
+++ b/tilauskasittely/verkkolasku_finvoice_201.inc
@@ -551,7 +551,10 @@ if (!function_exists('finvoice_otsik')) {
       xml_add("InvoiceDate Format=\"CCYYMMDD\"", vlas_dateconv($lasrow['tapvm']), $tootfinvoice);
       xml_add("SellerReferenceIdentifier", substr($lasrow['tilausnumerot'], 0, 35), $tootfinvoice, 35);
 
-      if ($yhtiorow["verkkolasku_lah"] == "talenom" or $yhtiorow["verkkolasku_lah"] == "arvato") {
+      $sellersbuyeridentifier_avainsana_where = "AND selite = '{$yhtiorow["verkkolasku_lah"]}' AND selitetark = 'SellersBuyerIdentifier'";
+      $sellersbuyeridentifier_avainsana_kentta = t_avainsana("VERKLASKKENTSIS", "", $sellersbuyeridentifier_avainsana_where, "", "", "selitetark_2");
+
+      if ($yhtiorow["verkkolasku_lah"] == "talenom" or $yhtiorow["verkkolasku_lah"] == "arvato" or $sellersbuyeridentifier_avainsana_kentta == "asiakasnro") {
         xml_add("SellersBuyerIdentifier", substr($asiakasrow["asiakasnro"], 0, 35), $tootfinvoice, 35);
       }
       elseif (trim($lasrow['asiakkaan_tilausnumero']) != "") {
@@ -561,7 +564,13 @@ if (!function_exists('finvoice_otsik')) {
         xml_add("SellersBuyerIdentifier", substr($lasrow['viesti'], 0, 35), $tootfinvoice, 35);
       }
 
-      if (trim($lasrow['asiakkaan_tilausnumero']) != "") {
+      $orderidentifier_avainsana_where = "AND selite = '{$yhtiorow["verkkolasku_lah"]}' AND selitetark = 'OrderIdentifier'";
+      $orderidentifier_avainsana_kentta = t_avainsana("VERKLASKKENTSIS", "", $orderidentifier_avainsana_where, "", "", "selitetark_2");
+
+      if ($orderidentifier_avainsana_kentta == "tyhja") {
+        xml_add("OrderIdentifier", "", $tootfinvoice, 35);
+      }
+      elseif (trim($lasrow['asiakkaan_tilausnumero']) != "") {
         xml_add("OrderIdentifier", substr($lasrow['asiakkaan_tilausnumero'], 0, 35), $tootfinvoice, 35);
       }
       else {


### PR DESCRIPTION
Uusi yhtiön avainsanojen laji Verkkolaskukentän sisältö (VERKLASKKENTSIS), jolla pystyy pakottamaan muutaman kentän sisältö tietynlaiseksi. 
- SellersBuyerIdentifier kenttään voi pakottaa asiakasnumeron
- OrderIdentifier kentän voi pakottaa tyhjäksi