### PR TITLE
Automaattiseen tuotenumerointiin seuraavan numeron hakunappi

### DIFF
--- a/inc/tuoterivi.inc
+++ b/inc/tuoterivi.inc
@@ -43,7 +43,9 @@ if (mysql_field_name($result, $i) == "tuoteno") {
   else {
 
     // Jos automaattinen tuotenumeron ehdotus on p‰‰ll‰...
-    if ($trow[$i] == '' and ($yhtiorow['seuraava_tuotenumero'] == 'K' or ($yhtiorow['seuraava_tuotenumero'] == 'O' and isset($tee_myos_tuotteen_toimittaja_liitos)))) {
+    $automaattinen_tuotenumerointi = ($yhtiorow['seuraava_tuotenumero'] == 'K' or ($yhtiorow['seuraava_tuotenumero'] == 'O' and isset($tee_myos_tuotteen_toimittaja_liitos)));
+
+    if ($trow[$i] == '' and $automaattinen_tuotenumerointi) {
       $virheviesti = '';
       $autom_wherelisa = '';
       $autom_selectlisa = 'MAX(CAST(tuote.tuoteno AS UNSIGNED))';
@@ -68,7 +70,9 @@ if (mysql_field_name($result, $i) == "tuoteno") {
       else {
         $trow[$i] = $autom_tuoteno_row['seuraava_tuoteno'];
       }
+    }
 
+    if ($automaattinen_tuotenumerointi) {
       $tuotenohaku = "<input type = 'button' name = 'etsi_vapaa_tuoteno' id = 'etsi_vapaa_tuoteno' value = '" . t("Etsi seuraava vapaa") . "'>";
     }
     else {

--- a/inc/tuoterivi.inc
+++ b/inc/tuoterivi.inc
@@ -70,7 +70,12 @@ if (mysql_field_name($result, $i) == "tuoteno") {
       }
     }
 
-    $ulos = "<td><input type = 'hidden' name = 'uusi' value = '$uusi'><input type = 'text' name = '$nimi' value = '$trow[$i]' size='$size' maxlength='$maxsize'>{$virheviesti}</td>";
+    $ulos = "<td>
+               <input type = 'hidden' name = 'uusi' value = '$uusi'>
+               <input type = 'text' name = '$nimi' id = 'input_tuoteno' value = '$trow[$i]' size='$size' maxlength='$maxsize'>
+               <input type = 'button' name = 'etsi_vapaa_tuoteno' id = 'etsi_vapaa_tuoteno' value = '" . t("Etsi seuraava vapaa") . "'>
+               <div id = 'tuoteno_virhe'>{$virheviesti}</div>
+             </td>";
     $jatko=0;
 
     // Jos on uusi tuote niin kaikki lukot on auki

--- a/inc/tuoterivi.inc
+++ b/inc/tuoterivi.inc
@@ -68,12 +68,17 @@ if (mysql_field_name($result, $i) == "tuoteno") {
       else {
         $trow[$i] = $autom_tuoteno_row['seuraava_tuoteno'];
       }
+
+      $tuotenohaku = "<input type = 'button' name = 'etsi_vapaa_tuoteno' id = 'etsi_vapaa_tuoteno' value = '" . t("Etsi seuraava vapaa") . "'>";
+    }
+    else {
+      $tuotenohaku = "";
     }
 
     $ulos = "<td>
                <input type = 'hidden' name = 'uusi' value = '$uusi'>
                <input type = 'text' name = '$nimi' id = 'input_tuoteno' value = '$trow[$i]' size='$size' maxlength='$maxsize'>
-               <input type = 'button' name = 'etsi_vapaa_tuoteno' id = 'etsi_vapaa_tuoteno' value = '" . t("Etsi seuraava vapaa") . "'>
+               {$tuotenohaku}
                <div id = 'tuoteno_virhe'>{$virheviesti}</div>
              </td>";
     $jatko=0;


### PR DESCRIPTION
Lisätty uusi ominaisuus automaattiseen tuotenumerointiin liittyen ja laajennettu tuotenumerointiautomatiikkaa. Tuotenumero kentän viereen on lisätty "Etsi seuraava vapaa"-nappi, jolla pystyy hakemaan manuaalisesti hakemaan seuraavan vapaan tuotenumeron. Mikäli tuotteen perustukseen mentäessä ruudulle tuotu tuotenumero on vielä vapaana niin tämä pysyy ruudulla, mutta siinä tapauksessa, että joku onkin jo ehtinyt sillä numerolla tuotteen perustamaan, niin tällä uudella napilla pystyy hakemaan seuraavaksi suurimman vapaan tuotenumeron.