### PR TITLE
Rahtitisopimusnumeron pituuden ehto

### DIFF
--- a/inc/unifaun_send.inc
+++ b/inc/unifaun_send.inc
@@ -521,7 +521,7 @@ class Unifaun {
           $rahtisopimusnro = 999999;
         }
 
-        if ($this->toitarow['virallinen_selite'] == "KLGRP" and strlen($rahtisopimusnro) < 7) {
+        if ($this->toitarow['virallinen_selite'] == "KLGRP" and strlen($rahtisopimusnro) <= 3) {
           $rahtisopimusnro = 9999999;
         }
       }


### PR DESCRIPTION
DB schenker kotimaankuljetuksen rahtisopimusnumero on oikein mikäli sen on vähintään 3 merkkiä pitkä, muutettu ehtoa siis nykyisestä jotta myös lyhyemmät rahtisopimusnumerot hyväksytään.