### PR TITLE
Ostotilaus näytä korjaus

### DIFF
--- a/tilauskasittely/tulosta_ostotilaus.inc
+++ b/tilauskasittely/tulosta_ostotilaus.inc
@@ -481,7 +481,7 @@ else {
         $pdf->draw_text(45, $kala, "(".$row["tuoteno"].")", $thispage, $norm);
       }
 
-      $nimitykset_tulostetaan = (isset($nimitykset) and $nimitykset != "") or (!isset($nimitykset) and $yhtiorow['ostotilaustyyppi'] == 'A') or $toim == "HAAMU";
+      $nimitykset_tulostetaan = ((isset($nimitykset) and $nimitykset != "") or (!isset($nimitykset) and $yhtiorow['ostotilaustyyppi'] == 'A') or $toim == "HAAMU");
       if ($nimitykset_tulostetaan) {
 
         //K‰‰nnet‰‰n nimitys


### PR DESCRIPTION
Ostotilaus näytä nappulan kautta tulostettavasta ostotilauksesta oli kadonnut tuotteiden nimitykset toisen ostotilauksen tulostukseen liittyvän muutoksen yhteydessä. Tehty pieni korjaus, jolla palautettiin nimitykset tulosteelle, mikäli yhtiön parametri ostotilaustyyppi on sellaisessa asennossa, että nimitykset oletuksena tulostetaan.