### PR TITLE
Eränumeroiden myynnissä ongelma kappaleiden kanssa

### DIFF
--- a/tilauskasittely/laskutus.inc
+++ b/tilauskasittely/laskutus.inc
@@ -652,6 +652,19 @@ else {
                             and tunnus           = '$erajaljella_row[tunnus]'";
                   $lisa_res = pupe_query($query);
 
+                  // Jos ostorivin (sarjanumeroseuranta taulun rivi) määrä vähenee nollaan,
+                  // poistetaan se ettei jäisi roikkumaan 0 kpl eränumerorivejä
+                  if ($erajaljella_row["era_kpl"] - $eravahennetaan == 0) {
+                    $delete_q = "DELETE FROM sarjanumeroseuranta
+                                 WHERE yhtio          = '$kukarow[yhtio]'
+                                 AND tuoteno          = '$trow[tuoteno]'
+                                 AND ostorivitunnus   = '$erajaljella_row[ostorivitunnus]'
+                                 AND myyntirivitunnus = 0
+                                 AND sarjanumero      = '$lisa_row[sarjanumero]'
+                                 AND tunnus           = '$erajaljella_row[tunnus]'";
+                    pupe_query($delete_q);
+                  }
+
                   // haetaan päivitettävä myyntirivi jotta voidaan kloonata se myöhemmin tarvittaessa
                   $query = "SELECT *
                             FROM sarjanumeroseuranta


### PR DESCRIPTION
Kun erä myydään kokonaan loppuun jää siitä jäljelle erä jonka era_kpl on 0. Tälläiset rivit näkyvät häiritsevästi ainakin inventoinnissa. Siivotaan nämä 0 kpl rivit heti pois mikäli niitä meinaa syntyä, jotta eivät jäisi roikkumaan turhaan. 0kpl erällä kun ei mitään myöskään edes tee (sehän on myyty loppuun).

Myynnissä on tehty kokonaan oma rivi myynnin eränumeroa varten ja kpl määrä siirtyy sinne laskutuksessa, joten senkin puoleen tuo 0kpl rivi on turha.

Tähän liittyy valmistuksen vastaava korjaus: https://github.com/devlab-oy/pupesoft/pull/4114