### PR TITLE
Valmistuksiin korjaus eränumerokäsittelyyn

### DIFF
--- a/valmistatuotteita.inc
+++ b/valmistatuotteita.inc
@@ -383,6 +383,19 @@ if ($tee == 'UV') { //Tehdään tuotteet!
                     and tunnus  = '$erajaljella_row[tunnus]'";
           $lisa_res = pupe_query($query);
 
+          // Jos ostorivin (sarjanumeroseuranta taulun rivi) määrä vähenee nollaan,
+          // poistetaan se ettei jäisi roikkumaan 0 kpl eränumerorivejä
+          if ($erajaljella_row["era_kpl"] - $eravahennetaan == 0) {
+            $delete_q = "DELETE FROM sarjanumeroseuranta
+                         WHERE yhtio          = '$kukarow[yhtio]'
+                          AND tuoteno          = '$raakaainerow[tuoteno]'
+                          AND myyntirivitunnus = 0
+                          AND era_kpl          = 0
+                          AND sarjanumero      = '$lisa_row[sarjanumero]'
+                          AND tunnus           = '$erajaljella_row[tunnus]'";
+            pupe_query($delete_q);
+          }          
+
           $raakaerarow = array('tunnus' => 0, 'ostorivitunnus' => 0);
 
           if ($ederaostorivi == 0 and $lisa_row['era_kpl'] == 0) {


### PR DESCRIPTION
Kun erä käytetään raaka-aineena kokonaan loppuun jää siitä jäljelle erä jonka era_kpl on 0. Tälläiset rivit näkyvät häiritsevästi ainakin inventoinnissa. Siivotaan nämä 0 kpl rivit heti pois mikäli niitä meinaa syntyä, jotta eivät jäisi roikkumaan turhaan. 0kpl erällä kun ei mitään myöskään edes tee (sehän on myyty/käytetty loppuun).

Valmistuksessa on tehty kokonaan oma rivi myynnin eränumeroa varten ja kpl määrä siirtyy sinne valmistuksen yhteydessä, joten senkin puoleen tuo 0kpl rivi on turha.

Tähän liittyy myynnin vastaava korjaus: https://github.com/devlab-oy/pupesoft/pull/4113