### PR TITLE
Mahdollisuus saada siirtolistalle ostohintojen summa

### DIFF
--- a/inc/yhtion_parametritrivi.inc
+++ b/inc/yhtion_parametritrivi.inc
@@ -4221,10 +4221,12 @@ if ($fieldname == 'oletusvarasto_tilaukselle') {
 if ($fieldname == 'siirtolistatyyppi') {
   $ulos = "<td><select name='$nimi' ".js_alasvetoMaxWidth($nimi, 400).">";
 
-  $sel = $trow[$i] == 'A' ? ' selected' : '';
+  $selA = $trow[$i] == 'A' ? ' selected' : '';
+  $selB = $trow[$i] == 'B' ? ' selected' : '';
 
-  $ulos .= "<option value = ''>".t("Siirtolistalla ei n‰ytet‰ tuotteen myyntihintaa")."</option>";
-  $ulos .= "<option value = 'A' {$sel}>".t("Siirtolistalla n‰ytet‰‰n tuotteen myyntihinta")."</option>";
+  $ulos .= "<option value = ''>".t("Siirtolistalla ei n‰ytet‰ tuotteiden hintoja")."</option>";
+  $ulos .= "<option value = 'A' {$selA}>".t("Siirtolistalla n‰ytet‰‰n tuotteen myyntihinta")."</option>";
+  $ulos .= "<option value = 'B' {$selB}>".t("Siirtolistalla n‰ytet‰‰n tuotteiden ostohintojen summa")."</option>";
   $ulos .= "</select></td>";
 
   $jatko = 0;

--- a/tilauskasittely/tulosta_lahete_kerayslista.inc
+++ b/tilauskasittely/tulosta_lahete_kerayslista.inc
@@ -350,6 +350,18 @@ if (!function_exists('alku_kerayslista')) {
         $pdf->draw_text(310, 614, $keraaja_teksti,   $thispage, $keraaja_font);
       }
 
+      if ($yhtiorow["siirtolistatyyppi"] == "B" and $asrow["asiakasnro"] == "SIIRTO") {
+        // Haetaan siirtolistan rivien ostohinta yhteensä
+        $query = "SELECT ROUND(SUM(tuotteen_toimittajat.ostohinta * (tilausrivi.varattu + tilausrivi.kpl)), 2) AS ostohinta_summa
+                  FROM tilausrivi
+                    JOIN tuotteen_toimittajat ON (tuotteen_toimittajat.yhtio = tilausrivi.yhtio AND tuotteen_toimittajat.tuoteno = tilausrivi.tuoteno)
+                  WHERE tilausrivi.yhtio = '{$kukarow["yhtio"]}'
+                    AND tilausrivi.otunnus IN ($tilausnumeroita)";
+        $ostohinta_sum = mysql_fetch_assoc(pupe_query($query));
+
+        $pdf->draw_text(300, 604, t("Ostohinnat yhteensä:", $kieli),   $thispage, $norm);
+        $pdf->draw_text(390, 604, $ostohinta_sum["ostohinta_summa"],   $thispage, $norm);
+      }
 
       $komm = "";
 


### PR DESCRIPTION
Uusi siirtolistatyyppi, jolle saa tulostettua siirtolistan tuotteiden ostohinnan summan. Ostohinnat eivät siis tulostu rivikohtaisesti vaan siirtolistan rivien yläpuolelle tulostetaan kaikkien rivien ostohintojen summa.